### PR TITLE
Optimise English copy across all customer story pages

### DIFF
--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -39,7 +39,7 @@ const allStories = [
   {
     id: 'mediaset', company: 'Mediaset', industry: 'Media & Telecom', useCases: ['Hiring'],
     headlineIt: 'Mediaset: come selezionare e far crescere il talento su scala in un gruppo che sta triplicando le dimensioni',
-    headlineEn: 'Mediaset: how to select and grow talent at scale in a group that is tripling in size',
+    headlineEn: 'Mediaset: how to select and develop talent at scale in a group that is tripling in size',
     bgImage: '/logos/mediaset-background-explore-stories (2).jpg',
   },
   {

--- a/pages/customers/adr.tsx
+++ b/pages/customers/adr.tsx
@@ -104,7 +104,7 @@ const content = {
     },
     objectives: {
       badge: 'OBIETTIVI DI COLLABORAZIONE',
-      title: 'Costruire la capacità organizzativa che la crescita richiede.',
+      title: 'Cosa doveva cambiare',
       items: [
         { icon: Users, text: "Rendere visibile il potenziale su tutta la popolazione: assessment accessibile a tutti i 4.500+ dipendenti, non solo i 1.000 corporate. Includere per la prima volta gli operativi" },
         { icon: Target, text: 'Guidare le decisioni con un approccio science-based e auditabile: passare dalle segnalazioni soggettive a dati strutturati per ogni ruolo, con criteri chiari, feedback per ogni dipendente e piena compliance regolatoria' },
@@ -130,7 +130,7 @@ const content = {
       metrics: [
         { value: '-97%', label: 'Time-to-Process' },
         { value: 'fino a 4.000', label: 'operativi inclusi' },
-        { value: 'Giorni, non mesi', label: 'tempi di selezione interna' },
+        { value: 'Giorni, non mesi', label: 'dall\'application alla valutazione' },
       ],
       qualitative: [
         { icon: Eye, title: 'Talento nascosto, finalmente visibile', text: "Per la prima volta, ADR ha dati aggiornati su competenze, comportamenti, e potenziale della forza lavoro che fisicamente gestirà i nuovi terminal e le nuove infrastrutture. La pipeline di talento futuro si costruisce da qui." },
@@ -215,7 +215,7 @@ const content = {
         {
           icon: Users,
           title: 'The potential of nearly 4,000 people was not visible',
-          text: "Operational staff — the very people on whom to build the management of a growing airport — could not all be put through assessment: development opportunities started from nominations by direct line managers.",
+          text: "Operational staff — the very people on whom to build the management of a growing airport — could not all be invited to a structured assessment: development opportunities started from nominations by direct line managers.",
         },
         {
           icon: TrendingUp,
@@ -237,7 +237,7 @@ const content = {
         {
           icon: BarChart3,
           title: 'Democratisation of development at risk',
-          text: 'A possible perception of not entirely equal access to growth and professional development opportunities, with the risk that this affects employees\' sense of trust in the process.',
+          text: 'Possible perception of unequal access to growth and professional development opportunities could affect the employees\' sense of trust in the process.',
         },
         {
           icon: Shield,
@@ -248,21 +248,21 @@ const content = {
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'Building the organizational capacity that growth demands.',
+      title: 'What needed to change',
       items: [
         { icon: Users, text: "Make potential visible across the entire workforce: assessment accessible to all 4,500+ employees, not just the 1,000 corporate staff. Including operational employees for the first time" },
-        { icon: Target, text: 'Guide decisions with a science-based and auditable approach: move from subjective nominations to structured competency data for every role, with clear criteria, structured feedback for each employee, and full regulatory compliance' },
+        { icon: Target, text: 'Guide decisions with a science-based and auditable approach: move from subjective nominations to structured skills data for every role, with clear criteria, structured feedback for each employee, and full regulatory compliance' },
         { icon: Zap, text: 'Scale without adding operational burden or delays: process internal applications in days instead of months, while preserving the psychometric quality a public entity requires' },
-        { icon: Layers, text: "Build a human-in-the-loop model: the assessment must produce intelligence to support managerial decisions, not replace them. Data to decide better, not automated verdicts" },
+        { icon: Layers, text: "Build a human-in-the-loop model: the assessment must produce intelligence to support managerial decisions, not replace them. Data is used to decide better, not to automate verdicts" },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI Assessment with Skillvue',
-      intro: "Skillvue was integrated into ADR's existing People Strategy, which already included a leadership model and defined development paths. Skillvue's People Science team worked with ADR to align the platform with the company's competency model, ensuring every assessment measured what ADR considers relevant — not generic competencies.",
+      intro: "Skillvue was integrated into ADR's existing People Strategy, which already included a leadership model and defined development paths. Skillvue's People Science team worked with ADR to align the platform with the company's leadership model, ensuring every assessment measured what ADR considers relevant — not generic skills.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
-        { icon: Wrench, label: 'Technical competencies (role-specific, calibrated on ADR\'s model)' },
+        { icon: Wrench, label: 'Technical skills (role-specific, calibrated on ADR\'s model)' },
         { icon: Heart, label: 'Soft skills (for operational roles too, for the first time in ADR\'s history)' },
         { icon: CheckCircle, label: 'English language (critical for an international hub with 240 destinations and 100+ airlines)' },
       ],
@@ -274,7 +274,7 @@ const content = {
       metrics: [
         { value: '-97%', label: 'Time-to-Process' },
         { value: 'up to 4,000', label: 'operational staff included' },
-        { value: 'Days, not months', label: 'internal selection timeline' },
+        { value: 'Days, not months', label: 'application-to-screen timeline' },
       ],
       qualitative: [
         { icon: Eye, title: 'Hidden talent, finally visible', text: "ADR built a data set that simply didn't exist before: people who would have remained invisible under the old approach can now be identified, assessed, and placed into development pipelines." },
@@ -301,7 +301,7 @@ const content = {
     related: {
       title: 'Related Stories',
       stories: [
-        { id: 'ins-mercato', company: "In's Mercato", tag: 'Retail GDO · Internal Mobility', headline: "How In's Mercato built an internal pipeline of Store Managers" },
+        { id: 'ins-mercato', company: "In's Mercato", tag: 'Large-scale distribution · Internal Mobility', headline: "How In's Mercato built an internal pipeline of Store Managers" },
         { id: 'credem', company: 'Credem', tag: 'Banking & Finance · Development', headline: 'Credem: how to find the best talent at scale among 30,000 applications to fuel business growth' },
       ],
       cta: 'Read the story',
@@ -499,7 +499,7 @@ export default function ADRStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.results.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.results.subtitle}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.results.subtitle}</p>
 
               <div className="rounded-2xl bg-[#111128] p-10 lg:p-14 mb-10">
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 max-w-3xl mx-auto">
@@ -583,7 +583,7 @@ export default function ADRStoryPage() {
                   {c.vision.badge}
                 </span>
                 <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4 leading-[1.3]">{c.vision.title}</h2>
-                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8 max-w-3xl">{c.vision.intro}</p>
+                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8">{c.vision.intro}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>
                     <Target className="h-5 w-5" style={{ color: '#4b4df7' }} />

--- a/pages/customers/carrefour.tsx
+++ b/pages/customers/carrefour.tsx
@@ -64,7 +64,7 @@ const content = {
       title: 'Il problema strutturale',
       intro: "Carrefour Italia aveva un vincolo operativo chiaro: scalare la qualità della selezione senza moltiplicare le risorse, in un settore dove ogni assunzione sbagliata erode direttamente i margini.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Target,
@@ -171,7 +171,7 @@ const content = {
       highlight2: 'key hiring KPI',
       after: '',
     },
-    subtitle: "In a sector where labour cost is 3.4x operating profit, Carrefour Italia turned hiring into a real profitability lever — with clear data on people and their competencies.",
+    subtitle: "In a sector where labour cost is 3.4x operating profit, Carrefour Italia turned hiring into a real profitability lever thanks to clear, transparent data on skills.",
     heroMetrics: [
       { value: '-35%', label: 'Time-to-Hire' },
       { value: '+20%', label: 'Hiring success rate' },
@@ -182,7 +182,7 @@ const content = {
     clientCard: {
       label: 'CLIENT PROFILE',
       facts: [
-        { label: 'Industry', value: 'GDO' },
+        { label: 'Industry', value: 'Large-scale distribution' },
         { label: 'Group', value: 'Carrefour Group' },
         { label: 'Revenue', value: '~€4.5B' },
         { label: 'Employees', value: '13,000+ direct + 8,000 franchise network' },
@@ -192,68 +192,68 @@ const content = {
     },
     context: {
       badge: 'CONTEXT',
-      title: 'The Project Context',
+      title: 'The Company and The Context',
       paragraph: <>
-        Carrefour Italia (now <strong className="text-[#1A1A2E]/80 font-semibold">Princes Retail S.p.A.</strong>) operates approximately <strong className="text-[#1A1A2E]/80 font-semibold">1,200 stores</strong> across 4 formats — Hypermarkets, Market, Express, Cash &amp; Carry — with <strong className="text-[#1A1A2E]/80 font-semibold">13,000 direct employees</strong> and a franchise network of 8,000 people.
+        Carrefour Italia (now <strong className="text-[#1A1A2E]/80 font-semibold">Princes Retail S.p.A.</strong>) operates approximately <strong className="text-[#1A1A2E]/80 font-semibold">1,200 stores</strong> across 4 formats (Hypermarkets, Market, Express, Cash &amp; Carry) with <strong className="text-[#1A1A2E]/80 font-semibold">13,000 direct employees</strong> and a franchise network of 8,000 people.
         <br /><br />
-        In a sector where labour cost accounts for <strong className="text-[#1A1A2E]/80 font-semibold">9.8% of revenue</strong> (3.4 times operating profit), every people decision is inevitably also a margin decision. In this context, the ability to put the right person in the right role — at scale, with data — was not an HR issue: it was a prerequisite for protecting profitability. Carrefour received up to <strong className="text-[#1A1A2E]/80 font-semibold">30,000 applications per year</strong>, managed by just <strong className="text-[#1A1A2E]/80 font-semibold">3 recruiters</strong>, with no tool capable of distinguishing — across 1,200 stores — who would perform from who would leave within months.
+        In an industry where labour cost accounts for <strong className="text-[#1A1A2E]/80 font-semibold">9.8% of revenues</strong> (3.4 times the costs of operating profits), every people decision is inevitably also a decision that impacts margins. In this context, the ability to put the right person in the right role at scale, with data, was not just an HR issue: it was a prerequisite for protecting profitability. Carrefour received up to <strong className="text-[#1A1A2E]/80 font-semibold">30,000 applications per year</strong>, managed by just <strong className="text-[#1A1A2E]/80 font-semibold">3 recruiters</strong>, with no tool capable of distinguishing, across 1,200 stores, who would perform from who would leave within months.
       </>,
     },
     challenge: {
       badge: 'THE CHALLENGE',
       title: 'The Structural Problem',
-      intro: "Carrefour Italia had a clear operational constraint: scale selection quality without multiplying resources — in a sector where every wrong hire directly erodes margins.",
+      intro: "Carrefour Italia had a clear operational constraint: scale hiring quality without multiplying resources, in a sector where every wrong hire directly erodes margins.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Target,
           title: 'Cost of potential wrong hires',
-          text: "Frontline replacement costs €3,000–6,600; a store manager can reach €40,000–90,000. Keeping selection quality high and turnover low was a direct financial imperative.",
+          text: "Frontline replacement costs €3,000–6,600; a store manager can reach €40,000–90,000. Keeping hiring quality high and turnover low was a direct financial imperative.",
         },
         {
           icon: Layers,
           title: 'Multi-format complexity',
-          text: "4 retail formats, each with different profiles and competencies. 3 recruiters could not guarantee evaluation depth across 1,200 stores without risking store performance.",
+          text: "4 retail formats, each with different profiles and skills. 3 recruiters could not guarantee the correct depth of evaluation across 1,200 stores without risking negative impact on store performance.",
         },
         {
           icon: Eye,
-          title: 'Competencies invisible across the store network',
-          text: "For thousands of employees, no structured mapping existed. Decisions on who to promote, where to invest in training, who was ready for more responsibility had no data behind them.",
+          title: 'Skills invisible across the store network',
+          text: "No structured skills mapping was available for thousands of employees. Decisions on who to promote, where to invest in training, who was ready for more responsibility had no data behind them.",
         },
       ],
       hrChallenges: [
         {
           icon: BarChart3,
           title: "CVs didn't predict performance",
-          text: "For junior and operational profiles — most of the 30,000 annual applications — CVs are a poor predictor. Customer orientation, problem solving, adaptability: all invisible on paper.",
+          text: "For junior and operational profiles — most of the 30,000 annual applications — CVs are a poor predictor of real capabilities. Customer orientation, problem solving, adaptability: all invisible on paper.",
         },
         {
           icon: Wrench,
           title: 'Pre-screening with no structured output',
-          text: "Decisions relied on individual judgment and unstructured interviews, reducing predictive accuracy by 14%. No competency data before the interview.",
+          text: "Decisions relied on individual judgment and traditional interviews, something that can reduce predictive accuracy by up to 14% in comparison to structured interviews. No skill data was available before the interview.",
         },
         {
           icon: Users,
-          title: 'The competency model existed on paper, not in the process',
-          text: "Carrefour had defined critical behaviours for each role, but hiring could not always happen with a systematic evaluation against that framework.",
+          title: 'The skills model existed on paper, not in the process',
+          text: "Carrefour had defined critical behaviours for each role, but hiring was not always conducted with a systematic evaluation based on that framework.",
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'What Needed to Change',
+      title: 'What needed to change',
       items: [
         { icon: Zap, text: "Scale pre-screening without sacrificing quality: handle 30,000 applications/year with 3 recruiters, reducing reliance on external headhunters and freeing time for in-depth evaluation and employer branding" },
-        { icon: CheckCircle, text: "Integrate the proprietary leadership model into selection: assess soft and hard skills aligned to the Carrefour framework, with structured output on every candidate before the first interview" },
-        { icon: Layers, text: "Cover a multi-format organization: a single adaptable tool for different profiles — HQ internships, operational roles across multiple store formats, leadership profiles — each with a specific competency mix" },
-        { icon: TrendingUp, text: "Build a bridge between selection and development: align competencies measured at hiring with those developed internally, creating the foundation for a skills-based model covering the entire talent lifecycle" },
+        { icon: CheckCircle, text: "Integrate the proprietary leadership model into hiring: assess soft and hard skills aligned to the Carrefour framework, with structured output on every candidate before the first interview" },
+        { icon: Layers, text: "Cover a multi-format organization: a single adaptable tool for different profiles — HQ internships, operational roles across multiple store formats, leadership profiles — each with a specific skill mix" },
+        { icon: TrendingUp, text: "Build a bridge between hiring and development: align skills measured at hiring with those developed internally, creating the foundation for a skills-based model covering the entire talent lifecycle" },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI Assessment with Skillvue',
-      intro: "Skillvue was integrated first into the selection process for junior profiles, then progressively extended to the internal workforce.",
+      intro: "Skillvue was integrated first into the hiring process for junior profiles, then progressively extended to the internal workforce.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
         { icon: Heart, label: "Soft skills aligned to the proprietary leadership model" },
@@ -263,38 +263,38 @@ const content = {
       methodology: [
         {
           title: "01 — Integration with the proprietary leadership model",
-          text: "Carrefour's leadership model was integrated into Skillvue assessments, calibrating content and observable behaviours. Every candidate receives a structured evaluation before their first interview, with the scalability and objectivity that only a science-backed assessment can guarantee.",
+          text: "Carrefour's leadership model was integrated into Skillvue assessments, calibrating content and observable behaviours. This way every candidate gets a structured evaluation before their first interview, with the scalability and objectivity that only a science-backed assessment can guarantee.",
         },
         {
           title: "02 — Multi-channel architecture, one process",
-          text: "Assessments configured for different profiles — HQ internships, operational roles, leadership — each with a specific mix of soft and hard skills. The recruiter receives a structured report with competency profile and role matching. One single standard across 4 formats and 1,200 stores.",
+          text: "Assessments configured for different profiles — HQ internships, operational roles, leadership — each with a specific mix of soft and hard skills. The recruiter receives a structured report with skill profile and role matching. One single standard across 4 formats and 1,200 stores.",
         },
         {
           title: "03 — From hiring to store network mapping",
-          text: "The value demonstrated in selection led to extending the model to the store network: 6,000 employees mapped on competencies in 1 month, replacing in-person observation. For the first time, a single language from selection to development.",
+          text: "The value demonstrated in hiring led to extending the model to the store network: 6,000 employees mapped on skills in 1 month, replacing in-person observation. For the first time, a single language from hiring to development.",
         },
       ],
     },
     results: {
       badge: 'RESULTS',
       title: 'Key Metrics & Impact',
-      subtitle: 'The measurable outcomes Carrefour Italia achieved through Skillvue across selection and internal skills mapping.',
+      subtitle: 'The measurable outcomes Carrefour Italia achieved through Skillvue across hiring and internal skills mapping.',
       metrics: [
         { value: '-35%', label: 'Time-to-hire' },
-        { value: '65% → 85%', label: 'Success rate of selections advanced by Hiring Managers' },
+        { value: '65% → 85%', label: 'Success rate of hires once handed over to Hiring Managers' },
         { value: '6,000', label: 'Employees mapped in 1 month' },
       ],
       qualitative: [
-        { icon: CheckCircle, title: 'Radically more qualified shortlists', text: "Candidates advanced in the process were more aligned to expectations, with a direct reduction in interviews that didn't lead to a hire. Across 30,000 applications/year, hundreds of mistakes avoided — each costing €3,000–6,600." },
-        { icon: Eye, title: 'Hidden talent discovered in the network', text: "Mapping 6,000 employees surfaced high-potential profiles where no visibility previously existed. In a market where developing internally costs 30–50% less than external hiring, knowing who you have is the first step to stop chasing demand on the market." },
-        { icon: Wrench, title: 'The leadership model came to life in practice', text: "The proprietary framework became a measurable selection criterion. Every candidate is evaluated with structured output: the model informs decisions, not just declared values." },
+        { icon: CheckCircle, title: 'Radically more qualified shortlists', text: "Candidates moving on to next steps in the process were more aligned to expectations, with a direct reduction in interviews that didn't lead to a hire. Across 30,000 applications/year, hundreds of mistakes avoided — each costing €3,000–6,600." },
+        { icon: Eye, title: 'Hidden talent discovered in the network', text: "Mapping 6,000 employees highlighted high-potential profiles where no visibility previously existed. In a market where developing internally costs 30–50% less than external hiring, knowing who you have is the first step to stop chasing demand on the market." },
+        { icon: Wrench, title: 'The leadership model came to life', text: "The proprietary framework became a measurable hiring criterion. Every candidate is evaluated and receives a structured output: the model informs decisions, not just declared values." },
       ],
     },
     related: {
       title: 'Related Stories',
       stories: [
         { id: 'europ-assistance', company: 'Europ Assistance', tag: 'Insurance · Hiring at Scale', headline: 'How Europ Assistance hired 24% more with 18% fewer interviews.' },
-        { id: 'subdued', company: 'Subdued', tag: 'Retail Fashion · Hiring', headline: 'Subdued: building a single scalable selection standard for a network of 130+ stores' },
+        { id: 'subdued', company: 'Subdued', tag: 'Retail Fashion · Hiring', headline: 'Subdued: building a single scalable hiring standard for a network of 130+ stores' },
       ],
       cta: 'Read the story',
     },
@@ -487,7 +487,7 @@ export default function CarrefourStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.results.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.results.subtitle}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.results.subtitle}</p>
 
               <div className="rounded-2xl bg-[#111128] p-10 lg:p-14 mb-10">
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 max-w-3xl mx-auto">

--- a/pages/customers/credem.tsx
+++ b/pages/customers/credem.tsx
@@ -64,7 +64,7 @@ const content = {
       title: '30.000 candidature, 600+ filiali, profili junior indistinguibili da CV.',
       intro: "I migliori candidati rischiavano di andarsene prima che il processo si concludesse. In un mercato dove Credem compete con altre banche, fintech e tech company per gli stessi profili, ogni settimana di ritardo nel processo aumentava il rischio di perdere i candidati più ricercati.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: TrendingUp,
@@ -92,7 +92,7 @@ const content = {
     },
     objectives: {
       badge: 'OBIETTIVI DI COLLABORAZIONE',
-      title: 'Trasformare lo screening da collo di bottiglia a vantaggio competitivo.',
+      title: 'Cosa doveva cambiare',
       items: [
         { icon: Target, text: "Rendere il primo filtro più selettivo e predittivo: intercettare i profili ad alto potenziale nascosti nelle 30.000 candidature, riducendo i falsi positivi" },
         { icon: Zap, text: "Ridurre il time-to-hire e ottimizzare le shortlist: rispondere ai candidati migliori prima della concorrenza e portare al colloquio solo candidati con competenze verificate" },
@@ -192,9 +192,9 @@ const content = {
     challenge: {
       badge: 'THE CHALLENGE',
       title: '30,000 applications, 600+ branches, junior profiles indistinguishable by CV.',
-      intro: "The best candidates risked leaving before the process concluded. In a market where Credem competes with other banks, fintechs and tech companies for the same profiles, every week of delay in the process increased the risk of losing the most sought-after candidates.",
+      intro: "The best candidates risked leaving before the process ended. In a market where Credem competes with other banks, fintechs and tech companies for the same profiles, every week of delay in the process increased the risk of losing the most sought-after candidates.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: TrendingUp,
@@ -216,16 +216,16 @@ const content = {
         {
           icon: Target,
           title: 'Selection quality was not consistent',
-          text: "Guaranteeing uniform screening standards across a network of 600+ branches in 19 regions was an operational and fairness challenge. Without a centralised, structured filter, selection quality could vary significantly.",
+          text: "Guaranteeing uniform screening standards across a network of 600+ branches in 19 regions was an operational and fairness challenge. Without a centralised, structured filter, hiring quality could vary significantly.",
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'Turn screening from a bottleneck into a competitive advantage.',
+      title: 'What needed to change',
       items: [
         { icon: Target, text: "Make the first filter more selective and predictive: identify high-potential profiles hidden among the 30,000 applications, reducing false positives" },
-        { icon: Zap, text: "Reduce time-to-hire and optimise shortlists: respond to the best candidates before the competition and bring to interview only candidates with verified competencies" },
+        { icon: Zap, text: "Reduce time-to-hire and optimise shortlists: respond to the best candidates before the competition and bring to interview only candidates with verified skills" },
         { icon: Layers, text: "Guarantee consistent standards across the network: same level of evaluation across 600+ branches" },
         { icon: Heart, text: "Improve employer brand: a fast, inclusive and modern process, consistent with the Top Employer positioning" },
       ],
@@ -233,7 +233,7 @@ const content = {
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI Assessment with Skillvue',
-      intro: "Skillvue was integrated into the Progetto Giovani selection process with a gradual, data-driven approach: first validation on an initial perimeter, then progressive extension. The goal was to measure impact with real data before scaling.",
+      intro: "Skillvue was integrated into the Progetto Giovani hiring process with a gradual, data-driven approach: first validation on an initial perimeter, then progressive extension. The goal was to measure impact with real data before scaling.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
         { icon: Target, label: 'Resilienza' },
@@ -244,7 +244,7 @@ const content = {
       methodology: [
         {
           title: 'Application collection and AI Assessment',
-          text: "The HR team collects and shortlists applications. Every candidate completes an assessment on the key cross-functional competencies for client management in branch.",
+          text: "The HR team collects and shortlists applications. Every candidate completes an assessment on the key cross-functional skills for client management in branch.",
         },
         {
           title: 'Ranking and shortlist',
@@ -265,15 +265,15 @@ const content = {
         { value: '-15%', label: 'Misaligned interviews' },
       ],
       qualitative: [
-        { icon: Eye, title: 'More candidates get to demonstrate their value', text: "The assessment gave more people the opportunity to surface real competencies beyond the CV. High-potential profiles that previously got lost in the volume are now identified — exactly what a bank hiring 400 people a year and competing for the best needs." },
+        { icon: Eye, title: 'More candidates get to demonstrate their value', text: "The assessment gave more people the opportunity to surface real skills beyond the CV. High-potential profiles that previously got lost in the volume are now identified — exactly what a bank hiring 400 people a year and competing for the best needs." },
         { icon: CheckCircle, title: 'Radically improved interview quality', text: "The +50% fit-to-hire means the second step of the process has become more efficient: less time spent on low-yield interviews, more informed decisions, faster feedback cycles." },
-        { icon: Layers, title: 'Human-in-the-loop, always', text: "The assessment doesn't produce a verdict: it produces information. The ranking and competency profiles feed the recruiter's decision — they don't replace it. AI augments human analytical capacity, it doesn't replace it." },
+        { icon: Layers, title: 'Human-in-the-loop, always', text: "The assessment doesn't produce a verdict: it produces information. The ranking and skills profiles feed the recruiter's decision — they don't replace it. AI augments human analytical capacity, it doesn't replace it." },
       ],
     },
     related: {
       title: 'Related Stories',
       stories: [
-        { id: 'carrefour', company: 'Carrefour', tag: 'GDO Retail · Hiring at Scale', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
+        { id: 'carrefour', company: 'Carrefour', tag: 'Large-scale distribution · Hiring at Scale', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
         { id: 'europ-assistance', company: 'Europ Assistance', tag: 'Insurance · Hiring', headline: 'How Europ Assistance hired 24% more with 18% fewer interviews.' },
       ],
       cta: 'Read the story',

--- a/pages/customers/douglas.tsx
+++ b/pages/customers/douglas.tsx
@@ -156,7 +156,7 @@ const content = {
       highlight2: '5 weeks',
       after: '',
     },
-    subtitle: "A retail network of 2,500 employees spread across nearly 400 stores, zero visibility on competencies, and the high turnover typical of beauty retail. With Skillvue, Douglas created the first-ever complete skills database of its entire workforce, closing the gap between HQ and the sales network and enabling data-driven career development.",
+    subtitle: "A retail network of 2,500 employees spread across nearly 400 stores, zero visibility on skills, and the high turnover typical of beauty retail. With Skillvue, Douglas created the first-ever complete skills database of its entire workforce, closing the gap between HQ and the sales network and enabling data-driven career development.",
     heroMetrics: [
       { value: '2K', label: 'people brought into HR\u2019s radar' },
       { value: '5 weeks', label: 'mapping timeframe' },
@@ -177,16 +177,16 @@ const content = {
     },
     context: {
       badge: 'CONTEXT',
-      title: 'The Project Context',
+      title: 'The Company and The Context',
       paragraph: <>
-        Douglas Group, with <strong className="text-[#1A1A2E]/80 font-semibold">1,972 stores across 22 countries</strong>, a European revenue of <strong className="text-[#1A1A2E]/80 font-semibold">€4.58 billion</strong>, and an expansion plan of <strong className="text-[#1A1A2E]/80 font-semibold">200 new openings and 400 renovations by end of 2026</strong>, is Europe\u2019s leading omnichannel beauty retailer. The quality of in-store advisory is the primary competitive advantage of physical retail over e-commerce \u2014 yet it is also the least measured and structured variable in the sector. In Italy, Douglas operates with over <strong className="text-[#1A1A2E]/80 font-semibold">370 stores</strong> and approximately <strong className="text-[#1A1A2E]/80 font-semibold">2,500 people</strong> in the commercial network, in a beauty market worth <strong className="text-[#1A1A2E]/80 font-semibold">€14.2 billion</strong> in domestic consumption.<br /><br />Despite a context of very solid growth, people-side gaps were emerging. The Italian HQ had <strong className="text-[#1A1A2E]/80 font-semibold">no objective data on the competencies</strong> of its sales network: the only source was feedback from store or area managers. In a sector where sales staff turnover ranges between <strong className="text-[#1A1A2E]/80 font-semibold">25% and 35%</strong> annually \u2014 and can be directly linked to opportunities for growth and development within the company \u2014 the need to adopt a more data-driven approach to talent management became clear.
+        Douglas Group, with <strong className="text-[#1A1A2E]/80 font-semibold">1,972 stores across 22 countries</strong>, a European revenue of <strong className="text-[#1A1A2E]/80 font-semibold">€4.58 billion</strong>, and an expansion plan of <strong className="text-[#1A1A2E]/80 font-semibold">200 new openings and 400 renovations by end of 2026</strong>, is Europe's leading omnichannel beauty retailer. The quality of in-store advisory is the primary competitive advantage of physical retail over e-commerce — yet it is also the least measured and structured variable in the sector. In Italy, Douglas operates with over <strong className="text-[#1A1A2E]/80 font-semibold">370 stores</strong> and approximately <strong className="text-[#1A1A2E]/80 font-semibold">2,500 people</strong> in the commercial network, in a beauty market worth <strong className="text-[#1A1A2E]/80 font-semibold">€14.2 billion</strong> in domestic consumption.<br /><br />Despite a context of very solid growth, people-side gaps were emerging. The Italian HQ had <strong className="text-[#1A1A2E]/80 font-semibold">no objective data on the skills</strong> of its sales network: the only source was feedback from store or area managers. In a sector where sales staff turnover ranges between <strong className="text-[#1A1A2E]/80 font-semibold">25% and 35%</strong> annually — and can be directly linked to opportunities for growth and development within the company — the need to adopt a more data-driven approach to talent management became clear.
       </>,
       summary: "The project transformed talent management from a model based on subjective feedback and in-person observation to a scalable, data-driven system — creating for the first time a complete and objective picture of skills across the entire sales network, both soft and hard skills, and enabling career development, internal mobility and customised training based on real data.",
     },
     challenge: {
       badge: 'THE CHALLENGE',
       title: 'The Structural Problem',
-      intro: "Across 2,500 employees in nearly 400 stores, the HQ had no structured data on competencies. In a high-turnover sector, the absence of data meant losing talent, training poorly and being unable to plan internal mobility.",
+      intro: "Across 2,500 employees in nearly 400 stores, the HQ had no structured data on skills. In a high-turnover sector, the absence of data meant losing talent, training poorly and being unable to plan internal mobility.",
       businessLabel: 'BUSINESS IMPACT',
       hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
@@ -198,7 +198,7 @@ const content = {
         {
           icon: Users,
           title: 'A wide gap between HQ and the retail network',
-          text: "Employees had no way to surface their competencies and aspirations. Talent remained invisible, with direct impact on engagement and retention.",
+          text: "Employees had no way to surface their skills and aspirations. Talent remained invisible, with direct impact on engagement and retention.",
         },
         {
           icon: TrendingUp,
@@ -226,12 +226,12 @@ const content = {
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'What Needed to Change',
+      title: 'What needed to change',
       items: [
-        { icon: Eye, text: "Map the competencies of the entire retail network objectively and immediately: a standardised assessment across all roles (Beauty Advisor, Sales Assistant, Store Manager) and all seniority levels." },
-        { icon: Zap, text: "Optimise the time and cost of internal competency analysis: make it sustainable given turnover rates and the pace of the labour market, replacing in-person observation with a scalable system." },
+        { icon: Eye, text: "Map the skills of the entire retail network objectively and immediately: a standardised assessment across all roles (Beauty Advisor, Sales Assistant, Store Manager) and all seniority levels." },
+        { icon: Zap, text: "Optimise the time and cost of internal skills analysis: make it sustainable given turnover rates and the pace of the labour market, replacing in-person observation with a scalable system." },
         { icon: TrendingUp, text: "Promote internal career paths and reduce turnover: identify high-potential people and propensities for different roles to facilitate horizontal and vertical internal moves, reducing the need for external hiring." },
-        { icon: Target, text: "Work proactively on training and development: build a shared competency database to activate customised learning paths that close existing skill gaps and plan workforce development." },
+        { icon: Target, text: "Work proactively on training and development: build a shared skills database to activate customised learning paths that close existing skill gaps and plan workforce development." },
       ],
     },
     solution: {
@@ -254,7 +254,7 @@ const content = {
         { value: 'Only 3', label: 'People in the HR team' },
       ],
       qualitative: [
-        { icon: Eye, title: 'Skills finally visible', text: "For the first time, a clear and comparable view of the competencies of every person across the retail network \u2014 a picture directly actionable for decisions on growth, mobility and training." },
+        { icon: Eye, title: 'Skills finally visible', text: "For the first time, a clear and comparable view of the skills of every person across the retail network \u2014 a picture directly actionable for decisions on growth, mobility and training." },
         { icon: Target, title: 'Hidden talent and predictive potential', text: "The analysis identified predictive propensities for different roles, facilitating horizontal and vertical internal moves and revealing talent where no visibility previously existed." },
         { icon: CheckCircle, title: 'Customised training and skill gaps closed', text: "With the collected data, customised training paths were activated to close existing gaps and define internal redeployments more quickly. A key lever for optimising costs and performance." },
         { icon: Zap, title: 'Time and cost optimisation', text: "Analysis timelines optimised and the burden on managers reduced, freeing resources for higher-value development activities." },
@@ -263,8 +263,8 @@ const content = {
     related: {
       title: 'Related Stories',
       stories: [
-        { id: 'unicomm', company: 'Unicomm', tag: 'GDO Retail · Internal Development', headline: 'How Unicomm is building a new talent management system across a network of 270 stores and growing' },
-        { id: 'carrefour', company: 'Carrefour', tag: 'GDO Retail · Hiring at Scale', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
+        { id: 'unicomm', company: 'Unicomm', tag: 'Large-scale distribution · Internal Development', headline: 'How Unicomm is building a new talent management system across a network of 270 stores and growing' },
+        { id: 'carrefour', company: 'Carrefour', tag: 'Large-scale distribution · Hiring at Scale', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
       ],
       cta: 'Read the story',
     },

--- a/pages/customers/eataly.tsx
+++ b/pages/customers/eataly.tsx
@@ -55,7 +55,7 @@ const content = {
         Eataly non è un operatore qualsiasi del food italiano. Con <strong className="text-[#1A1A2E]/80 font-semibold">€684M di ricavi, una crescita del 47% in tre anni</strong>, e una revenue per employee doppia rispetto alla media di settore, è l'unico brand italiano del food con una presenza internazionale reale in <strong className="text-[#1A1A2E]/80 font-semibold">16 Paesi</strong>. Dal 2022 sta accelerando su tutti i fronti: nuovi flagship in Nord America (dove si genera il <strong className="text-[#1A1A2E]/80 font-semibold">60% dei ricavi</strong>), nuovi format compatti — Eataly Caffè in hub urbani e Eataly Collection negli aeroporti —, un piano da <strong className="text-[#1A1A2E]/80 font-semibold">€100M per il Medio Oriente</strong>, e il primo Eataly at Sea con MSC Cruises.<br /><br />
         Questa crescita richiede figure manageriali capaci di incarnare i valori del brand in contesti multiculturali: Head Chef, Director of Store Operations, General Manager capaci di portare l'autenticità italiana a Philadelphia, Toronto e Miami. Ma il settore della ristorazione non produce sempre il talento che serve. Con <strong className="text-[#1A1A2E]/80 font-semibold">258.000 posti vacanti, un turnover operativo del 50–70% e un tempo medio di reperimento di 4,5 mesi</strong>, la carenza di figure qualificate è il vincolo più critico al piano di espansione. Nasce da qui il <strong className="text-[#1A1A2E]/80 font-semibold">Progetto Career Passport</strong>, per trasformare questo vincolo in un vantaggio competitivo.
       </>,
-      summary: "Il Career Passport è stato il primo capitolo per la costruzione di una talent strategy sempre più solida e innovativa, orientata a rendere il brand Eataly una piattaforma globale del Made in Italy.",
+      summary: "Il Career Passport è stato il primo capitolo per la costruzione di una talent strategy sempre più solida e innovativa attorno al concetto di mobilità internazionale e crescita, orientata a rendere il brand Eataly una piattaforma globale del Made in Italy.",
     },
     challenge: {
       badge: 'LA SFIDA',
@@ -100,7 +100,7 @@ const content = {
     },
     objectives: {
       badge: 'OBIETTIVI DI COLLABORAZIONE',
-      title: 'Dare al piano di espansione lo strumento di assessment che merita.',
+      title: 'Cosa doveva cambiare',
       items: [
         { icon: Zap, text: "Processare 1.300+ candidature in settimane, non mesi: comprimere i tempi di pre-screening per stare al passo con un piano di aperture che non aspetta." },
         { icon: Eye, text: "Mappare tutti i fattori chiave gi\u00e0 al pre-screening: Leadership, gestione del personale, lingua inglese, aspirazione alla mobilit\u00e0 internazionale. Valutare tutto prima del primo colloquio umano, per concentrare l\u2019investimento di tempo sui candidati con il pi\u00f9 alto potenziale di successo." },
@@ -184,7 +184,7 @@ const content = {
         Eataly is no ordinary player in Italian food. With <strong className="text-[#1A1A2E]/80 font-semibold">€684M in revenue, 47% growth over three years</strong>, and revenue per employee double the industry average, it is the only Italian food brand with a truly international presence across <strong className="text-[#1A1A2E]/80 font-semibold">16 countries</strong>. Since 2022 it has been accelerating on all fronts: new flagships in North America (where <strong className="text-[#1A1A2E]/80 font-semibold">60% of revenues</strong> are generated), new compact formats — Eataly Caffè in urban hubs and Eataly Collection in airports —, a <strong className="text-[#1A1A2E]/80 font-semibold">€100M plan for the Middle East</strong>, and the first Eataly at Sea with MSC Cruises.<br /><br />
         This growth requires managerial talent capable of embodying the brand's values in multicultural contexts: Head Chefs, Directors of Store Operations, General Managers who can bring Italian authenticity to Philadelphia, Toronto and Miami. But the hospitality sector doesn't always produce the talent that is needed. With <strong className="text-[#1A1A2E]/80 font-semibold">258,000 vacancies, 50–70% operational turnover, and an average time-to-fill of 4.5 months</strong>, the shortage of qualified profiles is the most critical constraint on the expansion plan. This is the origin of the <strong className="text-[#1A1A2E]/80 font-semibold">Career Passport Project</strong> — to turn this constraint into a competitive advantage.
       </>,
-      summary: "The Career Passport was the first chapter in building an increasingly solid and innovative talent strategy, aimed at making the Eataly brand a global platform for Made in Italy.",
+      summary: "The Career Passport was the first chapter in building an increasingly solid and innovative talent strategy around the concept of international mobility and growth, aimed at making the Eataly brand a global platform for Made in Italy.",
     },
     challenge: {
       badge: 'THE CHALLENGE',
@@ -223,13 +223,13 @@ const content = {
         {
           icon: Heart,
           title: 'The hiring process as an employer branding lever',
-          text: "To attract the best, Eataly needed to communicate its brand value through the selection process itself: innovation, care for the individual, and the uniqueness of an international career opportunity.",
+          text: "To attract the best, Eataly needed to communicate its brand value through the hiring process itself: innovation, care for the individual, and the uniqueness of an international career opportunity.",
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'Give the expansion plan the assessment tool it deserves.',
+      title: 'What needed to change',
       items: [
         { icon: Zap, text: "Process 1,300+ applications in weeks, not months: compress pre-screening timelines to keep pace with an opening plan that can\u2019t wait." },
         { icon: Eye, text: "Map all key factors at the pre-screening stage: Leadership, team management, English language, aspiration for international mobility. Assess everything before the first human interview, to focus time investment on the highest-potential candidates." },
@@ -260,13 +260,13 @@ const content = {
       qualitative: [
         { icon: CheckCircle, title: 'Clear results in a matter of weeks', text: "In a sector where finding a qualified manager takes an average of 4.5 months, Skillvue made it possible to process the entire volume of applications and reach an interview-ready shortlist in just a few weeks, enabling the opening plan without delays." },
         { icon: Users, title: 'Transfers already underway from Europe to North America', text: "From London to Boston, Stockholm to Philadelphia, Munich to West Palm Beach, Rome to Toronto \u2014 Eataly is building an international talent pipeline that brings Italian authenticity to new markets. A tangible result of the Career Passport." },
-        { icon: Heart, title: 'Employer branding recognised', text: "The project was recognised as exceptionally high-value in 2025, the year of its launch, which is why it is being continued into 2026. In a sector where competition for talent is structurally unfavourable to hospitality, Eataly has shown that an innovative selection process is itself a brand asset." },
+        { icon: Heart, title: 'Employer branding recognised', text: "The project was recognised as exceptionally high-value in 2025, the year of its launch, which is why it is being continued into 2026. In a sector where competition for talent is structurally unfavourable to hospitality, Eataly has shown that an innovative hiring process is itself a brand asset." },
       ],
     },
     vision: {
       badge: 'EVOLUTION 2026',
       title: 'The expansion continues. So does the talent acquisition machine.',
-      intro: "Eataly is in the midst of a transformation from a single-format brand to a global multi-format platform. The Career Passport was the first chapter in building an increasingly solid and innovative talent strategy, aimed at making the Eataly brand a global platform for Made in Italy.",
+      intro: "Eataly is in the midst of a transformation from a single-format brand to a global multi-format platform. The Career Passport was the first chapter in building an increasingly solid and innovative talent strategy around the concept of international mobility and growth, aimed at making the Eataly brand a global platform for Made in Italy.",
     },
     related: {
       title: 'Related Stories',

--- a/pages/customers/europ-assistance.tsx
+++ b/pages/customers/europ-assistance.tsx
@@ -61,7 +61,7 @@ const content = {
       title: 'Migliaia di candidature, due picchi stagionali, 3 persone nel team recruiting.',
       intro: 'Le assunzioni di Europ Assistance Italia si concentrano in due picchi stagionali l\'anno, generando volumi nell\'ordine delle migliaia di candidature in pochi mesi. Per i ruoli di assistenza e customer care, le soft skill sono il primo predittore di successo — problem solving, orientamento al cliente, gestione dello stress — ma sono completamente invisibili nel CV.',
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Users,
@@ -169,7 +169,7 @@ const content = {
       highlight2: 'human interaction',
       after: '',
     },
-    subtitle: "With Skillvue, Europ Assistance transformed pre-screening from a bottleneck into a competitive advantage and is now extending the model to internal competency mapping to keep optimising the match between internal talent quality and the service delivered externally.",
+    subtitle: "With Skillvue, Europ Assistance transformed pre-screening from a bottleneck into a competitive advantage and is now extending the model to internal skills mapping to keep optimising the match between internal talent quality and the service delivered externally.",
     heroMetrics: [
       { value: '+24%', label: 'year-over-year hires' },
       { value: '-18%', label: 'interviews required' },
@@ -191,7 +191,7 @@ const content = {
       badge: 'CONTEXT',
       title: 'In a business built on human interaction, the quality of who you hire translates directly into the quality of the service.',
       paragraph: <>
-        Europ Assistance, part of the <strong className="text-[#1A1A2E]/80 font-semibold">Generali Group</strong>, is one of the world's leading providers of assistance and travel insurance services. Its growth is constant: operations are expanding into new markets and converging with Generali Care into an <strong className="text-[#1A1A2E]/80 font-semibold">integrated hub worth €5.3 billion</strong>.<br /><br />In Italy, it operates with a business model built on the quality of human interaction: 24/7 assistance, claims management, multilingual customer care. Hiring and developing the right people is a critical lever for the business to function and grow, especially given the instability of the insurance labour market — characterised by rising turnover rates and a salary gap with fintech and consulting that makes attracting top talent harder. In this context, every wrong hire costs more and every right person who stays is worth even more.
+        Europ Assistance, part of the <strong className="text-[#1A1A2E]/80 font-semibold">Generali Group</strong>, is one of the world's leading providers of assistance and travel insurance services. Its growth is constant: operations are expanding into new markets and converging with Generali Care into an <strong className="text-[#1A1A2E]/80 font-semibold">integrated hub worth €5.3 billion</strong>.<br /><br />In Italy, it operates with a business model built on the quality of human interaction: 24/7 assistance, claims management, multilingual customer care. <strong className="text-[#1A1A2E]/80 font-semibold">Hiring and developing the right people is a critical lever</strong> for the business to function and grow, especially given the instability of the insurance labour market — characterised by rising turnover rates and a salary gap with fintech and consulting that makes attracting top talent harder. In this context, every wrong hire costs more and every right person who stays is worth even more.
       </>,
     },
     challenge: {
@@ -199,17 +199,17 @@ const content = {
       title: 'Thousands of applications, two seasonal peaks, 3 people in the recruiting team.',
       intro: "Europ Assistance Italia's hires are concentrated in two seasonal peaks per year, generating volumes in the order of thousands of applications in just a few months. For assistance and customer care roles, soft skills are the top predictor of success — problem solving, customer orientation, stress management — but are completely invisible in a CV.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Users,
           title: 'Need to manage seasonal peaks',
-          text: "Hiring concentrates in two seasonal peaks per year, generating thousands of applications in just a few months — managed by a team of 3 people.",
+          text: "Hiring concentrates in two seasonal peaks per year, generating thousands of applications in just a few months that need to be managed by the same 3 people the HR team employs all year round.",
         },
         {
           icon: BarChart3,
           title: 'No visibility on growth potential',
-          text: "Selection only evaluated immediate fit. Europ Assistance was looking for more: identifying from the first step the soft skills predictive of future growth, to give line managers visibility on how a person could develop over time.",
+          text: "The old process only evaluated immediate fit. Europ Assistance was looking for more: identifying from the first step the soft skills predictive of future growth, to give line managers visibility on how a person could develop over time.",
         },
       ],
       hrChallenges: [
@@ -221,39 +221,39 @@ const content = {
         {
           icon: Zap,
           title: 'HR time was trapped in screening',
-          text: "Recruiters spent most of their hours on introductory calls and manual filtering. Yet half the candidates who passed the first filter lacked the necessary competencies.",
+          text: "Recruiters spent most of their hours on introductory calls and manual filtering. Yet half the candidates who passed the first filter lacked the necessary skills.",
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'What Needed to Change',
+      title: 'What needed to change',
       items: [
         { icon: Zap, text: 'Scale pre-screening without scaling the team: manage thousands of applications with 3 FTE, freeing recruiters from screening to focus on interviews and potential evaluation' },
-        { icon: Eye, text: 'Make soft skills visible from the first step: objective data on cross-functional competencies and English language before any human interaction' },
+        { icon: Eye, text: 'Make soft skills visible from the first step: objective data on cross-functional skills and English language needed to be available before any human intervention in the process' },
         { icon: Shield, text: 'Build a fair and defensible process: AI as support to the recruiter, not a substitute — human-in-the-loop at every stage, bias reduction' },
-        { icon: Target, text: 'Select for potential, not just fit: identify candidates with competencies that make them employable for internal growth and future roles' },
+        { icon: Target, text: 'Select for potential, not just fit: identify candidates with skills that make them employable for internal growth and future roles' },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI Assessment with Skillvue',
-      intro: "Skillvue was integrated into Europ Assistance Italia's selection process as the first structured step of the funnel, managing pre-screening across multiple profiles and geographic locations. Deployment is recurring, tied primarily to the two annual seasonal peaks.",
+      intro: "Skillvue was integrated into Europ Assistance Italia's hiring process as the first structured step of the funnel, managing pre-screening across multiple profiles and geographic locations. Deployment is recurring, tied primarily to the two annual seasonal peaks.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
         { icon: Heart, label: 'Soft skills — problem solving, customer orientation, goal orientation, teamworking' },
-        { icon: Wrench, label: 'English language — B1/B2/C1 tests, a critical competency for a company operating in 39 countries with multilingual customer care' },
+        { icon: Wrench, label: 'English language — B1/B2/C1 tests, a critical skill for a company operating in 39 countries with multilingual customer care' },
         { icon: Layers, label: 'Role-specific hard skills — e.g. Compensation & Benefits for HR roles' },
       ],
       methodologyLabel: 'HOW IT WAS BUILT',
       methodology: [
         {
-          title: 'Assessment independently as the first step',
-          text: "After applying, every candidate completes the assessment from any device — phone or laptop.",
+          title: 'Assessment is done independently as the first step',
+          text: "After applying, every candidate completes the assessment from any device, phone or laptop.",
         },
         {
           title: 'Structured report for the recruiter',
-          text: "The HR team receives an objective, in-depth competency analysis. The first interview is based on data, not impressions.",
+          text: "The HR team receives an objective, in-depth skills analysis. The first interview is based on data, not impressions.",
         },
         {
           title: 'Human-in-the-loop at every stage',
@@ -279,18 +279,18 @@ const content = {
     vision: {
       badge: 'EVOLUTION 2026',
       title: 'From hiring tool to talent intelligence partner',
-      intro: "When the recruiting results proved that Skillvue could scale quality and speed simultaneously, the next steps in the talent lifecycle were immediately put on the table. In 2026, Europ Assistance is extending Skillvue to internal competency mapping.",
-      objective: 'Mapping against the "We IMPACT" leadership model — 5 leadership competencies assessed across 3 seniority levels (Line Manager, Manager of Managers, Senior Leader).',
+      intro: "When the recruiting results proved that Skillvue could scale quality and speed simultaneously, the next steps in the talent lifecycle were immediately put on the table. In 2026, Europ Assistance is extending Skillvue to internal skills mapping.",
+      objective: 'Mapping against the "We IMPACT" leadership model — 5 leadership skills assessed across 3 seniority levels (Line Manager, Manager of Managers, Senior Leader).',
       bullets: [
-        'Personalised assessments on the Europ Assistance model — calibrated to the specific competency framework, with psychometrically validated behavioural indicators',
-        'From selection to succession planning — competency data feeds individual development paths, career planning and succession readiness',
+        'Personalised assessments on the Europ Assistance model — calibrated to the specific skills framework, with psychometrically validated behavioural indicators',
+        'From hiring to succession planning — skills data feeds individual development paths, career planning and succession readiness',
       ],
     },
     related: {
       title: 'Related Stories',
       stories: [
         { id: 'carrefour', company: 'Carrefour', tag: 'Retail · Hiring at Scale', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
-        { id: 'mediaset', company: 'Mediaset', tag: 'Media & Telecom · Hiring', headline: 'How to select and grow talent at scale in a group that is tripling in size' },
+        { id: 'mediaset', company: 'Mediaset', tag: 'Media & Telecom · Hiring', headline: 'How to select and develop talent at scale in a group that is tripling in size' },
       ],
       cta: 'Read the story',
     },
@@ -451,7 +451,7 @@ export default function EuropAssistanceStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.solution.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.solution.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.solution.intro}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.solution.intro}</p>
 
               <div className="mb-12">
                 <span className="text-[12px] font-bold text-[#1A1A2E]/30 tracking-[0.1em] uppercase mb-5 block">{c.solution.skillsLabel}</span>
@@ -483,7 +483,7 @@ export default function EuropAssistanceStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.results.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.results.subtitle}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.results.subtitle}</p>
 
               {/* Key metrics */}
               <div className="rounded-2xl bg-[#111128] p-10 lg:p-14 mb-10">
@@ -545,7 +545,7 @@ export default function EuropAssistanceStoryPage() {
                   {c.vision.badge}
                 </span>
                 <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4 leading-[1.3]">{c.vision.title}</h2>
-                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8 max-w-3xl">{c.vision.intro}</p>
+                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8">{c.vision.intro}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>
                     <Target className="h-5 w-5" style={{ color: '#4b4df7' }} />

--- a/pages/customers/ins-mercato.tsx
+++ b/pages/customers/ins-mercato.tsx
@@ -30,7 +30,7 @@ const businessPains = [
   },
   {
     icon: Layers,
-    en: { title: 'Dependence on external hiring', desc: "Chasing demand through external recruitment means higher costs, longer onboarding times, and a real risk of cultural mismatch — in a sector where finding experienced profiles is increasingly difficult." },
+    en: { title: 'Dependence on external hiring', desc: "Chasing demand through external recruitment means higher costs, longer onboarding times, and a real risk of cultural mismatch, in a sector where finding experienced profiles is increasingly difficult." },
     it: { title: 'Dipendenza dal mercato esterno', desc: 'Rincorrere il fabbisogno con selezione esterna significa costi più alti, tempi di inserimento più lunghi e un rischio concreto di mismatch culturale, in un settore dove trovare profili formati è sempre più difficile.' },
   },
 ];
@@ -38,7 +38,7 @@ const businessPains = [
 const hrPains = [
   {
     icon: Eye,
-    en: { title: 'Invisible talent across the network', desc: 'No objective visibility into the competencies of thousands of sales associates distributed across 570+ stores: decisions on potential were based on sales numbers and subjective perceptions.' },
+    en: { title: 'Invisible talent across the network', desc: 'No objective visibility into the skills of thousands of sales associates distributed across 570+ stores: decisions on potential were based on sales numbers and subjective perceptions.' },
     it: { title: 'Invisibilità del talento in rete', desc: 'Nessuna visibilità oggettiva sulle competenze di migliaia di addetti vendita distribuiti su oltre 570 punti vendita: le decisioni sul potenziale si basavano su numeri di vendita e percezioni soggettive.' },
   },
   {
@@ -48,7 +48,7 @@ const hrPains = [
   },
   {
     icon: Zap,
-    en: { title: 'Reactive talent management, not predictive', desc: 'Without structured visibility on internal potential, every key position to fill turned into an external recruitment process. A double cost: time and investment to recruit, plus the risk of losing unrecognized talent already in the company.' },
+    en: { title: 'Reactive, not predictive talent management', desc: 'Without structured visibility on internal potential, every key position to fill turned into an external recruitment process. A double cost: time and investment to recruit, plus the risk of losing unrecognized talent already in the company.' },
     it: { title: 'Gestione reattiva del talento, non predittiva', desc: 'Senza visibilità strutturata sul potenziale interno, ogni posizione chiave da coprire si trasformava in un processo di selezione esterna. Un doppio costo: tempi e investimenti per reclutare, più il rischio di perdere talenti già in azienda non valorizzati.' },
   },
 ];
@@ -61,18 +61,18 @@ const objectives = [
   },
   {
     icon: Users,
-    en: 'Build an internal pipeline of ready Store Managers to support the opening plan without depending on an increasingly competitive and costly external market',
-    it: 'Costruire una pipeline interna di Store Manager pronti, per sostenere il piano di aperture senza dipendere da un mercato esterno sempre più competitivo e costoso',
+    en: 'Build an internal pipeline of ready Store Managers: to support the opening plan without depending on an increasingly competitive and costly external market',
+    it: 'Costruire una pipeline interna di Store Manager pronti: per sostenere il piano di aperture senza dipendere da un mercato esterno sempre più competitivo e costoso',
   },
   {
     icon: TrendingUp,
-    en: 'Maximize store performance and return on investment in new openings, ensuring every store is led by a qualified, culturally aligned Store Manager',
-    it: 'Massimizzare la performance dei punti vendita e il ritorno sugli investimenti in nuove aperture, garantendo che ogni store sia presidiato da uno Store Manager qualificato e allineato alla cultura aziendale',
+    en: 'Maximize store performance and return on investment in new openings: ensuring every store is led by a qualified, culturally aligned Store Manager',
+    it: 'Massimizzare la performance dei punti vendita e il ritorno sugli investimenti in nuove aperture: garantendo che ogni store sia presidiato da uno Store Manager qualificato e allineato alla cultura aziendale',
   },
   {
     icon: Target,
-    en: 'Anticipate key role needs months in advance, moving from an emergency-driven logic to a predictive talent planning capability',
-    it: 'Anticipare il fabbisogno di ruoli chiave con mesi di anticipo, passando da una logica emergenziale a una capacità predittiva di pianificazione del talento',
+    en: 'Anticipate key role needs months in advance: moving from an emergency-driven logic to a predictive talent planning capability',
+    it: 'Anticipare il fabbisogno di ruoli chiave con mesi di anticipo: passando da una logica emergenziale a una capacità predittiva di pianificazione del talento',
   },
 ];
 
@@ -94,7 +94,7 @@ const methodologyCards = [
 const impactCards = [
   {
     icon: Users,
-    en: { title: 'Internal pipeline built', text: "For the first time, In's has an objective map of potential across the network and can plan openings with the certainty of having qualified talent available." },
+    en: { title: 'Construction of internal talent pipeline', text: "For the first time, In's has an objective map of potential across the network and can plan openings with the certainty of having qualified talent available." },
     it: { title: 'Costruzione pipeline interna', text: "Per la prima volta, In's dispone di una mappatura oggettiva del potenziale sulla rete e può pianificare le aperture con la certezza di avere figure qualificate disponibili." },
   },
   {
@@ -129,7 +129,7 @@ const quote = {
 
 const visionBullets = {
   en: [
-    'Same criteria and competency framework from hiring to development: new hires are assessed from day one with the same logic used to develop them',
+    'Same criteria and skills framework from hiring to development: new hires are assessed from day one with the same logic used to develop them',
     'Assessment via WhatsApp: in grocery retail this isn\'t a convenience choice, it\'s a strategic one. It removes every barrier to access and drives completion rates that other tools can\'t match',
     'Extending assessment to current Store Managers to identify profiles ready for the Area Manager role',
     'Hiring, development, and training integrated into one continuous system. No longer separate processes, but a single talent strategy that works as a business asset',
@@ -192,7 +192,7 @@ export default function InsMercatoStoryPage() {
                   <p className="text-[17px] text-white/[0.60] leading-[1.75] mb-12 max-w-2xl">
                     {lang === 'it'
                       ? "La crescita della rete dipende dalla capacità di avere figure manageriali formate nel momento in cui servono. Con Skillvue, In's ha trasformato la gestione del talento da reattiva a predittiva."
-                      : "Network growth depends on having trained managerial talent ready when it's needed. With Skillvue, In's transformed talent management from reactive to predictive."
+                      : "Network growth depends on having trained managerial talent ready when it's needed. With Skillvue, In's Mercato transformed talent management from reactive to predictive."
                     }
                   </p>
                   <div className="flex flex-wrap gap-4">
@@ -228,7 +228,7 @@ export default function InsMercatoStoryPage() {
                       { label: 'Punti vendita', value: '+570' },
                       { label: 'Use Case', value: 'Internal Mobility' },
                     ] : [
-                      { label: 'Industry', value: 'GDO - Hard Discount' },
+                      { label: 'Industry', value: 'Large-scale distribution - Hard Discount' },
                       { label: 'Revenue', value: '€1.5B' },
                       { label: 'Employees', value: '4,200+' },
                       { label: 'Stores', value: '570+' },
@@ -263,28 +263,20 @@ export default function InsMercatoStoryPage() {
             {/* Context */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{lang === 'it' ? 'CONTESTO' : 'CONTEXT'}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{lang === 'it' ? 'Il contesto del progetto' : 'Project Background'}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{lang === 'it' ? 'Il contesto del progetto' : 'The Company and The Context'}</h2>
               <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-6">
                 {lang === 'it'
-                  ? <>In's Mercato è una delle principali insegne hard discount italiane, con un fatturato di <strong className="text-[#1A1A2E]/80 font-semibold">1,5 miliardi di euro</strong>, oltre <strong className="text-[#1A1A2E]/80 font-semibold">4.200 dipendenti</strong> e una rete di più di <strong className="text-[#1A1A2E]/80 font-semibold">570 punti vendita</strong>. L'azienda è in una fase di forte espansione immobiliare, con un piano di nuove aperture che pone un vincolo operativo preciso: senza Store Manager qualificati, pronti e pienamente allineati alla cultura aziendale, i nuovi negozi rischiano di sottoperformare. La crescita della rete dipende direttamente dalla capacità di avere figure manageriali formate nel momento in cui servono.</>
-                  : <>In's Mercato is one of Italy's leading hard discount grocery chains, with <strong className="text-[#1A1A2E]/80 font-semibold">€1.5 billion in revenue</strong>, over <strong className="text-[#1A1A2E]/80 font-semibold">4,200 employees</strong>, and a network of more than <strong className="text-[#1A1A2E]/80 font-semibold">570 stores</strong>. The company is in a phase of aggressive real estate expansion, with a new store opening plan that creates a clear operational constraint: without qualified Store Managers who are ready and fully aligned with the company culture, new stores risk underperforming. Network growth depends directly on having trained managerial talent available when it's needed.</>
+                  ? <>In's Mercato è una delle principali insegne hard discount italiane, con un fatturato di <strong className="text-[#1A1A2E]/80 font-semibold">1,5 miliardi di euro</strong>, oltre <strong className="text-[#1A1A2E]/80 font-semibold">4.200 dipendenti</strong> e una rete di più di <strong className="text-[#1A1A2E]/80 font-semibold">570 punti vendita</strong>. L'azienda è in una fase di forte <strong className="text-[#1A1A2E]/80 font-semibold">espansione immobiliare</strong>, con un piano di nuove aperture che pone un <strong className="text-[#1A1A2E]/80 font-semibold">vincolo operativo preciso</strong>: senza Store Manager qualificati, pronti e pienamente allineati alla cultura aziendale, i nuovi negozi rischiano di sottoperformare. La crescita della rete dipende direttamente dalla capacità di avere figure manageriali formate nel momento in cui servono.</>
+                  : <>In's Mercato is one of Italy's leading hard discount grocery chains, with <strong className="text-[#1A1A2E]/80 font-semibold">€1.5 billion in revenue</strong>, over <strong className="text-[#1A1A2E]/80 font-semibold">4,200 employees</strong>, and a network of more than <strong className="text-[#1A1A2E]/80 font-semibold">570 stores</strong>. The company is in a phase of aggressive <strong className="text-[#1A1A2E]/80 font-semibold">real estate expansion</strong>, with a new store opening plan that creates a clear <strong className="text-[#1A1A2E]/80 font-semibold">operational constraint</strong>: without qualified Store Managers who are ready and fully aligned with the company culture, new stores risk underperforming. Network growth depends directly on having trained managerial talent available when it's needed.</>
                 }
               </p>
-              <div className="rounded-xl border border-[#e2e8f0] bg-white px-8 py-6 shadow-sm">
-                <p className="text-[15px] text-[#1A1A2E]/[0.65] leading-[1.7] italic">
-                  {lang === 'it'
-                    ? "Il progetto ha trasformato la gestione del talento da reattiva a predittiva, collegando direttamente la people strategy al piano di espansione: ogni nuova apertura può ora contare su una pipeline interna di figure pronte, invece di rincorrere il fabbisogno sul mercato esterno."
-                    : "The project transformed talent management from reactive to predictive, directly linking the people strategy to the expansion plan: every new opening can now count on an internal pipeline of ready talent, instead of chasing demand on the external market."
-                  }
-                </p>
-              </div>
             </Section>
 
             {/* Challenge */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{lang === 'it' ? 'LA SFIDA' : 'THE CHALLENGE'}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{lang === 'it' ? 'Il problema strutturale' : 'The Structural Problem'}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-14 max-w-3xl">
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-14">
                 {lang === 'it'
                   ? "In's Mercato è un'azienda in forte crescita. Con oltre 570 punti vendita e un piano di sviluppo immobiliare attivo, il business aveva un vincolo operativo che precedeva qualsiasi considerazione HR."
                   : "In's Mercato is a fast-growing company. With over 570 stores and an active real estate development plan, the business faced an operational constraint that preceded any HR consideration."
@@ -514,7 +506,7 @@ export default function InsMercatoStoryPage() {
                   </div>
                   <div className="rounded-xl bg-[#4B4DF7]/[0.06] p-6 text-center">
                     <span className="block text-[#1A1A2E]" style={{ fontSize: '2.5rem', fontWeight: 800, lineHeight: 1 }}>51%+</span>
-                    <span className="text-[13px] text-[#1A1A2E]/[0.65] mt-2 block">{t('Structured competency assessment')}<br />{t('predictive validity')}</span>
+                    <span className="text-[13px] text-[#1A1A2E]/[0.65] mt-2 block">{t('Structured skills assessment')}<br />{t('predictive validity')}</span>
                   </div>
                 </div>
                 <button onClick={() => { router.push('/science'); window.scrollTo(0,0); }} className="group inline-flex items-center gap-2 text-[13px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] transition-colors duration-300">
@@ -534,8 +526,8 @@ export default function InsMercatoStoryPage() {
             <h3 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-white/90 leading-[1.4] mb-12">{t('Related Stories')}</h3>
             <div className="grid md:grid-cols-2 gap-5">
               {[
-                { id: 'carrefour', company: 'Carrefour', tag: 'Retail GDO · Hiring', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
-                { id: 'subdued', company: 'Subdued', tag: 'Fashion Retail · Hiring', headline: 'Subdued: building a single scalable selection standard for a network of 130+ stores' },
+                { id: 'carrefour', company: 'Carrefour', tag: 'Large-scale distribution · Hiring', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
+                { id: 'subdued', company: 'Subdued', tag: 'Fashion Retail · Hiring', headline: 'Subdued: building a single scalable hiring standard for a network of 130+ stores' },
               ].map(s => (
                 <button key={s.id} onClick={() => { router.push(`/customers/${s.id}`); window.scrollTo(0,0); }} className="group text-left rounded-2xl border border-white/[0.08] bg-white/[0.04] hover:bg-white/[0.07] hover:border-white/[0.14] backdrop-blur-sm p-10 lg:p-14 transition-all duration-500">
                   <span className="text-[14px] text-white/40 mb-4 block">{t(s.tag)}</span>

--- a/pages/customers/mediaset.tsx
+++ b/pages/customers/mediaset.tsx
@@ -61,7 +61,7 @@ const content = {
       title: 'Migliaia di candidati, un team HR di piccole dimensioni e tanti CV troppo uguali tra di loro.',
       intro: 'Il Progetto GRAPE ha generato oltre 3.000 candidature. Il team HR dedicato (1 manager + 2 figure operative) si è posto l\'obiettivo di raggiungere 80 candidati qualificati a settimana da portare avanti nelle fasi successive del processo.',
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Zap,
@@ -141,11 +141,11 @@ const content = {
     vision: {
       badge: 'EVOLUZIONE 2026',
       title: 'Da graduate program a Talent Acquisition strategy',
-      intro: 'Quando il Progetto GRAPE ha dimostrato che grazie al supporto di Skillvue era possibile gestire anche alti volumi di candidature in tempi ridotti con un\'esperienza candidato positiva, si è subito cominciato a ragionare sugli step successivi.',
-      objective: 'Estendere il pre-screening AI a tutti i processi di Talent Acquisition di Mediaset, in un gruppo che sta crescendo vertiginosamente in sei paesi con la sfida strutturale di attrarre competenze digitali in un mercato del lavoro in contrazione demografica.',
+      intro: 'Quando il Progetto GRAPE ha dimostrato che grazie al supporto di Skillvue era possibile gestire anche alti volumi di candidature in tempi ridotti con un\'esperienza candidato positiva, il passo successivo è diventato quasi naturale.',
+      objective: 'Estendere il pre-screening AI ai processi di Talent Acquisition di Mediaset, in un gruppo che sta crescendo vertiginosamente in sei paesi con la sfida strutturale di attrarre competenze digitali in un mercato del lavoro in contrazione demografica.',
       bullets: [
         'Mediaset ha già esteso Skillvue alla selezione di un Junior HR Business Partner per la sede centrale (1.500+ candidature)',
-        'Obiettivo 2026: estendere il pre-screening AI a tutti i processi di Talent Acquisition',
+        'Obiettivo 2026: estendere il pre-screening AI ai processi di Talent Acquisition',
         'In un gruppo che sta crescendo su 6 paesi, identificare talento su scala non è un nice-to-have: è la base per costruire una forza lavoro a prova di futuro',
       ],
     },
@@ -164,13 +164,13 @@ const content = {
     breadcrumb: 'Customers',
     badge: 'CUSTOMER STORY',
     headline: {
-      before: 'How to select and grow talent at scale in a group that is ',
+      before: 'How to select and develop talent at scale in a group that is ',
       highlight1: 'tripling',
       middle: ' ',
       highlight2: 'in size',
       after: '',
     },
-    subtitle: 'With Skillvue, Mediaset turned 3,000 applications into 15 targeted hires of graduates and junior profiles in just 5 weeks. Soft skills became the first selection filter, and their objectification gave the HR team structured data on every person — useful for supporting their professional growth within a rapidly expanding organisation.',
+    subtitle: 'With Skillvue, Mediaset turned 3,000 applications into 15 targeted hires of graduates and junior profiles in just 5 weeks. Soft skills became the first hiring filter, and their objectification gave the HR team structured data on every person to support their professional growth within a rapidly expanding organisation.',
     heroMetrics: [
       { value: '3,000+', label: 'applications processed' },
       { value: '5 weeks', label: 'end-to-end management' },
@@ -190,9 +190,9 @@ const content = {
     },
     context: {
       badge: 'CONTEXT',
-      title: 'The Project Context',
+      title: 'The Company and The Context',
       paragraph: <>
-        Mediaset, part of the <strong className="text-[#1A1A2E]/80 font-semibold">MFE – MediaForEurope</strong> group, is Italy's leading private commercial broadcaster and is undergoing an unprecedented phase of evolution: with the acquisition of ProSiebenSat.1 and a stake in Impresa, MFE has become the first private free-to-air broadcaster to control operations across three major European markets, reaching <strong className="text-[#1A1A2E]/80 font-semibold">over 220 million people in six countries</strong>. The organisational leap is enormous: the workforce is growing from around <strong className="text-[#1A1A2E]/80 font-semibold">5,200 to over 12,000 people</strong>. It is in this context that <strong className="text-[#1A1A2E]/80 font-semibold">Progetto GRAPE</strong> (Graduate Program) was born: a selection programme for interns and junior profiles to be placed across various departments at Mediaset's Cologno Monzese headquarters. In a scenario of unprecedented expansion, the ability to identify and attract talent — especially high-potential junior profiles — becomes an indispensable strategic lever.
+        Mediaset, part of the <strong className="text-[#1A1A2E]/80 font-semibold">MFE – MediaForEurope</strong> group, is Italy's leading private commercial broadcaster and is undergoing an unprecedented phase of evolution: with the acquisition of ProSiebenSat.1 and a stake in Impresa, MFE has become the first private free-to-air broadcaster to control operations across three major European markets, reaching <strong className="text-[#1A1A2E]/80 font-semibold">over 220 million people in six countries</strong>. The organisational leap is enormous: the workforce is growing from around <strong className="text-[#1A1A2E]/80 font-semibold">5,200 to over 12,000 people</strong>. It is in this context that <strong className="text-[#1A1A2E]/80 font-semibold">Progetto GRAPE</strong> (Graduate Program) was born: a hiring programme for interns and junior profiles to be placed across various departments at Mediaset's Cologno Monzese headquarters. In a scenario of unprecedented expansion, <strong className="text-[#1A1A2E]/80 font-semibold">the ability to identify and attract talent</strong> — especially high-potential junior profiles — becomes an indispensable strategic lever.
       </>,
     },
     challenge: {
@@ -200,7 +200,7 @@ const content = {
       title: 'Thousands of candidates, a small HR team and CVs that all look the same.',
       intro: 'Progetto GRAPE generated over 3,000 applications. The dedicated HR team (1 manager + 2 operatives) set a target of 80 qualified candidates per week to advance to the next stages of the process.',
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Zap,
@@ -210,7 +210,7 @@ const content = {
         {
           icon: Shield,
           title: 'The first brand touchpoint had to be worthy of Mediaset',
-          text: 'Mediaset is one of Italy\'s most recognisable brands and competes with tech companies and digital platforms for the same profiles. The smoothness of the selection process cannot be underestimated.',
+          text: 'Mediaset is one of Italy\'s most recognisable brands and competes with tech companies and digital platforms for the same profiles. The smoothness of the hiring process cannot be underestimated.',
         },
       ],
       hrChallenges: [
@@ -222,24 +222,24 @@ const content = {
         {
           icon: Layers,
           title: 'A model integrable into a multi-phase ecosystem was needed',
-          text: 'From pre-screening to individual interviews to on-site group assessments. The initial evaluation tool had to produce auditable, comparable outputs usable in the subsequent stages.',
+          text: 'From pre-screening to individual interviews to on-site group assessments. The initial evaluation tool had to produce auditable, comparable outputs to be used in the subsequent stages.',
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'What Needed to Change',
+      title: 'What needed to change',
       items: [
-        { icon: Zap, text: <><strong>Manage application volumes within business timelines</strong> — 80 high-potential candidates pre-screened per week to keep the selection process moving at pace</> },
-        { icon: Eye, text: <><strong>Make soft skills visible from the first step</strong> — create a ranking based on real competencies, producing objective data validated against the Mediaset model</> },
-        { icon: Shield, text: <><strong>Ensure a candidate experience worthy of the brand</strong> — first contact with Mediaset positive, intuitive and accessible even for those who have never used this format</> },
-        { icon: Layers, text: <><strong>Integrate the tool into the existing process</strong> — outputs compatible with the multi-phase flow and usable as a benchmark for future development of the tool</> },
+        { icon: Zap, text: <><strong>Manage application volumes within business timelines</strong> — 80 high-potential candidates pre-screened per week to keep the hiring process moving at pace</> },
+        { icon: Eye, text: <><strong>Make soft skills visible from the first step</strong> — create a ranking based on real skills, producing objective data validated against the Mediaset model</> },
+        { icon: Shield, text: <><strong>Ensure a candidate experience worthy of the brand</strong> — first touchpoint with Mediaset had to be positive, intuitive and accessible even for those who have never tried this assessment format</> },
+        { icon: Layers, text: <><strong>Integrate the tool into the existing process</strong> — outputs compatible with the multi-phase flow and to be used as a benchmark for future development of the tool</> },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI Pre-screening with Skillvue',
-      intro: "Skillvue was integrated as the first filter of Progetto GRAPE, combining soft skills, logic tests and knowledge questions. The ranking is validated by the HR team on Mediaset\u2019s competency model; suitable profiles advance to the next stages.",
+      intro: "Skillvue was integrated as the first filter of Progetto GRAPE, combining soft skills, logic tests and knowledge questions. The ranking is validated by the HR team on Mediaset\u2019s leadership model; suitable profiles advance to the next stages.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
         { icon: CheckCircle, label: 'Soft skills — calibrated to Mediaset model' },
@@ -254,7 +254,7 @@ const content = {
         },
         {
           title: 'Ranking validated against the Mediaset model',
-          text: "The ranking is reviewed and integrated with Mediaset's competency model. AI supports, the recruiter decides.",
+          text: "The ranking is reviewed and integrated with Mediaset's leadership model. AI supports, the recruiter decides.",
         },
         {
           title: 'Integrated into a multi-phase process',
@@ -274,17 +274,17 @@ const content = {
       qualitative: [
         { icon: Eye, title: 'For the first time, Mediaset has visibility into its skills database', text: 'Before Skillvue, decisions based on individual subjective assessment remained personal knowledge. Now the team works with shared, standardised parameters.' },
         { icon: Target, title: 'Qualified shortlists, with immediate resource savings', text: 'Individual interviews started from a solid information base, not a blank page. A more efficient funnel and more informed decisions at every step.' },
-        { icon: Users, title: 'Human-in-the-loop, always', text: 'The ranking produced by Skillvue was reviewed and validated by the Mediaset HR team against the company competency model. AI produced the data; people made the decisions.' },
+        { icon: Users, title: 'Human-in-the-loop, always', text: 'The ranking produced by Skillvue was reviewed and validated by the Mediaset HR team against the company leadership model. AI produced the data; people made the decisions.' },
       ],
     },
     vision: {
       badge: 'EVOLUTION 2026',
       title: 'From graduate program to Talent Acquisition strategy',
-      intro: 'Once Progetto GRAPE demonstrated that Skillvue could handle high application volumes in compressed timelines with a positive candidate experience, the next steps became obvious.',
-      objective: 'Extend AI pre-screening to all Mediaset Talent Acquisition processes — in a group growing rapidly across six countries, with the structural challenge of attracting digital talent in a demographically contracting labour market.',
+      intro: 'Once Progetto GRAPE demonstrated that Skillvue could handle high application volumes in compressed timelines with a positive candidate experience, the next step became quite natural.',
+      objective: 'Extend AI pre-screening to Mediaset Talent Acquisition processes — in a group growing rapidly across six countries, with the structural challenge of attracting digital talent in a demographically contracting labour market.',
       bullets: [
-        'Mediaset has already extended Skillvue to a Junior HR Business Partner selection at HQ (1,500+ applications)',
-        '2026 target: extend AI pre-screening to all Talent Acquisition processes',
+        'Mediaset has already extended Skillvue to a Junior HR Business Partner hire at HQ (1,500+ applications)',
+        '2026 target: extend AI pre-screening to Talent Acquisition processes',
         'In a group expanding across 6 countries, identifying talent at scale is not a nice-to-have — it is the foundation for building a future-proof workforce',
       ],
     },
@@ -485,7 +485,7 @@ export default function MediasetStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.results.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.results.subtitle}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.results.subtitle}</p>
 
               {/* Key metrics */}
               <div className="rounded-2xl bg-[#111128] p-10 lg:p-14 mb-10">
@@ -553,7 +553,7 @@ export default function MediasetStoryPage() {
                   {c.vision.badge}
                 </span>
                 <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4 leading-[1.3]">{c.vision.title}</h2>
-                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8 max-w-3xl">{c.vision.intro}</p>
+                <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-8">{c.vision.intro}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>
                     <Target className="h-5 w-5" style={{ color: '#4b4df7' }} />

--- a/pages/customers/subdued.tsx
+++ b/pages/customers/subdued.tsx
@@ -35,7 +35,7 @@ const content = {
     heroMetrics: [
       { value: '-40%', label: 'Time-to-hire' },
       { value: '-50%', label: 'Turnover' },
-      { value: '80%', label: 'Candidati qualificati al 2° step' },
+      { value: '80%', label: 'Candidati qualificati dopo lo skills screening' },
     ],
     ctaPrimary: 'Contattaci',
     ctaSecondary: 'Scopri di più',
@@ -53,9 +53,11 @@ const content = {
       badge: 'CONTESTO',
       title: 'Il contesto del progetto',
       paragraph: <>
-        Subdued è un brand italiano di fashion retail. Fondato in Italia, oggi opera con oltre <strong className="text-[#1A1A2E]/80 font-semibold">130 negozi monomarca</strong> in continua espansione, <strong className="text-[#1A1A2E]/80 font-semibold">più di 1.000 dipendenti</strong> e una presenza in crescita su più continenti — inclusi USA, Medio Oriente, Sud-Est asiatico, Corea e Cina.
+        Subdued è un brand italiano di fashion retail. Fondato in Italia, oggi opera con oltre <strong className="text-[#1A1A2E]/80 font-semibold">130 negozi monomarca</strong> in continua espansione, <strong className="text-[#1A1A2E]/80 font-semibold">più di 1.000 dipendenti</strong> e una presenza in crescita su più continenti.
         <br /><br />
-        In questo scenario, la capacità di selezionare le persone giuste al ritmo delle aperture diventa il vincolo operativo numero uno. Ogni nuovo negozio richiede un team capace di rappresentare il brand e il suo DNA italiano davanti a un pubblico Gen Z in mercati culturalmente diversi, ma il team HR è composto da <strong className="text-[#1A1A2E]/80 font-semibold">1-3 persone per ciascuno dei paesi di attività</strong>. Con i metodi tradizionali, l'equazione non regge.
+        La traiettoria di crescita è eccezionale: il fatturato del brand è <strong className="text-[#1A1A2E]/80 font-semibold">quasi raddoppiato tra il 2022 e il 2024</strong> e più della metà dei ricavi arriva dai mercati internazionali, che danno ottimi segnali per il futuro con aperture in corso negli Stati Uniti, in Medio Oriente, nel Sud-Est asiatico, in Corea e in Cina.
+        <br /><br />
+        In questo scenario, la capacità di selezionare le persone giuste al ritmo delle aperture diventa <strong className="text-[#1A1A2E]/80 font-semibold">il vincolo operativo numero uno</strong>. Ogni nuovo negozio richiede un team formato capace di rappresentare il brand e il suo DNA italiano davanti a un pubblico Gen Z in mercati culturalmente diversi, ma il team HR è composto da <strong className="text-[#1A1A2E]/80 font-semibold">1-3 persone per ciascuno dei paesi di attività</strong>. Con i metodi tradizionali, l'equazione non regge.
       </>,
     },
     challenge: {
@@ -63,7 +65,7 @@ const content = {
       title: 'Il problema strutturale',
       intro: 'Tante figure chiave da selezionare, turnover alto e un team HR snello che non poteva scalare con l\'espansione senza un sistema strutturato.',
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Eye,
@@ -128,10 +130,10 @@ const content = {
     results: {
       badge: 'RISULTATI',
       title: 'Key Metrics & Impatto',
-      subtitle: 'I risultati misurabili ottenuti da Subdued attraverso l\'adozione di Skillvue nei processi di selezione su 6 paesi.',
+      subtitle: 'I risultati misurabili ottenuti da Subdued attraverso l\'adozione di Skillvue nei processi di selezione.',
       metrics: [
         { value: '-70%', label: 'Ore di pre-screening' },
-        { value: '80%', label: 'Candidati qualificati al 2° step' },
+        { value: '80%', label: 'Candidati qualificati dopo lo skills screening' },
         { value: '-50%', label: 'Turnover' },
       ],
       qualitative: [
@@ -156,16 +158,16 @@ const content = {
     badge: 'CUSTOMER STORY',
     headline: {
       before: 'Subdued: building a ',
-      highlight1: 'single scalable selection standard',
+      highlight1: 'single scalable hiring standard',
       middle: ' for a network of ',
       highlight2: '130+ stores',
       after: '',
     },
-    subtitle: 'With Skillvue, Subdued built a consistent, scalable evaluation process across multiple markets — allowing a lean HR team to apply the same selection rigour in every country while halving turnover.',
+    subtitle: 'With Skillvue, Subdued built a consistent, scalable evaluation process across multiple markets, allowing a lean HR team to apply the same hiring rigour in every country while halving turnover.',
     heroMetrics: [
       { value: '-40%', label: 'Time-to-hire' },
       { value: '-50%', label: 'Turnover' },
-      { value: '80%', label: 'Qualified candidates at 2nd step' },
+      { value: '80%', label: 'Qualified candidates after skills screening' },
     ],
     ctaPrimary: 'Contact Us',
     ctaSecondary: 'Learn More',
@@ -181,11 +183,13 @@ const content = {
     },
     context: {
       badge: 'CONTEXT',
-      title: 'The Project Context',
+      title: 'The Company and The Context',
       paragraph: <>
-        Subdued is an Italian fashion retail brand. Founded in Italy, it now operates over <strong className="text-[#1A1A2E]/80 font-semibold">130 mono-brand stores</strong> in continuous expansion, <strong className="text-[#1A1A2E]/80 font-semibold">1,000+ employees</strong> and a growing presence across multiple continents — including the US, Middle East, South-East Asia, Korea and China.
+        Subdued is an Italian fashion retail brand. Founded in Italy, it now operates over <strong className="text-[#1A1A2E]/80 font-semibold">130 mono-brand stores</strong> in continuous expansion, <strong className="text-[#1A1A2E]/80 font-semibold">1,000+ employees</strong> and a growing presence across multiple continents.
         <br /><br />
-        In this context, the ability to hire the right people at the pace of new store openings becomes the number one operational constraint. Every new store requires a team capable of representing the brand and its Italian DNA to a Gen Z audience in culturally different markets — yet each country's HR team is just <strong className="text-[#1A1A2E]/80 font-semibold">1–3 people</strong>. With traditional methods, the equation simply does not work.
+        The growth trajectory is exceptional: the brand's revenue <strong className="text-[#1A1A2E]/80 font-semibold">nearly doubled between 2022 and 2024</strong>, and more than half of revenues come from international markets — which are showing strong signals for the future, with openings underway in the United States, the Middle East, South-East Asia, Korea and China.
+        <br /><br />
+        In this context, the ability to hire the right people at the pace of new store openings becomes <strong className="text-[#1A1A2E]/80 font-semibold">the number one operational constraint</strong>. Every new store requires a trained team capable of representing the brand and its Italian DNA to a Gen Z audience in culturally different markets — yet each country's HR team is just <strong className="text-[#1A1A2E]/80 font-semibold">1–3 people</strong>. With traditional methods, the equation simply does not work.
       </>,
     },
     challenge: {
@@ -193,7 +197,7 @@ const content = {
       title: 'The Structural Problem',
       intro: 'Key store roles to fill, structurally high turnover, and a lean HR team that could not scale with global expansion without a structured system.',
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Eye,
@@ -221,9 +225,9 @@ const content = {
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: 'What Needed to Change',
+      title: 'What needed to change',
       items: [
-        { icon: Zap, text: 'Make invisible competencies visible: assess communication, selling and teamworking before the interview, with objective data on every candidate' },
+        { icon: Zap, text: 'Make invisible skills visible: assess communication, selling and teamworking before the interview, with objective data on every candidate' },
         { icon: Target, text: 'Free the team from operational work: reduce screening hours to recover time for strategic activities, employer branding and development' },
         { icon: Layers, text: 'Create a cross-country standard: the same evaluation criteria across all markets, adapted by language and role, without multiplying HR resources' },
         { icon: Heart, text: 'Scale at the pace of expansion: a hiring infrastructure that supports every new store opening without adding pressure to the HR team' },
@@ -251,21 +255,21 @@ const content = {
         },
         {
           title: 'Skillvue generates a detailed report',
-          text: 'Score per competency, overall fit, strengths, and development areas — used by HR to guide the in-person interview.',
+          text: 'Score per skill, overall fit, strengths, and development areas — used by HR to guide the in-person interview.',
         },
       ],
     },
     results: {
       badge: 'RESULTS',
       title: 'Key Metrics & Impact',
-      subtitle: 'The measurable outcomes Subdued achieved through Skillvue across its hiring processes in 6 countries.',
+      subtitle: 'The measurable outcomes Subdued achieved through Skillvue across its hiring processes.',
       metrics: [
         { value: '-70%', label: 'Pre-screening hours' },
-        { value: '80%', label: 'Qualified candidates at 2nd step' },
+        { value: '80%', label: 'Qualified candidates after skills screening' },
         { value: '-50%', label: 'Turnover' },
       ],
       qualitative: [
-        { icon: Heart, title: 'The unexpected employer branding effect', text: 'The result no one anticipated: the innovative selection process itself became an attraction asset — a concrete competitive advantage in the retail labour market.' },
+        { icon: Heart, title: 'The unexpected employer branding effect', text: 'The result no one anticipated: the innovative hiring process itself became an attraction asset — a concrete competitive advantage in the retail labour market.' },
         { icon: Users, title: 'Human-in-the-loop, always', text: 'The first in-person interview is now more focused and personalised, grounded in report data. The recruiter arrives prepared. The candidate feels heard. The human connection is preserved.' },
         { icon: Layers, title: 'Cross-country expansion of the project', text: 'HR teams in the UK, Netherlands, Belgium, and France are now applying the same methodology to achieve the same results: greater speed and scalability, higher hiring quality, and satisfied candidates.' },
       ],
@@ -273,7 +277,7 @@ const content = {
     related: {
       title: 'Related Stories',
       stories: [
-        { id: 'carrefour', company: 'Carrefour', tag: 'Retail GDO · Hiring', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
+        { id: 'carrefour', company: 'Carrefour', tag: 'Retail · Hiring', headline: 'Carrefour: how to protect margins across 1,200 stores by optimising the key hiring KPI' },
         { id: 'europ-assistance', company: 'Europ Assistance', tag: 'Insurance · Hiring at Scale', headline: 'How to achieve a 76% hiring success rate in a business built on human interaction' },
       ],
       cta: 'Read the story',
@@ -467,7 +471,7 @@ export default function SubduedStoryPage() {
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
               <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-[#1A1A2E] leading-[1.4] mb-4">{c.results.title}</h2>
-              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12 max-w-3xl">{c.results.subtitle}</p>
+              <p className="text-[16px] text-[#1A1A2E]/[0.65] leading-[1.8] mb-12">{c.results.subtitle}</p>
 
               <div className="rounded-2xl bg-[#111128] p-10 lg:p-14 mb-10">
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 max-w-3xl mx-auto">

--- a/pages/customers/unicomm.tsx
+++ b/pages/customers/unicomm.tsx
@@ -33,7 +33,7 @@ const content = {
     },
     subtitle: "Con Skillvue, Unicomm sta trasformando un'infrastruttura HR ancora poco digitalizzata in un sistema skills-based agile e capace di rispondere con efficacia alle necessità di selezione, conferme e sviluppo interno su tutta la rete.",
     heroMetrics: [
-      { value: '3', label: 'Filoni attivati in parallelo (hiring, conferme, sviluppo)' },
+      { value: '3', label: 'Filoni attivati in parallelo' },
       { value: '4', label: "Livelli di ruolo coperti, dall'addetto vendita al gerente" },
       { value: 'End-to-end', label: 'Talent lifecycle su 7 insegne e 7 regioni' },
     ],
@@ -62,7 +62,7 @@ const content = {
       title: 'Non bastava ottimizzare: serviva costruire dalle fondamenta.',
       intro: "Unicomm partiva da una infrastruttura HR ancora poco digitalizzata, e lo faceva nel momento di crescita più intensa della propria storia.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Layers,
@@ -90,7 +90,7 @@ const content = {
     },
     objectives: {
       badge: 'OBIETTIVI DI COLLABORAZIONE',
-      title: "Costruire l'infrastruttura di talento che la crescita richiede.",
+      title: 'Cosa doveva cambiare',
       items: [
         { icon: Scale, text: "Standardizzare le valutazioni su tutta la rete: stessi criteri, stesso framework di competenze, indipendentemente dall'insegna, dal punto vendita o dal singolo responsabile" },
         { icon: CheckCircle, text: "Adottare un approccio skills-based completo: valutazioni calibrate per obiettivo (hiring, conferma, sviluppo) e per ruolo/reparto, con un mix di soft e hard skill" },
@@ -156,12 +156,12 @@ const content = {
       before: 'How Unicomm is building a new ',
       highlight1: 'talent management system',
       middle: ' across a network of ',
-      highlight2: '270 stores',
-      after: ' and growing',
+      highlight2: '270+ stores',
+      after: '',
     },
-    subtitle: "With Skillvue, Unicomm is transforming a barely-digitized HR infrastructure into an agile, skills-based system capable of effectively responding to the needs of hiring, confirmations and internal development across its entire network.",
+    subtitle: "With Skillvue, Unicomm is transforming a scarcely-digitized HR infrastructure into an agile, skills-based system capable of effectively responding to the needs of hiring, confirmations and internal development across its entire network.",
     heroMetrics: [
-      { value: '3', label: 'Streams activated in parallel (hiring, confirmations, development)' },
+      { value: '3', label: 'Streams activated in parallel' },
       { value: '4', label: 'Role levels covered, from sales associate to store manager' },
       { value: 'End-to-end', label: 'Talent lifecycle across 7 brands and 7 regions' },
     ],
@@ -170,7 +170,7 @@ const content = {
     clientCard: {
       label: 'CLIENT PROFILE',
       facts: [
-        { label: 'Industry', value: 'GDO' },
+        { label: 'Industry', value: 'Large-scale distribution' },
         { label: 'Group', value: 'Unicomm Group' },
         { label: 'Revenue', value: '~€2B' },
         { label: 'Employees', value: '8,000+' },
@@ -182,15 +182,15 @@ const content = {
       badge: 'CONTEXT',
       title: 'A group that doubles revenue in three years needs people ready at the same speed.',
       paragraph: <>
-        <strong className="text-[#1A1A2E]/80 font-semibold">Gruppo Unicomm</strong>, part of <strong className="text-[#1A1A2E]/80 font-semibold">Selex Gruppo Commerciale</strong>, is one of Italy's leading <strong className="text-[#1A1A2E]/80 font-semibold">organized grocery retail</strong> groups. Over the past 3 years, the group has recorded <strong className="text-[#1A1A2E]/80 font-semibold">growth nearly double the sector average</strong>, with a declared objective to continue — through new store openings, strategic integration with <strong className="text-[#1A1A2E]/80 font-semibold">Etruria Retail</strong>, and new logistics infrastructure. In this context of accelerated expansion, the ability to hire, confirm and develop the right people becomes a priority for both HR and the business — especially given that in Italy's grocery retail labor market, <strong className="text-[#1A1A2E]/80 font-semibold">50% of positions</strong> are classified as "hard to fill" and a store manager requires an average of <strong className="text-[#1A1A2E]/80 font-semibold">90-120 days</strong> to recruit.
+        <strong className="text-[#1A1A2E]/80 font-semibold">Gruppo Unicomm</strong>, part of <strong className="text-[#1A1A2E]/80 font-semibold">Selex Gruppo Commerciale</strong>, is one of Italy's leading <strong className="text-[#1A1A2E]/80 font-semibold">organized grocery retail</strong> groups. Over the past 3 years, the group has recorded <strong className="text-[#1A1A2E]/80 font-semibold">growth nearly double the sector average</strong>, with a declared objective to continue — through new store openings, strategic integration with <strong className="text-[#1A1A2E]/80 font-semibold">Etruria Retail</strong>, and new logistics infrastructure. In this context of accelerated expansion, the ability to hire, confirm and develop the right people becomes a priority for both HR and the business, especially given that in Italy's grocery retail labor market, <strong className="text-[#1A1A2E]/80 font-semibold">50% of positions</strong> are classified as "hard to fill" and a store manager requires an average of <strong className="text-[#1A1A2E]/80 font-semibold">90-120 days</strong> to recruit.
       </>,
     },
     challenge: {
       badge: 'THE CHALLENGE',
       title: 'Optimization was not enough: they needed to build from scratch.',
-      intro: "Unicomm was starting from a barely-digitized HR infrastructure, and doing so at the most intense growth phase in its history.",
+      intro: "Unicomm was starting from a scarcely-digitized HR infrastructure, and doing so at the most intense growth phase in its history.",
       businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR REALITY',
+      hrLabel: 'HR & PEOPLE IMPACT',
       businessChallenges: [
         {
           icon: Layers,
@@ -212,27 +212,27 @@ const content = {
         {
           icon: Heart,
           title: 'Change management with no digital precedents',
-          text: "Introducing digital assessments into an organization that had never used HR technology meant driving a deep transformation at every level of the organization.",
+          text: "Introducing digital assessments into an organization that had never used HR technology meant driving a deep transformation at every level of the organization: quite a big challenge to take on for a small HR team.",
         },
       ],
     },
     objectives: {
       badge: 'COLLABORATION OBJECTIVES',
-      title: "Build the talent infrastructure that growth requires.",
+      title: 'What needed to change',
       items: [
-        { icon: Scale, text: "Standardize assessments across the entire network: same criteria, same competency framework, regardless of brand, store or individual manager" },
+        { icon: Scale, text: "Standardize assessments across the entire network: same criteria, same skills framework, regardless of brand, store or individual manager" },
         { icon: CheckCircle, text: "Adopt a complete skills-based approach: assessments calibrated by objective (hiring, confirmation, development) and by role/department, with a mix of soft and hard skills" },
-        { icon: Wrench, text: "Build sector-specific assessment capabilities: develop bespoke assessments where the Unicomm model required it" },
+        { icon: Wrench, text: "Build sector-specific assessment capabilities: develop selected assessments where the Unicomm model required it" },
         { icon: Users, text: "Lead real change management: transform the organization's HR culture, not just introduce a tool" },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
       title: 'AI assessment across three parallel streams, calibrated on the Unicomm model.',
-      intro: "Skillvue was integrated as a partner for building Unicomm's talent lifecycle, working with the HR team led by Giuseppe Curci to align the platform to the company's competency model and the specifics of grocery retail.",
+      intro: "Skillvue was integrated as a partner for building Unicomm's talent lifecycle, working with the HR team led by Giuseppe Curci to align the platform to the company's leadership model and the specifics of grocery retail.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
-        { icon: Wrench, label: 'Grocery retail technical competencies — differentiated by department and level of responsibility (client-facing or not, from sales associate to store manager)' },
+        { icon: Wrench, label: 'Grocery retail technical skills — differentiated by department and level of responsibility (client-facing or not, from sales associate to store manager)' },
         { icon: Heart, label: 'Bespoke soft skills — developed ad hoc on the Unicomm model (e.g. service orientation in grocery retail contexts, team management across shifts)' },
       ],
       methodologyLabel: 'PROJECT STRUCTURE — THREE PARALLEL STREAMS',
@@ -247,7 +247,7 @@ const content = {
         },
         {
           title: 'Development',
-          text: "Two annual milestones for progression to department head or store manager, through an internal Academy based on objective competency data.",
+          text: "Two annual milestones for progression to department head or store manager, through an internal Academy based on objective skills data.",
         },
       ],
     },
@@ -261,7 +261,7 @@ const content = {
       ],
       qualitative: [
         { icon: TrendingUp, title: "From zero to integrated system", text: "Unicomm has gone from the complete absence of digital HR tools to a structured talent lifecycle covering hiring, confirmations and development in a single system. Not an incremental optimization, but a paradigm shift achieved during the most intense growth phase of the Group." },
-        { icon: Wrench, title: "Grocery retail competencies now measurable", text: "Sector-specific soft skills are now assessed with tools calibrated to the Unicomm model, not generic assessments. Measuring these competencies is a business lever, not just an HR exercise." },
+        { icon: Wrench, title: "Industry-relevant skills now measurable", text: "Sector-specific soft skills are now assessed with tools calibrated to the Unicomm model, not generic assessments. Measuring these skills is a business lever, not just an HR exercise." },
         { icon: BarChart3, title: "Decisions based on data, not impressions", text: "Assessments produce structured information that supports managerial decisions without replacing them. Managers decide with more data, and this raises the quality of the decision." },
         { icon: Users, title: "An ongoing change management journey", text: "The cultural transformation is still underway, but the foundations are solid: the system is live, the three streams are advancing in parallel, and the organization is building familiarity with a skills-based approach that did not exist before." },
       ],
@@ -269,7 +269,7 @@ const content = {
     related: {
       title: 'Related Stories',
       stories: [
-        { id: 'ins-mercato', company: "In's Mercato", tag: "Retail GDO · Internal Mobility", headline: "How In's Mercato built an internal pipeline of Store Managers" },
+        { id: 'ins-mercato', company: "In's Mercato", tag: "Large-scale distribution · Internal Mobility", headline: "How In's Mercato built an internal pipeline of Store Managers" },
         { id: 'adr', company: 'Aeroporti di Roma', tag: 'Aviation · Internal Development', headline: 'Aeroporti di Roma: how to develop an organisation of nearly 5,000 people to execute a €9 billion plan.' },
       ],
       cta: 'Read the story',


### PR DESCRIPTION
- Replace selection/competency/GDO with hiring/skills/large-scale distribution throughout
- Standardise section titles: 'The Company and The Context', 'What needed to change', 'HR & PEOPLE IMPACT'
- Remove max-w-3xl constraints from paragraph text elements
- Update context sections with richer business framing (Subdued, In's Mercato)
- Apply copy edits and tone refinements per page (Carrefour, Subdued, Mediaset, Europ Assistance, Unicomm, Eataly, Credem, ADR, Douglas, In's Mercato)
- Fix unicode escape sequences rendering as literal text in Douglas context section