### PR TITLE
Mobile responsive overhaul + hero product video

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -93,7 +93,7 @@ export default function Footer() {
               })}
             </div>
 
-            <p className="text-[10px] md:text-[11px] text-white/25 leading-[1.5] text-center lg:text-left max-w-[180px]">
+            <p className="text-[12px] md:text-[11px] text-white/25 leading-[1.5] text-center lg:text-left max-w-[180px]">
               {lang === 'it'
                 ? "Partner della ricerca 2025/2026 dell'Osservatorio HR del Politecnico di Milano"
                 : 'Partner of the 2025/2026 research of Osservatorio HR Politecnico di Milano'}
@@ -104,7 +104,7 @@ export default function Footer() {
           <div className="flex flex-col gap-6 md:grid md:grid-cols-4 md:gap-8">
             {footerLinks.map((group) => (
               <div key={group.title}>
-                <h4 className="text-[13px] md:text-[16px] font-semibold text-white/85 mb-2 md:mb-7">
+                <h4 className="text-[15px] md:text-[16px] font-semibold text-white/85 mb-2 md:mb-7">
                   {lang === 'it' ? group.titleIt : group.title}
                 </h4>
                 <div className="flex flex-wrap gap-x-4 gap-y-1.5 md:block md:space-y-4">
@@ -116,7 +116,7 @@ export default function Footer() {
                         key={link.name}
                         href={href}
                         onClick={handleClick(href)}
-                        className="text-[12px] md:text-[15px] text-white/35 hover:text-white/65 transition-colors duration-300"
+                        className="inline md:block text-[14px] md:text-[15px] text-white/35 hover:text-white/65 transition-colors duration-300"
                       >
                         {name}
                       </a>
@@ -130,7 +130,7 @@ export default function Footer() {
 
         {/* Bottom bar */}
         <div className="border-t border-white/[0.04] pt-6 md:pt-8 flex flex-col sm:flex-row items-center justify-between gap-3 md:gap-4">
-          <span className="text-[11px] md:text-[13px] text-white/20">
+          <span className="text-[12px] md:text-[13px] text-white/20">
             &copy; {new Date().getFullYear()} Skillvue. {t('All rights reserved.')}
           </span>
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 md:gap-6">
@@ -157,11 +157,11 @@ export default function Footer() {
               },
             ].map(({ label, href }) => (
               href.startsWith('http') ? (
-                <a key={label} href={href} target="_blank" rel="noopener noreferrer" className="text-[10px] md:text-[13px] text-white/20 hover:text-white/40 transition-colors duration-300">
+                <a key={label} href={href} target="_blank" rel="noopener noreferrer" className="text-[12px] md:text-[13px] text-white/20 hover:text-white/40 transition-colors duration-300">
                   {label}
                 </a>
               ) : (
-                <a key={label} href={href} onClick={handleClick(href)} className="text-[10px] md:text-[13px] text-white/20 hover:text-white/40 transition-colors duration-300">
+                <a key={label} href={href} onClick={handleClick(href)} className="text-[12px] md:text-[13px] text-white/20 hover:text-white/40 transition-colors duration-300">
                   {label}
                 </a>
               )
@@ -171,7 +171,7 @@ export default function Footer() {
 
         {/* Company info line */}
         <div className="border-t border-white/[0.04] pt-4 mt-6">
-          <p className="text-[11px] text-white/20 text-center">
+          <p className="text-[12px] text-white/20 text-center">
             Algojob S.r.l. — Via Molino delle Armi 11, 20123 Milano — P.IVA 11656370969 — REA MI-2617568
           </p>
         </div>

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -41,14 +41,14 @@ export default function CTASection() {
               <h3 className="text-[20px] md:text-[clamp(1.8rem,3vw,2.5rem)] font-bold text-white/85 mt-3 md:mt-5 mb-2 md:mb-4 leading-tight">
                 {t('Book a 30-min Demo')}
               </h3>
-              <p className="text-[12px] md:text-[17px] text-white/[0.65] mb-0 md:mb-8 max-w-md leading-[1.5] md:leading-normal">
+              <p className="text-[14px] md:text-[17px] text-white/[0.65] mb-0 md:mb-8 max-w-md leading-[1.5] md:leading-normal">
                 {t('See Skillvue live with your specific use case')}
               </p>
             </div>
             <a
               href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'}
               data-testid="cta-book-demo"
-              className="relative group/btn inline-flex items-center justify-between w-full px-5 py-3 md:px-8 md:py-5 md:max-w-sm text-[12px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500"
+              className="relative group/btn inline-flex items-center justify-between w-full px-5 py-3 md:px-8 md:py-5 md:max-w-sm text-[14px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500"
             >
               <span>{t('Book a Meeting')}</span>
               <ArrowRight className="h-3.5 w-3.5 md:h-4 md:w-4 text-white/30 group-hover/btn:text-[#9B9DFB] group-hover/btn:translate-x-1 transition-all duration-500" />

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -74,7 +74,7 @@ export default function CTASection() {
               ))}
             </div>
             <div className="flex justify-center gap-x-4 md:gap-x-10">
-              {['loropiana_fixed', 'fidia_fixed'].map((logo) => (
+              {['fidia_fixed'].map((logo) => (
                 <div key={logo} className="flex items-center justify-center h-8 md:h-12">
                   <img
                     src={`/logos/${logo}.png`}

--- a/components/landing/CustomerStoriesSection.tsx
+++ b/components/landing/CustomerStoriesSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useRouter } from 'next/router';
@@ -36,6 +36,20 @@ export default function CustomerStoriesSection() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
   const router = useRouter();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="customers" data-testid="customer-stories-section" className="relative py-16 md:py-20 lg:py-28" ref={ref}>
@@ -50,13 +64,13 @@ export default function CustomerStoriesSection() {
           <h2 className="text-[clamp(1.6rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-white/90 mb-3 md:mb-4">
             {t('Proof, not')} <span className="italic font-bold gradient-text">{t('promises.')}</span>
           </h2>
-          <p className="text-[14px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-2xl">
+          <p className="text-[15px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-2xl">
             {t('Leading Global enterprises make talent decisions with confidence.')}
           </p>
         </motion.div>
 
         {/* Story cards — horizontal scroll on mobile, 2-col grid on desktop */}
-        <div className="md:grid md:grid-cols-2 md:gap-5 flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 mb-8 md:mb-10 scrollbar-hide">
+        <div ref={scrollRef} className="md:grid md:grid-cols-2 md:gap-5 flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 mb-8 md:mb-10 scrollbar-hide">
           {stories.map((s, i) => (
             <motion.div
               key={s.company}
@@ -69,20 +83,28 @@ export default function CustomerStoriesSection() {
             >
               {/* Company + industry */}
               <div>
-                <h3 className="text-[16px] md:text-[22px] font-bold text-white/90 mb-1">{t(s.company)}</h3>
-                <span className="text-[11px] md:text-[15px] text-white/40">{t(s.industry)}</span>
+                <h3 className="text-[17px] md:text-[22px] font-bold text-white/90 mb-1">{t(s.company)}</h3>
+                <span className="text-[13px] md:text-[15px] text-white/40">{t(s.industry)}</span>
               </div>
 
               {/* Quote */}
-              <p className="text-[13px] md:text-[17px] text-white/[0.65] italic leading-[1.6] md:leading-[1.7]">"{t(s.quote)}"</p>
+              <p className="text-[14px] md:text-[17px] text-white/[0.65] italic leading-[1.6] md:leading-[1.7]">"{t(s.quote)}"</p>
 
               {/* Author */}
               <div>
-                <span className="text-[12px] md:text-[15px] font-semibold text-white/60">{t(s.author)}</span>
-                <span className="text-[11px] md:text-[14px] text-white/35 ml-1.5 md:ml-2">{t(s.role)}</span>
+                <span className="text-[13px] md:text-[15px] font-semibold text-white/60">{t(s.author)}</span>
+                <span className="text-[13px] md:text-[14px] text-white/35 ml-1.5 md:ml-2">{t(s.role)}</span>
               </div>
             </motion.div>
           ))}
+        </div>
+
+        {/* Progress bar — mobile only */}
+        <div className="md:hidden mx-auto -mt-4 mb-8 w-36 h-1 rounded-full bg-white/10 relative">
+          <div
+            className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
+            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+          />
         </div>
 
         {/* Join CTA */}
@@ -95,14 +117,14 @@ export default function CustomerStoriesSection() {
           <div className="flex flex-col md:flex-row items-start md:items-center gap-3 md:gap-6">
             <button
               onClick={() => { router.push(lang === 'it' ? '/prenota-incontro' : '/book-meeting'); window.scrollTo(0, 0); }}
-              className="group inline-flex items-center justify-between px-6 py-3 md:px-7 md:py-3.5 text-[13px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/[0.12] hover:border-white/[0.25] hover:bg-white/[0.04] transition-all duration-500"
+              className="group inline-flex items-center justify-between px-6 py-3 md:px-7 md:py-3.5 text-[14px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/[0.12] hover:border-white/[0.25] hover:bg-white/[0.04] transition-all duration-500"
             >
               <span>{t('Book a Meeting')}</span>
               <ArrowRight className="h-4 w-4 ml-4 md:ml-6 text-white/30 group-hover:text-white/70 group-hover:translate-x-1 transition-all duration-300" />
             </button>
             <button
               onClick={() => { router.push(lang === 'it' ? '/prenota-incontro' : '/book-meeting'); window.scrollTo(0, 0); }}
-              className="group inline-flex items-center gap-2 md:gap-2.5 text-[12px] md:text-[13px] font-semibold text-white/[0.45] hover:text-white/80 transition-colors duration-300 tracking-wide"
+              className="group inline-flex items-center gap-2 md:gap-2.5 text-[13px] md:text-[13px] font-semibold text-white/[0.45] hover:text-white/80 transition-colors duration-300 tracking-wide"
             >
               {t('Join 50+ Global enterprises')}
               <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-1 transition-transform duration-300" />
@@ -117,15 +139,15 @@ export default function CustomerStoriesSection() {
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.7 }}
         >
-          <h3 className="text-[17px] md:text-[20px] font-bold text-white/90 mb-3 md:mb-4">
+          <h3 className="text-[18px] md:text-[20px] font-bold text-white/90 mb-3 md:mb-4">
             {t('Built')} <span className="italic font-bold gradient-text">{t('enterprise-ready')}</span>
           </h3>
-          <p className="text-[12px] md:text-[15px] text-white/[0.65] leading-[1.6] md:leading-[1.75] mb-4 md:mb-6 max-w-3xl">
+          <p className="text-[14px] md:text-[15px] text-white/[0.65] leading-[1.6] md:leading-[1.75] mb-4 md:mb-6 max-w-3xl">
             {t('100+ native integrations (Oracle, SAP, Workday, Greenhouse + more). Fully customisable to your processes, on your terms.')}
           </p>
           <div className="flex flex-wrap gap-2 md:gap-3">
             {['ISO 27001', 'SOC 2', 'GDPR', 'EU AI Act'].map(b => (
-              <span key={b} className="inline-flex px-3 py-1.5 md:px-4 md:py-2 rounded-full text-[11px] md:text-[12px] font-semibold text-white/[0.65] border border-white/[0.1] bg-white/[0.03] tracking-wide">
+              <span key={b} className="inline-flex px-3 py-1.5 md:px-4 md:py-2 rounded-full text-[12px] md:text-[12px] font-semibold text-white/[0.65] border border-white/[0.1] bg-white/[0.03] tracking-wide">
                 {t(b)}
               </span>
             ))}

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
-import GradientBlinds from '../backgrounds/GradientBlinds';
 import { useLanguage } from '@/i18n/LanguageContext';
 
 const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
@@ -21,65 +20,23 @@ const logoImages: Record<string, string> = {
 
 export default function HeroSection() {
   const { t, lang } = useLanguage();
-  const [isMobile, setIsMobile] = React.useState(false);
-  const [reducedMotion, setReducedMotion] = React.useState(false);
-
-  React.useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    window.addEventListener('resize', check);
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReducedMotion(mq.matches);
-    const onMotionChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
-    mq.addEventListener('change', onMotionChange);
-    return () => {
-      window.removeEventListener('resize', check);
-      mq.removeEventListener('change', onMotionChange);
-    };
-  }, []);
 
   return (
     <section
       id="hero"
       data-testid="hero-section"
       className="relative overflow-hidden flex flex-col justify-between pt-[80px]"
-      style={{ width: '100%', minHeight: '100vh' }}
+      style={{ width: '100%', minHeight: '100vh', background: '#0d0d1f' }}
     >
-      {/* GradientBlinds background — desktop only */}
-      {!isMobile && (
-        <div className="absolute inset-0 z-0">
-          <GradientBlinds
-            dpr={typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1}
-            gradientColors={["#4B4DF7", "#FF5F24", "#FF5F24"]}
-            angle={0}
-            noise={0.8}
-            blindCount={30}
-            blindMinWidth={70}
-            mouseDampening={0.15}
-            mirrorGradient={false}
-            spotlightRadius={0.5}
-            spotlightSoftness={1}
-            spotlightOpacity={1}
-            distortAmount={0}
-            shineDirection="left"
-            mixBlendMode="normal"
-            paused={reducedMotion}
-          />
-        </div>
-      )}
-
-      {/* Mobile: subtle animated gradient */}
-      <div className="absolute inset-0 z-0 md:hidden hero-mobile-gradient" />
-
       {/* Hero content. layered above */}
       <div className="relative z-10 flex-1 flex items-start md:items-center pt-6 md:pt-0">
         <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-10 md:py-16 lg:py-0">
-          <div className="grid lg:grid-cols-12 gap-8 md:gap-12 lg:gap-10 items-center">
+          <div className="grid lg:grid-cols-12 gap-8 md:gap-12 lg:gap-12 items-center">
             {/* LEFT. Big headline */}
-            <div className="lg:col-span-5">
+            <div className="lg:col-span-6">
               <motion.h1
-                className="text-[clamp(2.5rem,10vw,3.75rem)] md:text-[clamp(3rem,6vw,5.5rem)] font-bold tracking-[-0.03em] text-white"
-                style={{ lineHeight: 1.1, textShadow: '0 2px 20px rgba(0,0,0,0.3)' }}
+                className="text-[clamp(2.5rem,10vw,3.75rem)] md:text-[clamp(2.75rem,4.8vw,4.5rem)] font-bold tracking-[-0.025em] text-white"
+                style={{ lineHeight: 1.08, textShadow: '0 2px 20px rgba(0,0,0,0.3)' }}
                 initial={{ opacity: 0, y: 40 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.3 }}
@@ -89,7 +46,7 @@ export default function HeroSection() {
                 {t('backed by science.')}
               </motion.h1>
               <motion.p
-                className="text-[15px] md:text-[18px] text-white/80 leading-[1.65] md:leading-[1.75] mt-5 md:mt-8 max-w-xl font-normal md:font-light"
+                className="text-[15px] md:text-[17px] text-white/75 leading-[1.65] md:leading-[1.65] mt-6 md:mt-8 max-w-lg font-normal md:font-light"
                 style={{ textShadow: '0 1px 8px rgba(0,0,0,0.2)' }}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -99,9 +56,9 @@ export default function HeroSection() {
               </motion.p>
             </div>
 
-            {/* RIGHT. Product video */}
+            {/* RIGHT. Product video — balanced size */}
             <motion.div
-              className="lg:col-span-7"
+              className="lg:col-span-6"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ duration: 0.8, delay: 0.7 }}

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -20,6 +20,50 @@ const logoImages: Record<string, string> = {
 
 export default function HeroSection() {
   const { t, lang } = useLanguage();
+  const [videoPlaying, setVideoPlaying] = React.useState(true);
+  const [videoMuted, setVideoMuted] = React.useState(true);
+  const [videoScale, setVideoScale] = React.useState(1);
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const videoWrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Render iframe at native 1920x1080 then scale down to fit container.
+  // This tricks YouTube into thinking the player is large → serves 1080p+ quality.
+  React.useEffect(() => {
+    const updateScale = () => {
+      const wrapper = videoWrapperRef.current;
+      if (!wrapper) return;
+      const w = wrapper.offsetWidth;
+      setVideoScale(w / 1920);
+    };
+    updateScale();
+    const ro = new ResizeObserver(updateScale);
+    if (videoWrapperRef.current) ro.observe(videoWrapperRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const toggleVideoMute = () => {
+    const iframe = iframeRef.current;
+    if (!iframe || !iframe.contentWindow) return;
+    const cmd = videoMuted ? 'unMute' : 'mute';
+    iframe.contentWindow.postMessage(`{"event":"command","func":"${cmd}","args":""}`, '*');
+    setVideoMuted(!videoMuted);
+  };
+
+  const forceHighQuality = () => {
+    const iframe = iframeRef.current;
+    if (!iframe || !iframe.contentWindow) return;
+    // Force highest available quality via YouTube IFrame API
+    const trySetQuality = () => {
+      iframe.contentWindow?.postMessage(
+        '{"event":"command","func":"setPlaybackQuality","args":["hd2160"]}',
+        '*'
+      );
+    };
+    // Try multiple times because the player needs to be ready
+    setTimeout(trySetQuality, 800);
+    setTimeout(trySetQuality, 2000);
+    setTimeout(trySetQuality, 4000);
+  };
 
   return (
     <section
@@ -56,24 +100,93 @@ export default function HeroSection() {
               </motion.p>
             </div>
 
-            {/* RIGHT. Product video — balanced size */}
+            {/* RIGHT. Product video — slightly larger */}
             <motion.div
-              className="lg:col-span-6"
+              className="lg:col-span-6 lg:-mr-8"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ duration: 0.8, delay: 0.7 }}
             >
               <div
-                className="relative rounded-2xl overflow-hidden border border-white/10"
+                ref={videoWrapperRef}
+                className="relative rounded-2xl overflow-hidden border border-white/10 aspect-video bg-black"
                 style={{ boxShadow: '0 20px 60px -15px rgba(75, 77, 247, 0.45), 0 0 0 1px rgba(255,255,255,0.05)' }}
               >
-                <video
-                  src="/videos/video-skillvue.mp4"
-                  controls
-                  playsInline
-                  preload="metadata"
-                  className="w-full h-auto block"
-                />
+                {videoPlaying ? (
+                  <>
+                    <iframe
+                      ref={iframeRef}
+                      src="https://www.youtube-nocookie.com/embed/Y8Oo5HBVl-Q?autoplay=1&mute=1&loop=1&playlist=Y8Oo5HBVl-Q&controls=0&rel=0&modestbranding=1&disablekb=1&iv_load_policy=3&playsinline=1&vq=hd2160&hd=1&enablejsapi=1"
+                      title="Skillvue product video"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                      allowFullScreen
+                      onLoad={forceHighQuality}
+                      width={1920}
+                      height={1080}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '1920px',
+                        height: '1080px',
+                        transformOrigin: 'top left',
+                        transform: `scale(${videoScale})`,
+                        pointerEvents: 'none',
+                      }}
+                    />
+                    {/* Click overlay — toggles audio mute/unmute */}
+                    <button
+                      type="button"
+                      onClick={toggleVideoMute}
+                      aria-label={videoMuted ? 'Activate sound' : 'Mute video'}
+                      className="absolute inset-0 z-10 group cursor-pointer"
+                    >
+                      {/* Audio indicator — bottom right */}
+                      <div className="absolute bottom-4 right-4 flex items-center gap-2 px-3 py-2 rounded-full bg-black/50 backdrop-blur-md border border-white/10 group-hover:bg-black/70 transition-all duration-300">
+                        {videoMuted ? (
+                          <>
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+                              <line x1="22" y1="9" x2="16" y2="15" />
+                              <line x1="16" y1="9" x2="22" y2="15" />
+                            </svg>
+                            <span className="text-[11px] font-medium text-white/90 tracking-wide">{t('Tap for sound')}</span>
+                          </>
+                        ) : (
+                          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+                            <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+                            <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+                          </svg>
+                        )}
+                      </div>
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setVideoPlaying(true)}
+                    aria-label="Play Skillvue product video"
+                    className="absolute inset-0 w-full h-full group cursor-pointer"
+                  >
+                    <img
+                      src="https://img.youtube.com/vi/Y8Oo5HBVl-Q/maxresdefault.jpg"
+                      alt="Skillvue product video"
+                      className="absolute inset-0 w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                    {/* Subtle dark overlay for readability of play button */}
+                    <div className="absolute inset-0 bg-black/15 group-hover:bg-black/25 transition-colors duration-300" />
+                    {/* Play button */}
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white/95 group-hover:bg-white flex items-center justify-center shadow-2xl transition-all duration-300 group-hover:scale-110">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="#0d0d1f" className="ml-1 md:w-7 md:h-7">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                )}
               </div>
             </motion.div>
           </div>

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -74,9 +74,9 @@ export default function HeroSection() {
       {/* Hero content. layered above */}
       <div className="relative z-10 flex-1 flex items-start md:items-center pt-6 md:pt-0">
         <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-10 md:py-16 lg:py-0">
-          <div className="grid lg:grid-cols-12 gap-12 lg:gap-8 items-center">
+          <div className="grid lg:grid-cols-12 gap-8 md:gap-12 lg:gap-10 items-center">
             {/* LEFT. Big headline */}
-            <div className="lg:col-span-7">
+            <div className="lg:col-span-5">
               <motion.h1
                 className="text-[clamp(2.5rem,10vw,3.75rem)] md:text-[clamp(3rem,6vw,5.5rem)] font-bold tracking-[-0.03em] text-white"
                 style={{ lineHeight: 1.1, textShadow: '0 2px 20px rgba(0,0,0,0.3)' }}
@@ -99,7 +99,26 @@ export default function HeroSection() {
               </motion.p>
             </div>
 
-            {/* RIGHT. CTA */}
+            {/* RIGHT. Product video */}
+            <motion.div
+              className="lg:col-span-7"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.8, delay: 0.7 }}
+            >
+              <div
+                className="relative rounded-2xl overflow-hidden border border-white/10"
+                style={{ boxShadow: '0 20px 60px -15px rgba(75, 77, 247, 0.45), 0 0 0 1px rgba(255,255,255,0.05)' }}
+              >
+                <video
+                  src="/videos/video-skillvue.mp4"
+                  controls
+                  playsInline
+                  preload="metadata"
+                  className="w-full h-auto block"
+                />
+              </div>
+            </motion.div>
           </div>
         </div>
       </div>

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -35,11 +35,25 @@ export default function HowItWorksSection() {
   const [active, setActive] = useState(0);
   const sectionRef = useRef(null);
   const isInView = useInView(sectionRef, { once: true, margin: '-80px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
 
   // Auto-advance every 5s
   useEffect(() => {
     const timer = setInterval(() => setActive(p => (p + 1) % 3), 5000);
     return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
   }, []);
 
   return (
@@ -65,7 +79,7 @@ export default function HowItWorksSection() {
         </motion.div>
 
         {/* 3 step cards — horizontal scroll on mobile, 3-col grid on desktop */}
-        <div className="md:grid md:grid-cols-3 md:gap-4 lg:gap-5 flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 scrollbar-hide">
+        <div ref={scrollRef} className="md:grid md:grid-cols-3 md:gap-4 lg:gap-5 flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 scrollbar-hide">
           {steps.map((step, i) => {
             const Icon = step.icon;
             const isActive = i === active;
@@ -136,7 +150,7 @@ export default function HowItWorksSection() {
                       </motion.h3>
 
                       <motion.p
-                        className="text-[12px] md:text-[15px] leading-[1.6] md:leading-[1.8] mb-3 md:mb-8"
+                        className="text-[13px] md:text-[15px] leading-[1.6] md:leading-[1.8] mb-3 md:mb-8"
                         animate={{ color: isActive ? 'rgba(255,255,255,0.5)' : 'rgba(26,26,46,0.55)' }}
                         transition={{ duration: 0.5 }}
                       >
@@ -148,7 +162,7 @@ export default function HowItWorksSection() {
                         {step.keywords.map(kw => (
                           <motion.span
                             key={kw}
-                            className="inline-flex px-2 py-1 md:px-3 md:py-1.5 rounded-full text-[9px] md:text-[11px] font-semibold tracking-wide"
+                            className="inline-flex px-2.5 py-1 md:px-3 md:py-1.5 rounded-full text-[11px] md:text-[11px] font-semibold tracking-wide"
                             animate={{
                               color: isActive ? 'rgba(155,157,251,0.7)' : 'rgba(75,77,247,0.5)',
                               backgroundColor: isActive ? 'rgba(75,77,247,0.12)' : 'rgba(75,77,247,0.04)',
@@ -167,6 +181,14 @@ export default function HowItWorksSection() {
               </motion.div>
             );
           })}
+        </div>
+
+        {/* Progress bar — mobile only */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div
+            className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
+            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+          />
         </div>
       </div>
     </section>

--- a/components/landing/ProblemSection.tsx
+++ b/components/landing/ProblemSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { useLanguage } from '@/i18n/LanguageContext';
 
@@ -40,6 +40,20 @@ export default function ProblemSection() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section
@@ -68,7 +82,7 @@ export default function ProblemSection() {
         </AnimatedSection>
 
         {/* Pain cards — horizontal scroll on mobile, 3-col grid on desktop */}
-        <div ref={ref} className="md:grid md:grid-cols-3 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 scrollbar-hide">
+        <div ref={(el) => { (ref as any).current = el; scrollRef.current = el; }} className="md:grid md:grid-cols-3 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 scrollbar-hide">
           {painCards.map((card, i) => (
             <motion.div
               key={card.stat + i}
@@ -92,15 +106,23 @@ export default function ProblemSection() {
 
               {/* Title + Description */}
               <div>
-                <h3 className="text-[13px] md:text-[15px] lg:text-[18px] font-semibold text-[#1A1A2E]/80 leading-snug mb-2 md:mb-3 lg:mb-4">
+                <h3 className="text-[15px] md:text-[15px] lg:text-[18px] font-semibold text-[#1A1A2E]/80 leading-snug mb-2 md:mb-3 lg:mb-4">
                   {t(card.title)}
                 </h3>
-                <p className="text-[11px] md:text-[13px] lg:text-[15px] text-[#1A1A2E]/50 leading-[1.6] md:leading-[1.7] lg:leading-[1.75]">
+                <p className="text-[13px] md:text-[13px] lg:text-[15px] text-[#1A1A2E]/50 leading-[1.6] md:leading-[1.7] lg:leading-[1.75]">
                   {t(card.desc)}
                 </p>
               </div>
             </motion.div>
           ))}
+        </div>
+
+        {/* Progress bar — mobile only */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div
+            className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
+            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+          />
         </div>
       </div>
     </section>

--- a/components/landing/ROISection.tsx
+++ b/components/landing/ROISection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -28,6 +28,20 @@ export default function ROISection() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section
@@ -54,7 +68,7 @@ export default function ROISection() {
           <a
             href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'}
             data-testid="roi-cta"
-            className="group inline-flex items-center gap-3 px-6 py-3 md:px-7 md:py-3.5 text-[12px] md:text-[13px] font-semibold tracking-wide rounded-full border border-[#4B4DF7]/15 text-[#4B4DF7] hover:bg-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/30 transition-all duration-500 shrink-0"
+            className="group inline-flex items-center gap-3 px-6 py-3 md:px-7 md:py-3.5 text-[14px] md:text-[13px] font-semibold tracking-wide rounded-full border border-[#4B4DF7]/15 text-[#4B4DF7] hover:bg-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/30 transition-all duration-500 shrink-0"
           >
             {t('Book a Meeting')}
             <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform duration-300" />
@@ -62,7 +76,7 @@ export default function ROISection() {
         </motion.div>
 
         {/* 3-column stat cards — horizontal scroll on mobile, 3-col grid on desktop */}
-        <div className="md:grid md:grid-cols-3 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 mb-10 md:mb-16 scrollbar-hide">
+        <div ref={scrollRef} className="md:grid md:grid-cols-3 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 md:pb-0 -mx-5 px-5 md:mx-0 md:px-0 mb-10 md:mb-16 scrollbar-hide">
           {stats.map((stat, i) => (
             <motion.div
               key={stat.value}
@@ -87,16 +101,24 @@ export default function ROISection() {
               {/* Label + Sublabel + Footnote */}
               <div>
                 <h3
-                  className="text-[13px] md:text-[18px] font-semibold text-[#1A1A2E]/80 leading-snug mb-2 md:mb-4"
+                  className="text-[15px] md:text-[18px] font-semibold text-[#1A1A2E]/80 leading-snug mb-2 md:mb-4"
                 >
                   {t(stat.label)} <span className="font-normal text-[#1A1A2E]/50">{t(stat.sublabel)}</span>
                 </h3>
-                <p className="text-[11px] md:text-[15px] text-[#1A1A2E]/50 leading-[1.5] md:leading-relaxed">
+                <p className="text-[13px] md:text-[15px] text-[#1A1A2E]/50 leading-[1.5] md:leading-relaxed">
                   {t(stat.footnote)}
                 </p>
               </div>
             </motion.div>
           ))}
+        </div>
+
+        {/* Progress bar — mobile only */}
+        <div className="md:hidden mx-auto -mt-6 mb-10 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div
+            className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
+            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+          />
         </div>
       </div>
     </section>

--- a/components/landing/SolutionSection.tsx
+++ b/components/landing/SolutionSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Target, TrendingUp, Award, Shield } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -43,6 +43,61 @@ export default function SolutionSection() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (pillar: typeof pillars[number], i: number) => (
+    <motion.div
+      key={pillar.id}
+      data-testid={`solution-card-${pillar.id}`}
+      className="group relative rounded-2xl border border-white/[0.06] hover:border-white/[0.14] bg-white/[0.03] hover:bg-white/[0.06] backdrop-blur-sm p-5 md:p-8 lg:p-10 transition-all duration-500 overflow-hidden md:aspect-auto"
+      initial={{ opacity: 0, y: 30 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: 0.1 + i * 0.1, ease: 'easeOut' }}
+    >
+      {/* Subtle hover glow */}
+      <div className="absolute top-0 right-0 w-[200px] h-[200px] rounded-full bg-[#4B4DF7]/[0.04] blur-[80px] opacity-0 group-hover:opacity-100 transition-opacity duration-700 pointer-events-none" />
+
+      <div className="relative">
+        {/* Top: Icon + Label */}
+        <div>
+          {(() => { const Icon = pillar.icon; return <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#9B9DFB]/50 mb-3 md:mb-5" strokeWidth={1.5} />; })()}
+          <h3
+            className="text-[15px] md:text-2xl font-semibold text-white/85 group-hover:text-white/95 transition-colors duration-500 leading-snug"
+          >
+            {t(pillar.label)}
+          </h3>
+        </div>
+
+        {/* Description */}
+        <p className="text-[13px] md:text-[16px] text-white/[0.55] md:text-white/[0.65] group-hover:text-white/[0.75] leading-[1.5] md:leading-[1.75] transition-colors duration-500 mb-4 md:mb-8 mt-2 md:mt-4">
+          {t(pillar.desc)}
+        </p>
+
+        {/* Stat */}
+        <div className="flex items-baseline gap-2 md:gap-3">
+          <span className="text-[22px] md:text-[1.8rem] text-white/90 font-extrabold tracking-tight leading-none">
+            {lang === 'it' && (pillar as any).statIt ? (pillar as any).statIt : pillar.stat}
+          </span>
+          <span className="text-[11px] md:text-[13px] text-white/50 font-medium tracking-wide leading-tight">
+            {t(pillar.statLabel)}
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
 
   return (
     <section id="solutions" data-testid="solution-section" className="relative py-20 lg:py-28" ref={ref}>
@@ -63,48 +118,29 @@ export default function SolutionSection() {
           </p>
         </motion.div>
 
-        {/* 2x2 Card grid */}
-        <div className="grid grid-cols-2 gap-3 md:gap-4 lg:gap-5">
+        {/* Mobile: horizontal scroll */}
+        <div
+          ref={scrollRef}
+          className="flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2 md:hidden"
+        >
           {pillars.map((pillar, i) => (
-            <motion.div
-              key={pillar.id}
-              data-testid={`solution-card-${pillar.id}`}
-              className="group relative rounded-2xl border border-white/[0.06] hover:border-white/[0.14] bg-white/[0.03] hover:bg-white/[0.06] backdrop-blur-sm p-4 md:p-8 lg:p-10 transition-all duration-500 overflow-hidden md:aspect-auto"
-              initial={{ opacity: 0, y: 30 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: 0.1 + i * 0.1, ease: 'easeOut' }}
-            >
-              {/* Subtle hover glow */}
-              <div className="absolute top-0 right-0 w-[200px] h-[200px] rounded-full bg-[#4B4DF7]/[0.04] blur-[80px] opacity-0 group-hover:opacity-100 transition-opacity duration-700 pointer-events-none" />
-
-              <div className="relative">
-                {/* Top: Icon + Label */}
-                <div>
-                  {(() => { const Icon = pillar.icon; return <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#9B9DFB]/50 mb-3 md:mb-5" strokeWidth={1.5} />; })()}
-                  <h3
-                    className="text-[13px] md:text-2xl font-semibold text-white/85 group-hover:text-white/95 transition-colors duration-500 leading-snug"
-                  >
-                    {t(pillar.label)}
-                  </h3>
-                </div>
-
-                {/* Description */}
-                <p className="text-[11px] md:text-[16px] text-white/[0.55] md:text-white/[0.65] group-hover:text-white/[0.75] leading-[1.5] md:leading-[1.75] transition-colors duration-500 mb-4 md:mb-8 mt-2 md:mt-4">
-                  {t(pillar.desc)}
-                </p>
-
-                {/* Stat */}
-                <div className="flex items-baseline gap-2 md:gap-3">
-                  <span className="text-[18px] md:text-[1.8rem] text-white/90 font-extrabold tracking-tight leading-none">
-                    {lang === 'it' && (pillar as any).statIt ? (pillar as any).statIt : pillar.stat}
-                  </span>
-                  <span className="text-[9px] md:text-[13px] text-white/50 font-medium tracking-wide leading-tight">
-                    {t(pillar.statLabel)}
-                  </span>
-                </div>
-              </div>
-            </motion.div>
+            <div key={pillar.id} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(pillar, i)}
+            </div>
           ))}
+        </div>
+
+        {/* Mobile scroll indicator — thumb-in-track (native scrollbar style) */}
+        <div className="md:hidden mx-auto mt-5 w-36 h-1 rounded-full bg-white/10 relative">
+          <div
+            className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
+            style={{ left: `${scrollProgress * 0.65}%`, transition: 'left 200ms ease-out' }}
+          />
+        </div>
+
+        {/* Desktop: 2x2 grid */}
+        <div className="hidden md:grid grid-cols-2 gap-3 md:gap-4 lg:gap-5">
+          {pillars.map((pillar, i) => renderCard(pillar, i))}
         </div>
       </div>
     </section>

--- a/components/product/AssessmentFormats.tsx
+++ b/components/product/AssessmentFormats.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { MessageSquare, MonitorSmartphone, ListChecks, UserCheck, Target, BookOpen, Wrench, GitBranch, Mic, Video, PenLine, CheckSquare } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -41,6 +41,36 @@ export default function AssessmentFormats() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
+  const scrollRef1 = useRef<HTMLDivElement | null>(null);
+  const scrollRef2 = useRef<HTMLDivElement | null>(null);
+  const scrollRef3 = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress1, setScrollProgress1] = useState(0);
+  const [scrollProgress2, setScrollProgress2] = useState(0);
+  const [scrollProgress3, setScrollProgress3] = useState(0);
+
+  useEffect(() => {
+    const refs = [
+      { el: scrollRef1.current, setter: setScrollProgress1 },
+      { el: scrollRef2.current, setter: setScrollProgress2 },
+      { el: scrollRef3.current, setter: setScrollProgress3 },
+    ];
+    const cleanups: Array<() => void> = [];
+    refs.forEach(({ el, setter }) => {
+      if (!el) return;
+      const onScroll = () => {
+        const max = el.scrollWidth - el.clientWidth;
+        const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+        setter(pct);
+      };
+      el.addEventListener('scroll', onScroll, { passive: true });
+      cleanups.push(() => el.removeEventListener('scroll', onScroll));
+    });
+    return () => cleanups.forEach((fn) => fn());
+  }, []);
+
+  const scrollRefs = [scrollRef1, scrollRef2, scrollRef3];
+  const scrollProgresses = [scrollProgress1, scrollProgress2, scrollProgress3];
+
   return (
     <section id="assessment-formats" data-testid="assessment-formats" className="relative py-16 md:py-20 lg:py-28" ref={ref}>
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
@@ -69,23 +99,47 @@ export default function AssessmentFormats() {
               {/* Section label */}
               <div className="flex items-center gap-2.5 md:gap-4 mb-5 md:mb-8">
                 <div className="w-1 h-6 md:w-1.5 md:h-8 rounded-full bg-gradient-to-b from-[#FF5F24] to-[#FF5F24]/30" />
-                <span className="text-[11px] md:text-[15px] font-bold text-[#FF5F24] tracking-[0.1em] uppercase">{t(layer.title)}</span>
-                <span className="text-[11px] md:text-[15px] text-white/35 font-light hidden md:inline">{t(layer.subtitle)}</span>
+                <span className="text-[12px] md:text-[15px] font-bold text-[#FF5F24] tracking-[0.1em] uppercase">{t(layer.title)}</span>
+                <span className="text-[12px] md:text-[15px] text-white/35 font-light hidden md:inline">{t(layer.subtitle)}</span>
               </div>
 
-              <div className={`grid gap-3 ${layer.items.length === 5 ? 'grid-cols-2 lg:grid-cols-5' : layer.items.length === 4 ? 'grid-cols-2 lg:grid-cols-4' : 'grid-cols-1 md:grid-cols-3'}`}>
+              {/* Mobile: horizontal scroll */}
+              <div ref={scrollRefs[i]} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
                 {layer.items.map((item) => {
                   const Icon = item.icon;
                   return (
                     <div
                       key={item.name}
-                      className="rounded-lg md:rounded-xl border border-white/[0.06] bg-white/[0.03] p-3.5 md:p-5 hover:border-white/[0.12] hover:bg-white/[0.06] transition-all duration-400"
+                      className="shrink-0 w-[80vw] snap-center rounded-lg border border-white/[0.06] bg-white/[0.03] p-4 transition-all duration-400"
+                    >
+                      <div className="w-8 h-8 rounded-lg bg-white/[0.06] flex items-center justify-center mb-2.5">
+                        <Icon className="h-5 w-5 text-white/50" />
+                      </div>
+                      <h4 className="text-[15px] font-bold text-white/90 mb-1 leading-tight" style={{ whiteSpace: 'pre-line' }}>{t(item.name)}</h4>
+                      <p className="text-[12px] text-white/[0.4] leading-[1.4]">{t(item.desc)}</p>
+                    </div>
+                  );
+                })}
+              </div>
+              {/* Progress bar */}
+              <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
+                <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgresses[i] * 0.65}%`, transition: "left 200ms ease-out" }} />
+              </div>
+
+              {/* Desktop: existing grid */}
+              <div className={`hidden md:grid gap-3 ${layer.items.length === 5 ? 'grid-cols-2 lg:grid-cols-5' : layer.items.length === 4 ? 'grid-cols-2 lg:grid-cols-4' : 'grid-cols-1 md:grid-cols-3'}`}>
+                {layer.items.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <div
+                      key={item.name}
+                      className="rounded-lg md:rounded-xl border border-white/[0.06] bg-white/[0.03] p-4 md:p-5 hover:border-white/[0.12] hover:bg-white/[0.06] transition-all duration-400"
                     >
                       <div className="w-8 h-8 md:w-10 md:h-10 rounded-lg bg-white/[0.06] flex items-center justify-center mb-2.5 md:mb-4">
-                        <Icon className="h-4 w-4 md:h-5 md:w-5 text-white/50" />
+                        <Icon className="h-5 w-5 md:h-5 md:w-5 text-white/50" />
                       </div>
-                      <h4 className="text-[12px] md:text-[15px] font-bold text-white/90 mb-1 md:mb-1.5 leading-tight" style={{ whiteSpace: 'pre-line' }}>{t(item.name)}</h4>
-                      <p className="text-[10px] md:text-[13px] text-white/[0.4] leading-[1.4] md:leading-[1.55]">{t(item.desc)}</p>
+                      <h4 className="text-[15px] md:text-[15px] font-bold text-white/90 mb-1 md:mb-1.5 leading-tight" style={{ whiteSpace: 'pre-line' }}>{t(item.name)}</h4>
+                      <p className="text-[12px] md:text-[13px] text-white/[0.4] leading-[1.4] md:leading-[1.55]">{t(item.desc)}</p>
                     </div>
                   );
                 })}

--- a/components/product/EnterpriseTrust.tsx
+++ b/components/product/EnterpriseTrust.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Settings, Shield, Scale } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -27,6 +27,19 @@ export default function EnterpriseTrust() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="enterprise-trust" data-testid="enterprise-trust" className="section-breathe relative py-14 md:py-16 lg:py-20" ref={ref}>
@@ -46,7 +59,33 @@ export default function EnterpriseTrust() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-5 mb-8 md:mb-12">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pillars.map((pillar, i) => {
+            const Icon = pillar.icon;
+            return (
+              <motion.div
+                key={pillar.title}
+                data-testid={`trust-${pillar.title.toLowerCase()}`}
+                className="shrink-0 w-[80vw] snap-center group rounded-xl border border-[#4B4DF7]/[0.08] bg-white p-5 transition-all duration-500"
+                initial={{ opacity: 0, y: 20 }}
+                animate={isInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}
+              >
+                <Icon className="h-5 w-5 text-[#4B4DF7]/50 mb-3" strokeWidth={1.5} />
+                <h3 className="text-[16px] font-bold text-[#1A1A2E] mb-2">{t(pillar.title)}</h3>
+                <p className="text-[13px] text-[#1A1A2E]/[0.55] leading-[1.5]">{t(pillar.desc)}</p>
+              </motion.div>
+            );
+          })}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop: existing grid */}
+        <div className="hidden md:grid md:grid-cols-3 gap-3 md:gap-5 mb-8 md:mb-12">
           {pillars.map((pillar, i) => {
             const Icon = pillar.icon;
             return (
@@ -59,8 +98,8 @@ export default function EnterpriseTrust() {
                 transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}
               >
                 <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#4B4DF7]/50 mb-3 md:mb-5" strokeWidth={1.5} />
-                <h3 className="text-[15px] md:text-[20px] font-bold text-[#1A1A2E] mb-2 md:mb-4">{t(pillar.title)}</h3>
-                <p className="text-[12px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.5] md:leading-[1.75]">{t(pillar.desc)}</p>
+                <h3 className="text-[16px] md:text-[20px] font-bold text-[#1A1A2E] mb-2 md:mb-4">{t(pillar.title)}</h3>
+                <p className="text-[13px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.5] md:leading-[1.75]">{t(pillar.desc)}</p>
               </motion.div>
             );
           })}
@@ -75,7 +114,7 @@ export default function EnterpriseTrust() {
           {badges.map((badge) => (
             <span
               key={badge}
-              className="inline-flex px-3.5 py-2 md:px-5 md:py-2.5 rounded-full text-[11px] md:text-[12px] font-semibold text-[#4B4DF7]/70 border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide"
+              className="inline-flex px-3.5 py-2 md:px-5 md:py-2.5 rounded-full text-[12px] md:text-[12px] font-semibold text-[#4B4DF7]/70 border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide"
             >
               {t(badge)}
             </span>

--- a/components/product/HowSkillvueWorks.tsx
+++ b/components/product/HowSkillvueWorks.tsx
@@ -66,12 +66,12 @@ export default function HowSkillvueWorks() {
             <div>
               <span className="text-[10px] md:text-[12px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.1em] uppercase mb-2 md:mb-4 block">{t('STEP')} {steps[active].num}</span>
               <h3 className="text-[18px] md:text-[clamp(1.5rem,2.5vw,2rem)] font-bold text-white/90 mb-3 md:mb-5 leading-[1.2]">{t(steps[active].title)}</h3>
-              <p className="text-[13px] md:text-[16px] text-white/[0.65] leading-[1.6] md:leading-[1.75]">{t(steps[active].what)}</p>
+              <p className="text-[14px] md:text-[16px] text-white/[0.65] leading-[1.6] md:leading-[1.75]">{t(steps[active].what)}</p>
             </div>
             <div>
               <div className="rounded-lg md:rounded-xl bg-white/[0.04] border border-white/[0.06] p-4 md:p-6 w-full">
-                <span className="text-[9px] md:text-[11px] font-semibold text-white/30 tracking-[0.1em] uppercase mb-2 md:mb-3 block">{t('KEY CAPABILITY')}</span>
-                <p className="text-[12px] md:text-[15px] text-white/[0.65] leading-[1.5] md:leading-[1.7]">{t(steps[active].capability)}</p>
+                <span className="text-[10px] md:text-[11px] font-semibold text-white/30 tracking-[0.1em] uppercase mb-2 md:mb-3 block">{t('KEY CAPABILITY')}</span>
+                <p className="text-[13px] md:text-[15px] text-white/[0.65] leading-[1.5] md:leading-[1.7]">{t(steps[active].capability)}</p>
               </div>
             </div>
           </div>
@@ -79,7 +79,7 @@ export default function HowSkillvueWorks() {
 
         {/* Nav arrows */}
         <div className="flex items-center justify-between mt-5 md:mt-8">
-          <span className="text-[11px] md:text-[12px] font-medium text-white/25">
+          <span className="text-[12px] md:text-[12px] font-medium text-white/25">
             {String(active + 1).padStart(2, '0')} / {String(steps.length).padStart(2, '0')}
           </span>
           <div className="flex items-center gap-2">

--- a/components/product/PlatformInfographic.tsx
+++ b/components/product/PlatformInfographic.tsx
@@ -19,7 +19,7 @@ export default function PlatformInfographic() {
           <h2 className="text-[clamp(1.5rem,3.5vw,2.5rem)] font-bold text-[#1A1A2E] tracking-[-0.02em] mb-3 md:mb-4">
             {t('From signals to decisions. One connected flow.')}
           </h2>
-          <p className="text-[13px] md:text-[17px] text-[#1A1A2E]/[0.45] leading-[1.6] md:leading-[1.75] max-w-2xl mx-auto">
+          <p className="text-[14px] md:text-[17px] text-[#1A1A2E]/[0.45] leading-[1.6] md:leading-[1.75] max-w-2xl mx-auto">
             {t('Skillvue gathers signals from candidates, workforce, and market data, processes them through AI-powered skills intelligence, integrates with your core HR systems, and enables every talent decision with objective, defensible data.')}
           </p>
         </motion.div>

--- a/components/product/ProductCTA.tsx
+++ b/components/product/ProductCTA.tsx
@@ -29,13 +29,13 @@ export default function ProductCTA() {
           transition={{ duration: 0.7, delay: 0.2 }}
         >
           <div className="group relative rounded-xl md:rounded-2xl border border-white/[0.06] hover:border-white/[0.14] bg-white/[0.04] hover:bg-white/[0.06] backdrop-blur-sm p-5 md:p-10 lg:p-14 transition-all duration-500 overflow-hidden">
-            <span className="text-[10px] md:text-[11px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.15em] uppercase">{t('Ready to explore')}</span>
+            <span className="text-[11px] md:text-[11px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.15em] uppercase">{t('Ready to explore')}</span>
             <h3 className="text-xl md:text-2xl font-bold text-white/90 mt-3 md:mt-4 mb-2 md:mb-3">{t('Book a Meeting')}</h3>
-            <p className="text-[13px] md:text-[15px] text-white/[0.65] mb-5 md:mb-8 max-w-md">{t('See Skillvue live with your specific use case')}</p>
+            <p className="text-[14px] md:text-[15px] text-white/[0.65] mb-5 md:mb-8 max-w-md">{t('See Skillvue live with your specific use case')}</p>
             <a
               href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'}
               data-testid="product-cta-book-demo"
-              className="group/btn inline-flex items-center justify-between w-full max-w-sm px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500"
+              className="group/btn inline-flex items-center justify-between w-full max-w-sm px-6 py-4 md:px-8 md:py-5 text-[14px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500"
             >
               <span>{t('Book a Meeting')}</span>
               <ArrowRight className="h-4 w-4 text-white/30 group-hover/btn:text-[#9B9DFB] group-hover/btn:translate-x-1 transition-all duration-500" />

--- a/components/product/ProductHero.tsx
+++ b/components/product/ProductHero.tsx
@@ -37,10 +37,10 @@ export default function ProductHero() {
           <a
             href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'}
             data-testid="product-hero-book-demo"
-            className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0"
+            className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 md:px-8 md:py-5 text-[14px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0"
           >
             <span>{t('Book a Meeting')}</span>
-            <ArrowRight className="h-4 w-4 md:h-5 md:w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
+            <ArrowRight className="h-5 w-5 md:h-5 md:w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>
         </motion.div>
       </div>

--- a/components/product/WhatSkillvueDoes.tsx
+++ b/components/product/WhatSkillvueDoes.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight, Target, BarChart3, GraduationCap, ArrowLeftRight } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -42,6 +42,19 @@ export default function WhatSkillvueDoes() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="what-skillvue-does" data-testid="what-skillvue-does" className="section-breathe relative py-16 md:py-20 lg:py-24" ref={ref}>
@@ -61,28 +74,60 @@ export default function WhatSkillvueDoes() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-2 gap-3 md:gap-5 auto-rows-fr">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
           {pillars.map((pillar, i) => {
             const Icon = pillar.icon;
             return (
               <motion.div
                 key={pillar.id}
                 data-testid={`pillar-${pillar.id}`}
-                className="group relative rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-4 md:p-10 lg:p-12 transition-all duration-500 flex flex-col h-full"
+                className="shrink-0 w-[80vw] snap-center group relative rounded-xl border border-[#4B4DF7]/[0.08] bg-white/60 p-5 transition-all duration-500 flex flex-col"
+                initial={{ opacity: 0, y: 30 }}
+                animate={isInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}
+              >
+                <div className="flex-1">
+                  <Icon className="h-5 w-5 text-[#4B4DF7]/40 mb-2" strokeWidth={1.5} />
+                  <h3 className="text-[15px] font-bold text-[#1A1A2E] mb-1.5 leading-snug">{t(pillar.title)}</h3>
+                  <p className="text-[12px] text-[#1A1A2E]/[0.5] leading-[1.4]">{t(pillar.desc)}</p>
+                </div>
+                <a href={pillar.path} className="group/link inline-flex items-center gap-1 text-[12px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] transition-colors duration-300 mt-3">
+                  {t(pillar.link)}
+                  <ArrowRight className="h-3.5 w-3.5 shrink-0 group-hover/link:translate-x-1 transition-transform duration-300" />
+                </a>
+              </motion.div>
+            );
+          })}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop: existing grid */}
+        <div className="hidden md:grid grid-cols-2 gap-3 md:gap-5 auto-rows-fr">
+          {pillars.map((pillar, i) => {
+            const Icon = pillar.icon;
+            return (
+              <motion.div
+                key={pillar.id}
+                data-testid={`pillar-${pillar.id}`}
+                className="group relative rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-5 md:p-10 lg:p-12 transition-all duration-500 flex flex-col h-full"
                 initial={{ opacity: 0, y: 30 }}
                 animate={isInView ? { opacity: 1, y: 0 } : {}}
                 transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}
               >
                 {/* Top content */}
                 <div className="flex-1">
-                  <Icon className="h-4 w-4 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-2 md:mb-5" strokeWidth={1.5} />
-                  <h3 className="text-[12px] md:text-[20px] font-bold text-[#1A1A2E] mb-1.5 md:mb-4 leading-snug">{t(pillar.title)}</h3>
-                  <p className="text-[10px] md:text-[15px] text-[#1A1A2E]/[0.5] leading-[1.4] md:leading-[1.75]">{t(pillar.desc)}</p>
+                  <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-2 md:mb-5" strokeWidth={1.5} />
+                  <h3 className="text-[15px] md:text-[20px] font-bold text-[#1A1A2E] mb-1.5 md:mb-4 leading-snug">{t(pillar.title)}</h3>
+                  <p className="text-[12px] md:text-[15px] text-[#1A1A2E]/[0.5] leading-[1.4] md:leading-[1.75]">{t(pillar.desc)}</p>
                 </div>
                 {/* Link — always anchored at bottom */}
-                <a href={pillar.path} className="group/link inline-flex items-center gap-1 md:gap-2 text-[10px] md:text-[13px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] transition-colors duration-300 mt-3 md:mt-8">
+                <a href={pillar.path} className="group/link inline-flex items-center gap-1 md:gap-2 text-[12px] md:text-[13px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] transition-colors duration-300 mt-3 md:mt-8">
                   {t(pillar.link)}
-                  <ArrowRight className="h-2.5 w-2.5 md:h-3.5 md:w-3.5 shrink-0 group-hover/link:translate-x-1 transition-transform duration-300" />
+                  <ArrowRight className="h-3.5 w-3.5 md:h-3.5 md:w-3.5 shrink-0 group-hover/link:translate-x-1 transition-transform duration-300" />
                 </a>
               </motion.div>
             );

--- a/components/product/WhatWeAssess.tsx
+++ b/components/product/WhatWeAssess.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -15,6 +15,19 @@ export default function WhatWeAssess() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="what-we-assess" data-testid="what-we-assess" className="section-breathe relative py-16 md:py-20 lg:py-24" ref={ref}>
@@ -34,19 +47,42 @@ export default function WhatWeAssess() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden mb-8 md:mb-10">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
           {dimensions.map((dim, i) => (
             <motion.div
               key={dim.title}
               data-testid={`dimension-${dim.title.toLowerCase().replace(/\s+/g, '-')}`}
-              className="bg-[#F5F5FA] rounded-xl md:rounded-none p-4 md:p-8 flex flex-col"
+              className="shrink-0 w-[80vw] snap-center bg-[#F5F5FA] rounded-xl p-4 flex flex-col"
               initial={{ opacity: 0, y: 20 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: 0.1 + i * 0.08 }}
             >
-              <h3 className="text-[13px] md:text-[17px] font-bold text-[#1A1A2E] mb-0.5 md:mb-1">{t(dim.title)}</h3>
-              <span className="text-[10px] md:text-[12px] text-[#4B4DF7]/[0.65] font-medium mb-2 md:mb-4">{t(dim.subtitle)}</span>
-              <p className="text-[10px] md:text-[14px] text-[#1A1A2E]/[0.55] leading-[1.5] md:leading-[1.7]">{t(dim.desc)}</p>
+              <h3 className="text-[15px] font-bold text-[#1A1A2E] mb-0.5">{t(dim.title)}</h3>
+              <span className="text-[12px] text-[#4B4DF7]/[0.65] font-medium mb-2">{t(dim.subtitle)}</span>
+              <p className="text-[12px] text-[#1A1A2E]/[0.55] leading-[1.5]">{t(dim.desc)}</p>
+            </motion.div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop: existing grid */}
+        <div className="hidden md:grid md:grid-cols-3 lg:grid-cols-5 md:gap-px md:bg-[#4B4DF7]/[0.06] md:rounded-2xl md:overflow-hidden mb-8 md:mb-10">
+          {dimensions.map((dim, i) => (
+            <motion.div
+              key={dim.title}
+              data-testid={`dimension-${dim.title.toLowerCase().replace(/\s+/g, '-')}`}
+              className="bg-[#F5F5FA] md:rounded-none p-4 md:p-8 flex flex-col"
+              initial={{ opacity: 0, y: 20 }}
+              animate={isInView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.5, delay: 0.1 + i * 0.08 }}
+            >
+              <h3 className="text-[15px] md:text-[17px] font-bold text-[#1A1A2E] mb-0.5 md:mb-1">{t(dim.title)}</h3>
+              <span className="text-[12px] md:text-[12px] text-[#4B4DF7]/[0.65] font-medium mb-2 md:mb-4">{t(dim.subtitle)}</span>
+              <p className="text-[12px] md:text-[14px] text-[#1A1A2E]/[0.55] leading-[1.5] md:leading-[1.7]">{t(dim.desc)}</p>
             </motion.div>
           ))}
         </div>
@@ -57,9 +93,9 @@ export default function WhatWeAssess() {
           animate={isInView ? { opacity: 1 } : {}}
           transition={{ duration: 0.5, delay: 0.6 }}
         >
-          <a href="/science" className="group inline-flex items-center gap-1.5 md:gap-2 text-[11px] md:text-[13px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] shrink-0 transition-colors duration-300">
+          <a href="/science" className="group inline-flex items-center gap-1.5 md:gap-2 text-[13px] md:text-[13px] font-semibold text-[#4B4DF7] hover:text-[#3A3BD6] shrink-0 transition-colors duration-300">
             {t('Discover the Science')}
-            <ArrowRight className="h-3 w-3 md:h-3.5 md:w-3.5 group-hover:translate-x-1 transition-transform duration-300" />
+            <ArrowRight className="h-3.5 w-3.5 md:h-3.5 md:w-3.5 group-hover:translate-x-1 transition-transform duration-300" />
           </a>
         </motion.div>
       </div>

--- a/components/science/MethodologyLifecycle.tsx
+++ b/components/science/MethodologyLifecycle.tsx
@@ -51,8 +51,8 @@ export default function MethodologyLifecycle() {
                 className={`w-full flex items-center gap-3 py-3.5 border-b transition-all duration-300 ${i === active ? 'border-[#9B9DFB]/30 bg-white/[0.03]' : 'border-white/[0.04]'}`}
               >
                 <span className={`text-[11px] font-bold w-6 ${i === active ? 'text-[#9B9DFB]' : 'text-white/15'}`}>{s.num}</span>
-                <span className={`text-[13px] flex-1 text-left ${i === active ? 'font-semibold text-white' : 'font-normal text-white/20'}`}>{t(s.title)}</span>
-                <span className={`text-[12px] transition-transform duration-300 ${i === active ? 'text-[#9B9DFB] rotate-90' : 'text-white/10'}`}>›</span>
+                <span className={`text-[14px] flex-1 text-left ${i === active ? 'font-semibold text-white' : 'font-normal text-white/20'}`}>{t(s.title)}</span>
+                <span className={`text-[14px] transition-transform duration-300 ${i === active ? 'text-[#9B9DFB] rotate-90' : 'text-white/10'}`}>›</span>
               </button>
               {i === active && (
                 <motion.div
@@ -61,7 +61,7 @@ export default function MethodologyLifecycle() {
                   transition={{ duration: 0.25 }}
                   className="overflow-hidden bg-white/[0.03]"
                 >
-                  <p className="text-[12px] text-white/[0.45] leading-[1.6] py-3 pl-9 pr-4">{t(s.desc)}</p>
+                  <p className="text-[13px] text-white/[0.55] leading-[1.65] py-3 pl-9 pr-4">{t(s.desc)}</p>
                 </motion.div>
               )}
             </div>
@@ -103,7 +103,7 @@ export default function MethodologyLifecycle() {
               >
                 <Icon className="h-5 w-5 text-[#9B9DFB]/50 mb-3" strokeWidth={1.5} />
                 <h3 className="text-[16px] font-bold text-white/90 mb-2">{t(p.title)}</h3>
-                <p className="text-[12px] text-white/[0.6] leading-[1.6]">{t(p.desc)}</p>
+                <p className="text-[14px] text-white/[0.6] leading-[1.65]">{t(p.desc)}</p>
               </motion.div>
             );
           })()}

--- a/components/science/ResponsibleAI.tsx
+++ b/components/science/ResponsibleAI.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { motion, useInView, AnimatePresence } from 'framer-motion';
 import { Eye, Users, Activity, Scale, ChevronDown } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -26,6 +26,31 @@ export default function ResponsibleAI() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderPillar = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div key={p.title} data-testid={`responsible-${p.title.toLowerCase().replace(/\s+/g, '-')}`} className="group rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-5 md:p-10 transition-all duration-500 h-full" initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.1 + i * 0.08 }}>
+        <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-3 md:mb-5" strokeWidth={1.5} />
+        <h3 className="text-[15px] md:text-[18px] font-bold text-[#1A1A2E] mb-2 md:mb-3">{t(p.title)}</h3>
+        <p className="text-[12px] md:text-[15px] text-[#1A1A2E]/[0.65] leading-[1.5] md:leading-[1.75]">{t(p.desc)}</p>
+      </motion.div>
+    );
+  };
+
   return (
     <section id="responsible-ai" data-testid="responsible-ai" className="section-breathe relative py-16 md:py-20 lg:py-24" ref={ref}>
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
@@ -38,17 +63,22 @@ export default function ResponsibleAI() {
           </h2>
         </motion.div>
 
-        <div className="grid grid-cols-2 md:grid-cols-2 gap-3 md:gap-5 mb-12 md:mb-20">
-          {pillars.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div key={p.title} data-testid={`responsible-${p.title.toLowerCase().replace(/\s+/g, '-')}`} className="group rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-4 md:p-10 transition-all duration-500" initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.1 + i * 0.08 }}>
-                <Icon className="h-4 w-4 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-2 md:mb-5" strokeWidth={1.5} />
-                <h3 className="text-[13px] md:text-[18px] font-bold text-[#1A1A2E] mb-1.5 md:mb-3">{t(p.title)}</h3>
-                <p className="text-[10px] md:text-[15px] text-[#1A1A2E]/[0.65] leading-[1.4] md:leading-[1.75]">{t(p.desc)}</p>
-              </motion.div>
-            );
-          })}
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pillars.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderPillar(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 mb-12 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop grid */}
+        <div className="hidden md:grid md:grid-cols-2 gap-3 md:gap-5 mb-12 md:mb-20">
+          {pillars.map((p, i) => renderPillar(p, i))}
         </div>
 
         {/* FAQ */}
@@ -63,13 +93,13 @@ export default function ResponsibleAI() {
           {faqs.map((faq, i) => (
             <motion.div key={i} className="border-b border-[#1A1A2E]/[0.08]" initial={{ opacity: 0, y: 15 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.4, delay: 0.1 + i * 0.06 }}>
               <button onClick={() => setOpenIdx(openIdx === i ? null : i)} data-testid={`faq-${i}`} className="w-full flex items-center justify-between py-4 md:py-6 text-left">
-                <span className="text-[14px] md:text-[16px] font-semibold text-[#1A1A2E]/85 pr-4 md:pr-8">{t(faq.q)}</span>
-                <ChevronDown className={`h-4 w-4 text-[#1A1A2E]/30 shrink-0 transition-transform duration-400 ${openIdx === i ? 'rotate-180' : ''}`} />
+                <span className="text-[15px] md:text-[16px] font-semibold text-[#1A1A2E]/85 pr-4 md:pr-8">{t(faq.q)}</span>
+                <ChevronDown className={`h-5 w-5 md:h-4 md:w-4 text-[#1A1A2E]/30 shrink-0 transition-transform duration-400 ${openIdx === i ? 'rotate-180' : ''}`} />
               </button>
               <AnimatePresence>
                 {openIdx === i && (
                   <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.3 }} className="overflow-hidden">
-                    <p className="text-[13px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.6] md:leading-[1.75] pb-4 md:pb-6">{t(faq.a)}</p>
+                    <p className="text-[14px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.65] md:leading-[1.75] pb-4 md:pb-6">{t(faq.a)}</p>
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/components/science/ScienceCTA.tsx
+++ b/components/science/ScienceCTA.tsx
@@ -22,10 +22,10 @@ export default function ScienceCTA() {
           <div className="group rounded-xl md:rounded-2xl border border-white/[0.06] hover:border-white/[0.14] bg-white/[0.04] hover:bg-white/[0.06] backdrop-blur-sm p-5 md:p-10 lg:p-14 transition-all duration-500">
             <span className="text-[10px] md:text-[11px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.15em] uppercase">{t('Ready to explore')}</span>
             <h3 className="text-xl md:text-2xl font-bold text-white/90 mt-3 md:mt-4 mb-2 md:mb-3">{t('Book a Meeting')}</h3>
-            <p className="text-[13px] md:text-[15px] text-white/[0.65] mb-5 md:mb-8 max-w-md">{t('See how science translates into better talent decisions')}</p>
-            <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="science-cta-demo" className="group/btn inline-flex items-center justify-between w-full max-w-sm px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500">
+            <p className="text-[14px] md:text-[15px] text-white/[0.65] mb-5 md:mb-8 max-w-md">{t('See how science translates into better talent decisions')}</p>
+            <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="science-cta-demo" className="group/btn inline-flex items-center justify-between w-full max-w-sm px-6 py-4 md:px-8 md:py-5 text-[14px] md:text-[14px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500">
               <span>{t('Book a Meeting')}</span>
-              <ArrowRight className="h-4 w-4 text-white/30 group-hover/btn:text-[#9B9DFB] group-hover/btn:translate-x-1 transition-all duration-500" />
+              <ArrowRight className="h-5 w-5 md:h-4 md:w-4 text-white/30 group-hover/btn:text-[#9B9DFB] group-hover/btn:translate-x-1 transition-all duration-500" />
             </a>
           </div>
         </motion.div>

--- a/components/science/ScienceHero.tsx
+++ b/components/science/ScienceHero.tsx
@@ -31,13 +31,13 @@ export default function ScienceHero() {
           transition={{ duration: 0.8, delay: 0.5 }}
         >
           <p
-            className="text-[14px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-md lg:max-w-lg font-normal md:font-light"
+            className="text-[15px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-md lg:max-w-lg font-normal md:font-light"
           >
             {t("Measuring people is hard. To make talent decisions you can trust, accuracy and reliability aren't optional. Skillvue is built on I/O psychology and psychometrics, ensuring every data point holds up to scrutiny.")}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} className="group inline-flex items-center justify-between shrink-0 w-full lg:w-[480px] px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} className="group inline-flex items-center justify-between shrink-0 w-full lg:w-[480px] px-6 py-4 md:px-8 md:py-5 text-[14px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500">
             <span>{t('Book a Meeting')}</span>
-            <ArrowRight className="h-4 w-4 md:h-5 md:w-5 ml-4 md:ml-8 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
+            <ArrowRight className="h-5 w-5 md:h-5 md:w-5 ml-4 md:ml-8 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>
         </motion.div>
       </div>

--- a/components/science/ScienceTeam.tsx
+++ b/components/science/ScienceTeam.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Linkedin } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -23,6 +23,43 @@ export default function ScienceTeam() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
+
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderMember = (m, i) => (
+    <motion.div
+      key={m.name}
+      data-testid={`team-${m.name.split(' ')[0]?.toLowerCase()}`}
+      className="group text-center"
+      initial={{ opacity: 0, y: 20 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: 0.2 + i * 0.08 }}
+    >
+      <div className="rounded-xl md:rounded-2xl border border-[#1A1A2E]/[0.06] bg-white overflow-hidden mb-2 md:mb-4 hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04] transition-all duration-500">
+        <div className="w-full aspect-[3/4]">
+          <img src={m.photo} alt={m.name} className="w-full h-full object-cover" />
+        </div>
+      </div>
+      <h4 className="text-[13px] md:text-[15px] font-bold text-[#1A1A2E] mb-0.5 md:mb-1 leading-tight">
+        {m.name}
+      </h4>
+      <p className="text-[12px] md:text-[13px] text-[#1A1A2E]/45 leading-snug">
+        {t(m.role)}
+      </p>
+    </motion.div>
+  );
 
   return (
     <section id="science-team" data-testid="science-team" className="section-breathe relative py-16 lg:py-24" ref={ref}>
@@ -56,10 +93,10 @@ export default function ScienceTeam() {
               <h3 className="text-[clamp(1.5rem,2.5vw,2rem)] font-bold text-[#1A1A2E] mb-1.5">
                 {lead.name}
               </h3>
-              <p className="text-[12px] md:text-[15px] font-semibold text-[#4B4DF7]/70 mb-3 md:mb-6">
+              <p className="text-[13px] md:text-[15px] font-semibold text-[#4B4DF7]/70 mb-3 md:mb-6">
                 {t(lead.role)}
               </p>
-              <p className="text-[12px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.6] md:leading-[1.8] max-w-2xl">
+              <p className="text-[14px] md:text-[15px] text-[#1A1A2E]/[0.55] leading-[1.6] md:leading-[1.8] max-w-2xl">
                 {t(lead.bio)}
               </p>
               <a
@@ -74,30 +111,22 @@ export default function ScienceTeam() {
           </div>
         </motion.div>
 
-        {/* Team members grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-5 lg:gap-6">
+        {/* Team members - Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
           {members.map((m, i) => (
-            <motion.div
-              key={m.name}
-              data-testid={`team-${m.name.split(' ')[0]?.toLowerCase()}`}
-              className="group text-center"
-              initial={{ opacity: 0, y: 20 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: 0.2 + i * 0.08 }}
-            >
-              <div className="rounded-xl md:rounded-2xl border border-[#1A1A2E]/[0.06] bg-white overflow-hidden mb-2 md:mb-4 hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04] transition-all duration-500">
-                <div className="w-full aspect-[3/4]">
-                  <img src={m.photo} alt={m.name} className="w-full h-full object-cover" />
-                </div>
-              </div>
-              <h4 className="text-[12px] md:text-[15px] font-bold text-[#1A1A2E] mb-0.5 md:mb-1 leading-tight">
-                {m.name}
-              </h4>
-              <p className="text-[10px] md:text-[13px] text-[#1A1A2E]/45 leading-snug">
-                {t(m.role)}
-              </p>
-            </motion.div>
+            <div key={m.name} className="shrink-0 w-[60vw] snap-center">
+              {renderMember(m, i)}
+            </div>
           ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Team members - Desktop grid */}
+        <div className="hidden md:grid md:grid-cols-4 gap-3 md:gap-5 lg:gap-6">
+          {members.map((m, i) => renderMember(m, i))}
         </div>
 
         {/* 50+ collaborators */}
@@ -109,7 +138,7 @@ export default function ScienceTeam() {
         >
           <span className="text-[32px] md:text-[48px] font-bold text-[#1A1A2E] leading-none tracking-[-0.03em] shrink-0">50+</span>
           <div className="w-px h-10 bg-[#1A1A2E]/[0.08] hidden sm:block shrink-0" />
-          <p className="text-[13px] md:text-[16px] text-[#1A1A2E]/[0.5] leading-[1.5] md:leading-[1.7]">
+          <p className="text-[14px] md:text-[16px] text-[#1A1A2E]/[0.5] leading-[1.6] md:leading-[1.7]">
             {t('External collaborators from academic, HR consulting and corporate world')}
           </p>
         </motion.div>

--- a/components/science/ScientificPillars.tsx
+++ b/components/science/ScientificPillars.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Brain, Ruler } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -24,6 +24,32 @@ export default function ScientificPillars() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div key={p.title} className="group rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-5 md:p-10 lg:p-12 transition-all duration-500 h-full" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}>
+        <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-3 md:mb-5" strokeWidth={1.5} />
+        <h3 className="text-[17px] md:text-[22px] font-bold text-[#1A1A2E] mb-1 md:mb-2">{t(p.title)}</h3>
+        <p className="text-[13px] md:text-[15px] text-[#4B4DF7]/[0.65] font-medium mb-3 md:mb-5">{t(p.subtitle)}</p>
+        <p className="text-[14px] md:text-[15px] text-[#1A1A2E]/[0.65] leading-[1.6] md:leading-[1.75]">{t(p.desc)}</p>
+      </motion.div>
+    );
+  };
+
   return (
     <section id="pillars" data-testid="scientific-pillars" className="section-breathe relative py-16 md:py-20 lg:py-24" ref={ref}>
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
@@ -33,18 +59,23 @@ export default function ScientificPillars() {
             <span className="italic font-bold gradient-text-on-light">{t('rigor')}</span>
           </h2>
         </motion.div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-5">
-          {pillars.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div key={p.title} className="group rounded-xl md:rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/80 p-5 md:p-10 lg:p-12 transition-all duration-500" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.15 + i * 0.1 }}>
-                <Icon className="h-5 w-5 md:h-6 md:w-6 text-[#4B4DF7]/40 mb-3 md:mb-5" strokeWidth={1.5} />
-                <h3 className="text-[17px] md:text-[22px] font-bold text-[#1A1A2E] mb-1 md:mb-2">{t(p.title)}</h3>
-                <p className="text-[12px] md:text-[15px] text-[#4B4DF7]/[0.65] font-medium mb-3 md:mb-5">{t(p.subtitle)}</p>
-                <p className="text-[12px] md:text-[15px] text-[#1A1A2E]/[0.65] leading-[1.5] md:leading-[1.75]">{t(p.desc)}</p>
-              </motion.div>
-            );
-          })}
+
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pillars.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop grid */}
+        <div className="hidden md:grid md:grid-cols-2 gap-3 md:gap-5">
+          {pillars.map((p, i) => renderCard(p, i))}
         </div>
       </div>
     </section>

--- a/components/shared/MobileScroller.tsx
+++ b/components/shared/MobileScroller.tsx
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import React, { useRef, useState, useEffect } from 'react';
+
+type Props = {
+  children: React.ReactNode[];
+  className?: string;
+  dotColor?: 'light' | 'dark';
+  desktopClassName?: string;
+};
+
+/**
+ * Mobile horizontal scroller with peek + dots indicator.
+ * On mobile: horizontal scroll with snap points, shows progress dots below.
+ * On desktop: renders children inside `desktopClassName` (e.g. a grid).
+ */
+export default function MobileScroller({ children, className = '', dotColor = 'light', desktopClassName = '' }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const items = React.Children.toArray(children);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const itemWidth = el.scrollWidth / items.length;
+      const idx = Math.round(el.scrollLeft / itemWidth);
+      setActiveIdx(Math.min(Math.max(idx, 0), items.length - 1));
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [items.length]);
+
+  const activeDot = dotColor === 'dark' ? 'bg-[#1A1A2E]/60' : 'bg-white/70';
+  const inactiveDot = dotColor === 'dark' ? 'bg-[#1A1A2E]/15' : 'bg-white/20';
+
+  return (
+    <div>
+      {/* Mobile: horizontal scroll */}
+      <div className="md:hidden">
+        <div
+          ref={scrollRef}
+          className={`flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2 ${className}`}
+        >
+          {items.map((child, i) => (
+            <div key={i} className="shrink-0 w-[80vw] snap-center">
+              {child}
+            </div>
+          ))}
+        </div>
+        {/* Progress dots */}
+        {items.length > 1 && (
+          <div className="flex justify-center items-center gap-1.5 mt-4">
+            {items.map((_, i) => (
+              <div
+                key={i}
+                className={`h-1 rounded-full transition-all duration-300 ${
+                  i === activeIdx ? `w-6 ${activeDot}` : `w-1.5 ${inactiveDot}`
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Desktop: normal grid/layout */}
+      <div className={`hidden md:block ${desktopClassName}`}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/shared/ProductCrossLinks.tsx
+++ b/components/shared/ProductCrossLinks.tsx
@@ -31,15 +31,15 @@ export default function ProductCrossLinks() {
               <motion.button
                 key={s.path}
                 onClick={() => handleNav(s.path)}
-                className="group text-left rounded-lg md:rounded-xl border border-white/[0.08] hover:border-white/[0.16] bg-white/[0.04] hover:bg-white/[0.07] p-3.5 md:p-6 transition-all duration-500"
+                className="group text-left rounded-lg md:rounded-xl border border-white/[0.08] hover:border-white/[0.16] bg-white/[0.04] hover:bg-white/[0.07] p-4 md:p-6 transition-all duration-500"
                 initial={{ opacity: 0, y: 15 }}
                 animate={isInView ? { opacity: 1, y: 0 } : {}}
                 transition={{ duration: 0.4, delay: 0.05 + i * 0.05 }}
               >
                 <div className="flex items-center justify-between">
                   <div>
-                    <span className="text-[12px] md:text-[15px] font-semibold text-white/85 block mb-0.5 md:mb-1 leading-tight">{t(s.name)}</span>
-                    <span className="text-[10px] md:text-[13px] text-white/40">{t(s.desc)}</span>
+                    <span className="text-[15px] md:text-[15px] font-semibold text-white/85 block mb-0.5 md:mb-1 leading-tight">{t(s.name)}</span>
+                    <span className="text-[12px] md:text-[13px] text-white/40">{t(s.desc)}</span>
                   </div>
                   <ArrowRight className="h-3 w-3 md:h-4 md:w-4 text-white/20 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-300 shrink-0 hidden md:block" />
                 </div>

--- a/components/shared/SolutionCrossLinks.tsx
+++ b/components/shared/SolutionCrossLinks.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useRouter } from 'next/router';
@@ -22,12 +22,52 @@ export default function SolutionCrossLinks({ currentPath }) {
 
   const handleNav = (path) => { router.push(path); window.scrollTo(0, 0); };
 
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
     <section className="relative pt-20 pb-16 lg:pt-24 lg:pb-20" ref={ref}>
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <motion.div initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.6 }}>
-          {/* Platform + Science links */}
-          <div className="grid md:grid-cols-2 gap-4 mb-8">
+          {/* Mobile: horizontal scroll for Platform + Science */}
+          <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+            <button onClick={() => handleNav('/product-overview')} className="shrink-0 w-[80vw] snap-center group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 transition-all duration-500">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-[11px] font-bold text-[#9B9DFB]/50 tracking-[0.1em] uppercase block mb-1">{t('Platform')}</span>
+                  <span className="text-[16px] font-semibold text-white/85">{t('See how the full product works')}</span>
+                </div>
+                <ArrowRight className="h-4 w-4 text-white/30" />
+              </div>
+            </button>
+            <button onClick={() => handleNav('/science')} className="shrink-0 w-[80vw] snap-center group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 transition-all duration-500">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-[11px] font-bold text-[#9B9DFB]/50 tracking-[0.1em] uppercase block mb-1">{t('Science')}</span>
+                  <span className="text-[16px] font-semibold text-white/85">{t('Why you can trust the data')}</span>
+                </div>
+                <ArrowRight className="h-4 w-4 text-white/30" />
+              </div>
+            </button>
+          </div>
+          {/* Progress bar */}
+          <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-white/10 relative">
+            <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+          </div>
+
+          {/* Desktop: Platform + Science links */}
+          <div className="hidden md:grid md:grid-cols-2 gap-4 mb-8">
             <button onClick={() => handleNav('/product-overview')} className="group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.06] hover:border-white/[0.14] p-6 transition-all duration-500">
               <div className="flex items-center justify-between">
                 <div>

--- a/components/solutions/ta/TAExperience.tsx
+++ b/components/solutions/ta/TAExperience.tsx
@@ -37,7 +37,7 @@ export default function TAExperience() {
           >
             <div className="flex items-center gap-3 mb-8">
               <div className="w-10 h-10 rounded-full bg-white/[0.06] border border-white/[0.1] flex items-center justify-center">
-                <User className="h-4 w-4 text-[#9B9DFB]/70" strokeWidth={1.5} />
+                <User className="h-5 w-5 md:h-4 md:w-4 text-[#9B9DFB]/70" strokeWidth={1.5} />
               </div>
               <h3 className="text-[16px] md:text-[20px] font-bold text-white/90">{t('Candidate Experience')}</h3>
             </div>
@@ -61,7 +61,7 @@ export default function TAExperience() {
           >
             <div className="flex items-center gap-3 mb-8">
               <div className="w-10 h-10 rounded-full bg-white/[0.06] border border-white/[0.1] flex items-center justify-center">
-                <Briefcase className="h-4 w-4 text-[#9B9DFB]/70" strokeWidth={1.5} />
+                <Briefcase className="h-5 w-5 md:h-4 md:w-4 text-[#9B9DFB]/70" strokeWidth={1.5} />
               </div>
               <h3 className="text-[16px] md:text-[20px] font-bold text-white/90">{t('HR Experience')}</h3>
             </div>

--- a/components/solutions/ta/TAFunnel.tsx
+++ b/components/solutions/ta/TAFunnel.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { motion, useInView, AnimatePresence } from 'framer-motion';
 import { Zap, BarChart3, Plug, FileText, Calendar, MessageSquare, Users, Filter, Trophy, Brain, Search, ArrowDown } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -107,9 +107,9 @@ function ColumnCard({ data, delay, t }) {
     >
       <div className="flex items-center gap-3 mb-6">
         <div className="w-9 h-9 rounded-lg bg-[#4B4DF7]/[0.12] flex items-center justify-center">
-          <Icon className="h-4.5 w-4.5 text-[#9B9DFB]" />
+          <Icon className="h-5 w-5 md:h-4.5 md:w-4.5 text-[#9B9DFB]" />
         </div>
-        <h4 className="text-[14px] font-bold text-[#1A1A2E]/70 tracking-wide">{t(data.title)}</h4>
+        <h4 className="text-[15px] md:text-[14px] font-bold text-[#1A1A2E]/70 tracking-wide">{t(data.title)}</h4>
       </div>
 
       {data.items ? (
@@ -118,11 +118,11 @@ function ColumnCard({ data, delay, t }) {
             const ItemIcon = item.icon;
             return (
               <div key={i} className="flex items-start gap-3">
-                <ItemIcon className="h-4 w-4 text-[#4B4DF7]/40 mt-0.5 shrink-0" />
+                <ItemIcon className="h-5 w-5 md:h-4 md:w-4 text-[#4B4DF7]/40 mt-0.5 shrink-0" />
                 <div>
                   <span className="text-[14px] text-[#1A1A2E]/80 font-medium">{t(item.text)}</span>
                   {item.detail && (
-                    <span className="text-[12px] text-[#1A1A2E]/35 ml-1.5">({t(item.detail)})</span>
+                    <span className="text-[13px] md:text-[12px] text-[#1A1A2E]/35 ml-1.5">({t(item.detail)})</span>
                   )}
                 </div>
               </div>
@@ -131,7 +131,7 @@ function ColumnCard({ data, delay, t }) {
         </div>
       ) : (
         <div>
-          <p className="text-[14px] text-[#1A1A2E]/60 font-semibold mb-5">{t(data.text)}</p>
+          <p className="text-[14px] md:text-[14px] text-[#1A1A2E]/60 font-semibold mb-5">{t(data.text)}</p>
           <div className="grid grid-cols-3 gap-3">
             {data.logos.map((logo) => (
               <div key={logo} className="flex items-center justify-center h-8">
@@ -157,6 +157,19 @@ export default function TAFunnel() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
   const stage = stages[active];
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [active]);
 
   return (
     <section id="ta-funnel" data-testid="ta-funnel" className="section-breathe relative py-20 lg:py-28" ref={ref}>
@@ -217,15 +230,34 @@ export default function TAFunnel() {
         <AnimatePresence mode="wait">
           <motion.div
             key={stage.id}
-            className="grid lg:grid-cols-3 gap-5"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <ColumnCard data={stage.automation} delay={0} t={t} />
-            <ColumnCard data={stage.reporting} delay={0.08} t={t} />
-            <ColumnCard data={stage.integration} delay={0.16} t={t} />
+            {/* Mobile: horizontal scroll */}
+            <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+              <div className="shrink-0 w-[85vw] snap-center">
+                <ColumnCard data={stage.automation} delay={0} t={t} />
+              </div>
+              <div className="shrink-0 w-[85vw] snap-center">
+                <ColumnCard data={stage.reporting} delay={0.08} t={t} />
+              </div>
+              <div className="shrink-0 w-[85vw] snap-center">
+                <ColumnCard data={stage.integration} delay={0.16} t={t} />
+              </div>
+            </div>
+            {/* Progress bar */}
+            <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
+              <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+            </div>
+
+            {/* Desktop */}
+            <div className="hidden md:grid lg:grid-cols-3 gap-5">
+              <ColumnCard data={stage.automation} delay={0} t={t} />
+              <ColumnCard data={stage.reporting} delay={0.08} t={t} />
+              <ColumnCard data={stage.integration} delay={0.16} t={t} />
+            </div>
           </motion.div>
         </AnimatePresence>
       </div>

--- a/components/solutions/ta/TAImpact.tsx
+++ b/components/solutions/ta/TAImpact.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { useLanguage } from '@/i18n/LanguageContext';
 
@@ -13,6 +13,19 @@ export default function TAImpact() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="ta-impact" data-testid="ta-impact" className="relative pb-20 lg:pb-24" style={{ background: '#F5F5FA' }} ref={ref}>
@@ -23,7 +36,28 @@ export default function TAImpact() {
             <span className="italic font-bold gradient-text-on-light">{t('matters')}</span>
           </h2>
         </motion.div>
-        <div className="grid lg:grid-cols-3 gap-px bg-[#4B4DF7]/[0.06] rounded-2xl overflow-hidden">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {kpis.map((k, i) => (
+            <motion.div
+              key={k.value}
+              className="shrink-0 w-[80vw] snap-center rounded-2xl border border-[#4B4DF7]/[0.06] bg-white/70 p-5"
+              initial={{ opacity: 0, y: 30 }}
+              animate={isInView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}
+            >
+              <span className="block mb-5 text-[#1A1A2E]" style={{ fontSize: 'clamp(2.8rem, 5vw, 4.2rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{k.value}</span>
+              <h3 className="text-[18px] font-semibold text-[#1A1A2E]/80 leading-snug mb-4">{t(k.label)} <span className="font-normal text-[#1A1A2E]/50">{t(k.sublabel)}</span></h3>
+            </motion.div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-px bg-[#4B4DF7]/[0.06] rounded-2xl overflow-hidden">
           {kpis.map((k, i) => (
             <motion.div key={k.value} className="bg-[#F5F5FA] p-5 md:p-10 lg:p-12" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}>
               <span className="block mb-5 text-[#1A1A2E]" style={{ fontSize: 'clamp(2.8rem, 5vw, 4.2rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{k.value}</span>

--- a/components/solutions/ta/TAPlaybook.tsx
+++ b/components/solutions/ta/TAPlaybook.tsx
@@ -62,7 +62,7 @@ export default function RecruitmentPlaybook() {
           <h2 className="text-[clamp(1.8rem,3.5vw,2.5rem)] font-bold text-[#1A1A2E] tracking-[-0.02em] mb-3">
             {t('Skillvue is a partner for the recruitment journey')}
           </h2>
-          <p className="text-[16px] text-[#1A1A2E]/[0.4]">{t('Skillvue playbook recruitment process')}</p>
+          <p className="text-[14px] md:text-[16px] text-[#1A1A2E]/[0.4]">{t('Skillvue playbook recruitment process')}</p>
         </motion.div>
 
         {/* Step headers */}
@@ -75,7 +75,7 @@ export default function RecruitmentPlaybook() {
           <div />
           <div className="grid grid-cols-4 gap-2">
             {['Step 1', 'Step 2', 'Step 3', 'Step N'].map((step, i) => (
-              <div key={step} className="py-3 rounded-xl text-center text-[14px] font-semibold text-white" style={{ backgroundColor: '#5E60F2', boxShadow: '0 2px 12px rgba(94,96,242,0.25)' }}>
+              <div key={step} className="py-3 rounded-xl text-center text-[13px] md:text-[14px] font-semibold text-white" style={{ backgroundColor: '#5E60F2', boxShadow: '0 2px 12px rgba(94,96,242,0.25)' }}>
                 {t(step)}
               </div>
             ))}
@@ -93,8 +93,8 @@ export default function RecruitmentPlaybook() {
               transition={{ duration: 0.5, delay: 0.25 + ri * 0.1 }}
             >
               {/* Role label */}
-              <div className="flex items-center pr-6 py-8">
-                <h3 className="text-[18px] font-bold text-[#1A1A2E] leading-tight">{t(row.role)}</h3>
+              <div className="flex items-center pr-4 md:pr-6 py-8">
+                <h3 className="text-[15px] md:text-[18px] font-bold text-[#1A1A2E] leading-tight">{t(row.role)}</h3>
               </div>
 
               {/* Steps + bar + Skillvue */}
@@ -109,7 +109,7 @@ export default function RecruitmentPlaybook() {
                             <circle cx="12" cy="8" r="4" fill="#5E60F2" fillOpacity="0.35" />
                             <path d="M4 20c0-4.4 3.6-8 8-8s8 3.6 8 8" stroke="#5E60F2" strokeOpacity="0.35" strokeWidth="2" strokeLinecap="round" />
                           </svg>
-                          <span className="text-[12px] text-[#1A1A2E]/50 text-center leading-tight">{t(step.label)}</span>
+                          <span className="text-[11px] md:text-[12px] text-[#1A1A2E]/50 text-center leading-tight">{t(step.label)}</span>
                         </>
                       ) : <div className="h-10" />}
                     </div>
@@ -130,7 +130,7 @@ export default function RecruitmentPlaybook() {
                       <path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83" />
                     </svg>
                   </div>
-                  <span className="text-[13px] font-medium text-[#1A1A2E]/60">{t(row.skillvue)}</span>
+                  <span className="text-[12px] md:text-[13px] font-medium text-[#1A1A2E]/60">{t(row.skillvue)}</span>
                 </div>
               </div>
             </motion.div>

--- a/components/solutions/ta/TAProblem.tsx
+++ b/components/solutions/ta/TAProblem.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { useLanguage } from '@/i18n/LanguageContext';
 
@@ -13,6 +13,19 @@ export default function TAProblem() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="ta-problem" data-testid="ta-problem" className="section-breathe relative py-20 lg:py-24 flex items-center"  ref={ref}>
@@ -27,12 +40,34 @@ export default function TAProblem() {
           </p>
         </motion.div>
 
-        {/* Vertical stacked pain cards with large stat on left */}
-        <div className="space-y-4">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
           {pains.map((p, i) => (
             <motion.div
               key={p.stat}
               data-testid={`ta-pain-${i}`}
+              className="shrink-0 w-[80vw] snap-center rounded-2xl border border-[#4B4DF7]/[0.06] bg-white/60 p-5 transition-all duration-500"
+              initial={{ opacity: 0, x: -30 }}
+              animate={isInView ? { opacity: 1, x: 0 } : {}}
+              transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}
+            >
+              <span className="block text-[#1A1A2E] mb-4" style={{ fontSize: 'clamp(1.5rem, 3vw, 2.8rem)', fontWeight: 800, lineHeight: 1.1, letterSpacing: '-0.03em' }}>{p.stat}</span>
+              <h3 className="text-[18px] font-bold text-[#1A1A2E]/80 mb-2">{t(p.title)}</h3>
+              <p className="text-[15px] text-[#1A1A2E]/50 leading-[1.7]">{t(p.desc)}</p>
+            </motion.div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop: Vertical stacked pain cards with large stat on left */}
+        <div className="hidden md:block space-y-4">
+          {pains.map((p, i) => (
+            <motion.div
+              key={p.stat}
+              data-testid={`ta-pain-desktop-${i}`}
               className="group grid grid-cols-12 gap-3 md:gap-6 lg:gap-10 items-center rounded-2xl border border-[#4B4DF7]/[0.06] bg-white/60 hover:bg-white/90 hover:border-[#4B4DF7]/[0.15] p-5 md:p-8 lg:p-10 transition-all duration-500"
               initial={{ opacity: 0, x: -30 }}
               animate={isInView ? { opacity: 1, x: 0 } : {}}

--- a/components/solutions/ta/TAShift.tsx
+++ b/components/solutions/ta/TAShift.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { X, Check } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -24,6 +24,19 @@ export default function TAShift() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <section id="ta-shift" data-testid="ta-shift" className="relative py-20 lg:py-28 flex items-center"  ref={ref}>
@@ -35,7 +48,54 @@ export default function TAShift() {
           </h2>
         </motion.div>
 
-        <div className="grid md:grid-cols-2 gap-6">
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {/* Old playbook */}
+          <motion.div
+            className="shrink-0 w-[85vw] snap-center rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5"
+            initial={{ opacity: 0, x: -20 }}
+            animate={isInView ? { opacity: 1, x: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.15 }}
+          >
+            <span className="text-[13px] font-bold text-white/30 tracking-[0.12em] uppercase mb-6 block">{t('The old playbook')}</span>
+            <div className="space-y-4">
+              {oldItems.map((item) => (
+                <div key={item} className="flex items-start gap-4">
+                  <div className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center shrink-0 mt-0.5">
+                    <X className="h-5 w-5 text-white/30" />
+                  </div>
+                  <p className="text-[14px] text-white/40 leading-[1.7]">{t(item)}</p>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+          {/* With Skillvue */}
+          <motion.div
+            className="shrink-0 w-[85vw] snap-center rounded-2xl border border-[#4B4DF7]/[0.15] bg-white/[0.06] p-5"
+            initial={{ opacity: 0, x: 20 }}
+            animate={isInView ? { opacity: 1, x: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.25 }}
+          >
+            <span className="text-[13px] font-bold text-[#9B9DFB]/[0.65] tracking-[0.12em] uppercase mb-6 block">{t('With Skillvue')}</span>
+            <div className="space-y-4">
+              {newItems.map((item) => (
+                <div key={item} className="flex items-start gap-4">
+                  <div className="w-8 h-8 rounded-full bg-[#4B4DF7]/[0.12] flex items-center justify-center shrink-0 mt-0.5">
+                    <Check className="h-5 w-5 text-[#9B9DFB]" />
+                  </div>
+                  <p className="text-[14px] text-white/[0.65] leading-[1.7]">{t(item)}</p>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        </div>
+
+        {/* Desktop */}
+        <div className="hidden md:grid md:grid-cols-2 gap-6">
           {/* Old playbook */}
           <motion.div
             className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 md:p-10 lg:p-14"
@@ -48,7 +108,7 @@ export default function TAShift() {
               {oldItems.map((item) => (
                 <div key={item} className="flex items-start gap-4">
                   <div className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center shrink-0 mt-0.5">
-                    <X className="h-4 w-4 text-white/30" />
+                    <X className="h-5 w-5 md:h-4 md:w-4 text-white/30" />
                   </div>
                   <p className="text-[14px] md:text-[17px] text-white/40 leading-[1.7]">{t(item)}</p>
                 </div>
@@ -68,7 +128,7 @@ export default function TAShift() {
               {newItems.map((item) => (
                 <div key={item} className="flex items-start gap-4">
                   <div className="w-8 h-8 rounded-full bg-[#4B4DF7]/[0.12] flex items-center justify-center shrink-0 mt-0.5">
-                    <Check className="h-4 w-4 text-[#9B9DFB]" />
+                    <Check className="h-5 w-5 md:h-4 md:w-4 text-[#9B9DFB]" />
                   </div>
                   <p className="text-[14px] md:text-[17px] text-white/[0.65] leading-[1.7]">{t(item)}</p>
                 </div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,6 +37,9 @@ function HreflangTags() {
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <LanguageProvider>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+      </Head>
       <HreflangTags />
       <div className="min-h-screen">
         {/* Animated flowing background. fixed */}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,6 +31,12 @@ html, body {
   display: none;
 }
 
+/* Skillvue-branded scroll progress bar fill */
+.skillvue-scroll-fill {
+  background: linear-gradient(90deg, #4B4DF7 0%, #7577F8 50%, #FF5F24 100%);
+  box-shadow: 0 0 8px rgba(75, 77, 247, 0.35);
+}
+
 #emergent-badge,
 [id="emergent-badge"],
 a[href*="emergent"] {


### PR DESCRIPTION
## Summary

- Critical fix: add viewport meta tag in `_app.tsx` (was missing, causing mobile devices to render at desktop width)
- Comprehensive mobile-first responsive optimizations across homepage, product, science, and solutions pages
- Convert all card grids on mobile to horizontal scroll with thumb-in-track progress indicator (Skillvue gradient fill)
- Increase mobile text sizes for readability on real phones (10-11px → 12-14px baseline)
- Add hero product video via YouTube embed with autoplay, click-to-unmute overlay, and quality-forcing tricks (1920x1080 native render + CSS scale)
- Hide YouTube branding via overflow-hidden wrapper, clean play state with no UI clutter
- Replace WebGL GradientBlinds animation with flat #0d0d1f bg consistent with site
- Restore footer desktop block layout while keeping mobile flex-wrap inline links
- Remove Loro Piana logo from hero trust bar marquee + CTA "Our Customers" grid
- Clean up: `git filter-repo` removed 85MB legacy video from repo history

## Test plan

- [ ] Mobile (390px / iPhone): viewport renders correctly, no horizontal scroll, all card sections scrollable with progress bar
- [ ] Tablet (768px): grid layouts engage, cards visible without scroll
- [ ] Desktop (1280px+): all sections render exactly as before, footer link columns intact
- [ ] Hero video autoplays muted, click toggles audio, no YouTube branding visible
- [ ] Reduce-motion preference respected
- [ ] Light/dark sections render progress bars with appropriate contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)