### PR TITLE
Mobile UX: scroll-progress bar overhaul + per-section layout fixes

### DIFF
--- a/components/customers/CustomersROI.tsx
+++ b/components/customers/CustomersROI.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -14,28 +14,65 @@ export default function CustomersROI() {
   const { t, lang } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (s, i) => (
+    <motion.div
+      key={s.value}
+      className="bg-[#F7F7F7] rounded-2xl md:rounded-none p-6 md:p-10 lg:p-12 h-full"
+      initial={{ opacity: 0, y: 30 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}
+    >
+      <span className="block mb-3 md:mb-5 text-[#121212]" style={{ fontSize: 'clamp(2.4rem, 5vw, 4.2rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{t(s.value)}</span>
+      <h3 className="text-[16px] md:text-[18px] font-semibold text-[#121212]/80 leading-snug mb-2">{t(s.label)}</h3>
+      <p className="text-[13px] md:text-[14px] text-[#121212]/50 leading-relaxed">{t(s.sub)}</p>
+    </motion.div>
+  );
 
   return (
     <section id="customers-roi" data-testid="customers-roi" className="section-breathe relative py-20 lg:py-24" ref={ref}>
-      <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
-        <motion.div className="mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
+      <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
+        <motion.div className="mb-12 md:mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#121212]">
             {t('People are your biggest cost.')}{' '}
             <span className="font-bold gradient-text-warm-on-light">{t('They can also be your biggest return.')}</span>
           </h2>
         </motion.div>
-        <div className="grid lg:grid-cols-3 gap-px bg-[#4B4DF7]/[0.06] rounded-2xl overflow-hidden mb-10">
+
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
           {stats.map((s, i) => (
-            <motion.div key={s.value} className="bg-[#F7F7F7] p-10 lg:p-12" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}>
-              <span className="block mb-5 text-[#121212]" style={{ fontSize: 'clamp(2.8rem, 5vw, 4.2rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{t(s.value)}</span>
-              <h3 className="text-[18px] font-semibold text-[#121212]/80 leading-snug mb-2">{t(s.label)}</h3>
-              <p className="text-[14px] text-[#121212]/50 leading-relaxed">{t(s.sub)}</p>
-            </motion.div>
+            <div key={s.value} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(s, i)}
+            </div>
           ))}
         </div>
-        <motion.div className="flex items-center justify-between" initial={{ opacity: 0 }} animate={isInView ? { opacity: 1 } : {}} transition={{ duration: 0.5, delay: 0.5 }}>
-          <p className="text-[15px] text-[#121212]/50">{t('Every other budget line has an ROI framework. These companies proved talent spend can too.')}</p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} className="group inline-flex items-center gap-3 px-7 py-3.5 text-[13px] font-semibold tracking-wide rounded-full border border-[#4B4DF7]/15 text-[#4B4DF7] hover:bg-[#4B4DF7]/[0.06] transition-all duration-500 shrink-0">
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 mb-10 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
+
+        {/* Desktop: bordered grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-px bg-[#4B4DF7]/[0.06] rounded-2xl overflow-hidden mb-10">
+          {stats.map((s, i) => renderCard(s, i))}
+        </div>
+
+        <motion.div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-6" initial={{ opacity: 0 }} animate={isInView ? { opacity: 1 } : {}} transition={{ duration: 0.5, delay: 0.5 }}>
+          <p className="text-[14px] md:text-[15px] text-[#121212]/50">{t('Every other budget line has an ROI framework. These companies proved talent spend can too.')}</p>
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} className="group inline-flex items-center justify-center gap-3 px-7 py-3.5 text-[13px] font-semibold tracking-wide rounded-full border border-[#4B4DF7]/15 text-[#4B4DF7] hover:bg-[#4B4DF7]/[0.06] transition-all duration-500 shrink-0">
             {t('Book a Demo')}
             <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform duration-300" />
           </a>

--- a/components/landing/CustomerStoriesSection.tsx
+++ b/components/landing/CustomerStoriesSection.tsx
@@ -100,10 +100,10 @@ export default function CustomerStoriesSection() {
         </div>
 
         {/* Progress bar — mobile only */}
-        <div className="md:hidden mx-auto -mt-4 mb-8 w-36 h-1 rounded-full bg-white/10 relative">
+        <div className="md:hidden mx-auto -mt-4 mb-8 w-48 h-1.5 rounded-full bg-white/20 relative">
           <div
             className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
-            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+            style={{ left: `${scrollProgress * 0.65}%` }}
           />
         </div>
 

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -184,10 +184,10 @@ export default function HowItWorksSection() {
         </div>
 
         {/* Progress bar — mobile only */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
           <div
             className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
-            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+            style={{ left: `${scrollProgress * 0.65}%` }}
           />
         </div>
       </div>

--- a/components/landing/ProblemSection.tsx
+++ b/components/landing/ProblemSection.tsx
@@ -118,10 +118,10 @@ export default function ProblemSection() {
         </div>
 
         {/* Progress bar — mobile only */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
           <div
             className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
-            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+            style={{ left: `${scrollProgress * 0.65}%` }}
           />
         </div>
       </div>

--- a/components/landing/ROISection.tsx
+++ b/components/landing/ROISection.tsx
@@ -114,10 +114,10 @@ export default function ROISection() {
         </div>
 
         {/* Progress bar — mobile only */}
-        <div className="md:hidden mx-auto -mt-6 mb-10 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
+        <div className="md:hidden mx-auto -mt-6 mb-10 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
           <div
             className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
-            style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }}
+            style={{ left: `${scrollProgress * 0.65}%` }}
           />
         </div>
       </div>

--- a/components/landing/SolutionSection.tsx
+++ b/components/landing/SolutionSection.tsx
@@ -131,10 +131,10 @@ export default function SolutionSection() {
         </div>
 
         {/* Mobile scroll indicator — thumb-in-track (native scrollbar style) */}
-        <div className="md:hidden mx-auto mt-5 w-36 h-1 rounded-full bg-white/10 relative">
+        <div className="md:hidden mx-auto mt-5 w-48 h-1.5 rounded-full bg-white/20 relative">
           <div
             className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill"
-            style={{ left: `${scrollProgress * 0.65}%`, transition: 'left 200ms ease-out' }}
+            style={{ left: `${scrollProgress * 0.65}%` }}
           />
         </div>
 

--- a/components/product/AssessmentFormats.tsx
+++ b/components/product/AssessmentFormats.tsx
@@ -122,8 +122,8 @@ export default function AssessmentFormats() {
                 })}
               </div>
               {/* Progress bar */}
-              <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
-                <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgresses[i] * 0.65}%`, transition: "left 200ms ease-out" }} />
+              <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-white/20 relative">
+                <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgresses[i] * 0.65}%` }} />
               </div>
 
               {/* Desktop: existing grid */}

--- a/components/product/EnterpriseTrust.tsx
+++ b/components/product/EnterpriseTrust.tsx
@@ -80,8 +80,8 @@ export default function EnterpriseTrust() {
           })}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 mb-8 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop: existing grid */}

--- a/components/product/WhatSkillvueDoes.tsx
+++ b/components/product/WhatSkillvueDoes.tsx
@@ -101,8 +101,8 @@ export default function WhatSkillvueDoes() {
           })}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop: existing grid */}

--- a/components/product/WhatWeAssess.tsx
+++ b/components/product/WhatWeAssess.tsx
@@ -65,8 +65,8 @@ export default function WhatWeAssess() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 mb-8 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop: existing grid */}

--- a/components/science/ResponsibleAI.tsx
+++ b/components/science/ResponsibleAI.tsx
@@ -72,8 +72,8 @@ export default function ResponsibleAI() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 mb-12 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 mb-12 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop grid */}

--- a/components/science/ScienceTeam.tsx
+++ b/components/science/ScienceTeam.tsx
@@ -120,8 +120,8 @@ export default function ScienceTeam() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Team members - Desktop grid */}

--- a/components/science/ScientificPillars.tsx
+++ b/components/science/ScientificPillars.tsx
@@ -69,8 +69,8 @@ export default function ScientificPillars() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop grid */}

--- a/components/shared/SolutionCrossLinks.tsx
+++ b/components/shared/SolutionCrossLinks.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useRouter } from 'next/router';
@@ -22,48 +22,30 @@ export default function SolutionCrossLinks({ currentPath }) {
 
   const handleNav = (path) => { router.push(path); window.scrollTo(0, 0); };
 
-  const scrollRef = useRef(null);
-  const [scrollProgress, setScrollProgress] = useState(0);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      const max = el.scrollWidth - el.clientWidth;
-      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
-      setScrollProgress(pct);
-    };
-    el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
-  }, []);
-
   return (
     <section className="relative pt-20 pb-16 lg:pt-24 lg:pb-20" ref={ref}>
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <motion.div initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.6 }}>
-          {/* Mobile: horizontal scroll for Platform + Science */}
-          <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
-            <button onClick={() => handleNav('/product-overview')} className="shrink-0 w-[80vw] snap-center group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 transition-all duration-500">
-              <div className="flex items-center justify-between">
+          {/* Mobile: vertical stack for Platform + Science */}
+          <div className="md:hidden flex flex-col gap-3 mb-6">
+            <button onClick={() => handleNav('/product-overview')} className="group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] active:bg-white/[0.06] p-5 transition-all duration-300">
+              <div className="flex items-center justify-between gap-3">
                 <div>
-                  <span className="text-[11px] font-bold text-[#9B9DFB]/50 tracking-[0.1em] uppercase block mb-1">{t('Platform')}</span>
-                  <span className="text-[16px] font-semibold text-white/85">{t('See how the full product works')}</span>
+                  <span className="text-[11px] font-bold text-[#9B9DFB]/60 tracking-[0.12em] uppercase block mb-1">{t('Platform')}</span>
+                  <span className="text-[15px] font-semibold text-white/85 leading-snug">{t('See how the full product works')}</span>
                 </div>
-                <ArrowRight className="h-4 w-4 text-white/30" />
+                <ArrowRight className="h-4 w-4 text-white/30 shrink-0" />
               </div>
             </button>
-            <button onClick={() => handleNav('/science')} className="shrink-0 w-[80vw] snap-center group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 transition-all duration-500">
-              <div className="flex items-center justify-between">
+            <button onClick={() => handleNav('/science')} className="group text-left rounded-xl border border-white/[0.08] bg-white/[0.03] active:bg-white/[0.06] p-5 transition-all duration-300">
+              <div className="flex items-center justify-between gap-3">
                 <div>
-                  <span className="text-[11px] font-bold text-[#9B9DFB]/50 tracking-[0.1em] uppercase block mb-1">{t('Science')}</span>
-                  <span className="text-[16px] font-semibold text-white/85">{t('Why you can trust the data')}</span>
+                  <span className="text-[11px] font-bold text-[#9B9DFB]/60 tracking-[0.12em] uppercase block mb-1">{t('Science')}</span>
+                  <span className="text-[15px] font-semibold text-white/85 leading-snug">{t('Why you can trust the data')}</span>
                 </div>
-                <ArrowRight className="h-4 w-4 text-white/30" />
+                <ArrowRight className="h-4 w-4 text-white/30 shrink-0" />
               </div>
             </button>
-          </div>
-          {/* Progress bar */}
-          <div className="md:hidden mx-auto mt-4 mb-8 w-36 h-1 rounded-full bg-white/10 relative">
-            <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
           </div>
 
           {/* Desktop: Platform + Science links */}

--- a/components/solutions/im/IMProblem.tsx
+++ b/components/solutions/im/IMProblem.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { EyeOff, AlertTriangle, Scale } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -14,39 +14,67 @@ export default function IMProblem() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div
+        key={p.title}
+        data-testid={`im-pain-${i}`}
+        className="group rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/90 p-6 md:p-10 transition-all duration-500 flex flex-col h-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.5, delay: 0.1 + i * 0.1 }}
+      >
+        <div className="flex items-center justify-between mb-6 md:mb-8">
+          <span className="text-[#121212]" style={{ fontSize: 'clamp(2rem, 4vw, 3rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{p.stat}</span>
+          <Icon className="h-6 w-6 text-[#4B4DF7]/30" strokeWidth={1.5} />
+        </div>
+        <h3 className="text-[18px] font-bold text-[#121212] mb-2 md:mb-3">{t(p.title)}</h3>
+        <p className="text-[14px] md:text-[15px] text-[#121212]/[0.65] leading-[1.75]">{t(p.desc)}</p>
+      </motion.div>
+    );
+  };
 
   return (
     <section id="im-problem" data-testid="im-problem" className="section-breathe relative py-20 lg:py-24" ref={ref}>
-      <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
-        <motion.div className="mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
+      <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
+        <motion.div className="mb-12 md:mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#121212]">
             {t('The blind spots in your')}{' '}
             <span className="font-bold gradient-text-on-light">{t('talent mobility')}</span>
           </h2>
         </motion.div>
 
-        {/* Large stat + icon cards */}
-        <div className="grid lg:grid-cols-3 gap-5">
-          {pains.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div
-                key={p.title}
-                data-testid={`im-pain-${i}`}
-                className="group rounded-2xl border border-[#4B4DF7]/[0.08] hover:border-[#4B4DF7]/[0.18] bg-white/60 hover:bg-white/90 p-10 transition-all duration-500 flex flex-col"
-                initial={{ opacity: 0, y: 30 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.1 + i * 0.1 }}
-              >
-                <div className="flex items-center justify-between mb-8">
-                  <span className="text-[#121212]" style={{ fontSize: '3rem', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}>{p.stat}</span>
-                  <Icon className="h-6 w-6 text-[#4B4DF7]/30" strokeWidth={1.5} />
-                </div>
-                <h3 className="text-[18px] font-bold text-[#121212] mb-3">{t(p.title)}</h3>
-                <p className="text-[15px] text-[#121212]/[0.65] leading-[1.75]">{t(p.desc)}</p>
-              </motion.div>
-            );
-          })}
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pains.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
+
+        {/* Desktop: grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-5">
+          {pains.map((p, i) => renderCard(p, i))}
         </div>
       </div>
     </section>

--- a/components/solutions/ld/LDHowSolves.tsx
+++ b/components/solutions/ld/LDHowSolves.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Search, Layers, TrendingUp } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -35,49 +35,78 @@ export default function LDHowSolves() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div
+        key={p.title}
+        className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-6 md:p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col h-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
+      >
+        <div className="flex items-center justify-between mb-6 md:mb-8">
+          <span className="text-[36px] md:text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
+          <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
+            <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
+          </div>
+        </div>
+
+        <h3 className="text-[18px] md:text-[20px] font-bold text-[#121212] mb-2 md:mb-3 leading-tight">{t(p.title)}</h3>
+        <p className="text-[14px] md:text-[15px] text-[#121212]/[0.5] leading-[1.7] mb-5 md:mb-8 flex-1">{t(p.desc)}</p>
+
+        <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-4 md:p-5">
+          <span className="text-[24px] md:text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
+          <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
+        </div>
+      </motion.div>
+    );
+  };
 
   return (
-    <section id="ld-how" data-testid="ld-how" className="section-breathe relative flex items-center" style={{ minHeight: '100vh' }} ref={ref}>
-      <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12 w-full py-20 lg:py-28">
+    <section id="ld-how" data-testid="ld-how" className="section-breathe relative md:flex md:items-center" style={{ minHeight: '100vh' }} ref={ref}>
+      <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-20 lg:py-28">
 
-        <motion.div className="max-w-3xl mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
+        <motion.div className="max-w-3xl mb-12 md:mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">
             {t('Three pillars of')}{' '}
             <span className="font-bold gradient-text-on-light">{t('skill-driven L&D')}</span>
           </h2>
-          <p className="text-[17px] text-[#121212]/[0.45] leading-[1.75]">
+          <p className="text-[15px] md:text-[17px] text-[#121212]/[0.45] leading-[1.75]">
             {t("Stop investing in training that doesn't move the needle. Measure gaps, design programs, and track impact with objective data.")}
           </p>
         </motion.div>
 
-        <div className="grid lg:grid-cols-3 gap-5">
-          {pillars.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div
-                key={p.title}
-                className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col"
-                initial={{ opacity: 0, y: 30 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
-              >
-                <div className="flex items-center justify-between mb-8">
-                  <span className="text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
-                  <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
-                    <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
-                  </div>
-                </div>
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pillars.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
 
-                <h3 className="text-[20px] font-bold text-[#121212] mb-3 leading-tight">{t(p.title)}</h3>
-                <p className="text-[15px] text-[#121212]/[0.5] leading-[1.75] mb-8 flex-1">{t(p.desc)}</p>
-
-                <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-5">
-                  <span className="text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
-                  <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
-                </div>
-              </motion.div>
-            );
-          })}
+        {/* Desktop: grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-5">
+          {pillars.map((p, i) => renderCard(p, i))}
         </div>
       </div>
     </section>

--- a/components/solutions/ld/LDImpact.tsx
+++ b/components/solutions/ld/LDImpact.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { Zap, Target, TrendingUp } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -32,62 +32,85 @@ export default function LDImpact() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (k, i) => {
+    const Icon = k.icon;
+    return (
+      <motion.div
+        key={k.value}
+        className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-6 md:p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col h-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}
+      >
+        <div className="flex items-center justify-between mb-5 md:mb-6">
+          <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
+            <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
+          </div>
+        </div>
+
+        <span
+          className="block mb-2 text-[#121212]"
+          style={{ fontSize: 'clamp(2rem, 4vw, 3.5rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}
+        >
+          {t(k.value)}
+        </span>
+
+        <h3 className="text-[15px] md:text-[17px] font-semibold text-[#121212]/80 leading-snug mb-1.5">
+          {t(k.label)} <span className="font-normal text-[#121212]/40">{t(k.sublabel)}</span>
+        </h3>
+
+        <div className="w-12 h-px bg-[#4B4DF7]/[0.15] my-4 md:my-5" />
+
+        <p className="text-[14px] text-[#121212]/[0.45] leading-[1.75] flex-1">{t(k.detail)}</p>
+      </motion.div>
+    );
+  };
 
   return (
-    <section id="ld-impact" data-testid="ld-impact" className="section-breathe relative flex items-center" style={{ minHeight: '100vh' }} ref={ref}>
-      <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12 w-full py-20 lg:py-28">
+    <section id="ld-impact" data-testid="ld-impact" className="section-breathe relative md:flex md:items-center" style={{ minHeight: '100vh' }} ref={ref}>
+      <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-20 lg:py-28">
 
         {/* Header */}
-        <motion.div className="text-center mb-16 lg:mb-20" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
+        <motion.div className="text-center mb-12 md:mb-16 lg:mb-20" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">
             {t('Measurable impact on')}{' '}
             <span className="font-bold gradient-text-on-light">{t('L&D outcomes')}</span>
           </h2>
-          <p className="text-[17px] text-[#121212]/[0.45] leading-[1.75] max-w-2xl mx-auto">
+          <p className="text-[15px] md:text-[17px] text-[#121212]/[0.45] leading-[1.75] max-w-2xl mx-auto">
             {t('When learning investments are driven by objective skill data, the results speak for themselves.')}
           </p>
         </motion.div>
 
-        {/* KPI cards */}
-        <div className="grid lg:grid-cols-3 gap-5">
-          {kpis.map((k, i) => {
-            const Icon = k.icon;
-            return (
-              <motion.div
-                key={k.value}
-                className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col"
-                initial={{ opacity: 0, y: 30 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.15 + i * 0.12 }}
-              >
-                {/* Top: icon */}
-                <div className="flex items-center justify-between mb-6">
-                  <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
-                    <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
-                  </div>
-                </div>
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {kpis.map((k, i) => (
+            <div key={k.value} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(k, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
 
-                {/* Big stat */}
-                <span
-                  className="block mb-2 text-[#121212]"
-                  style={{ fontSize: 'clamp(2.5rem, 4vw, 3.5rem)', fontWeight: 800, lineHeight: 1, letterSpacing: '-0.03em' }}
-                >
-                  {t(k.value)}
-                </span>
-
-                {/* Label */}
-                <h3 className="text-[17px] font-semibold text-[#121212]/80 leading-snug mb-1.5">
-                  {t(k.label)} <span className="font-normal text-[#121212]/40">{t(k.sublabel)}</span>
-                </h3>
-
-                {/* Divider */}
-                <div className="w-12 h-px bg-[#4B4DF7]/[0.15] my-5" />
-
-                {/* Detail text */}
-                <p className="text-[14px] text-[#121212]/[0.45] leading-[1.75] flex-1">{t(k.detail)}</p>
-              </motion.div>
-            );
-          })}
+        {/* Desktop: grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-5">
+          {kpis.map((k, i) => renderCard(k, i))}
         </div>
       </div>
     </section>

--- a/components/solutions/pm/PMProblem.tsx
+++ b/components/solutions/pm/PMProblem.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { UserX, GitCompare, HelpCircle } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -35,9 +35,51 @@ export default function PMProblem() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div
+        key={p.title}
+        data-testid={`pm-pain-${i}`}
+        className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-6 md:p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col h-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
+      >
+        <div className="flex items-center justify-between mb-6 md:mb-8">
+          <span className="text-[36px] md:text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
+          <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
+            <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
+          </div>
+        </div>
+
+        <h3 className="text-[18px] md:text-[20px] font-bold text-[#121212] mb-2 md:mb-3 leading-tight">{t(p.title)}</h3>
+        <p className="text-[14px] md:text-[15px] text-[#121212]/[0.5] leading-[1.7] mb-5 md:mb-8 flex-1">{t(p.desc)}</p>
+
+        <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-4 md:p-5">
+          <span className="text-[24px] md:text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
+          <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
+        </div>
+      </motion.div>
+    );
+  };
 
   return (
-    <section id="pm-problem" data-testid="pm-problem" className="section-breathe relative flex items-center" style={{ minHeight: '100vh' }} ref={ref}>
+    <section id="pm-problem" data-testid="pm-problem" className="section-breathe relative md:flex md:items-center" style={{ minHeight: '100vh' }} ref={ref}>
       <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12 w-full py-20 lg:py-28">
 
         {/* Header row: title + subtitle */}
@@ -51,39 +93,22 @@ export default function PMProblem() {
           </p>
         </motion.div>
 
-        {/* Cards with stat + content */}
-        <div className="grid lg:grid-cols-3 gap-5">
-          {pains.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div
-                key={p.title}
-                data-testid={`pm-pain-${i}`}
-                className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col"
-                initial={{ opacity: 0, y: 30 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
-              >
-                {/* Top: number + icon */}
-                <div className="flex items-center justify-between mb-8">
-                  <span className="text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
-                  <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
-                    <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
-                  </div>
-                </div>
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {pains.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
 
-                {/* Title + desc */}
-                <h3 className="text-[20px] font-bold text-[#121212] mb-3 leading-tight">{t(p.title)}</h3>
-                <p className="text-[15px] text-[#121212]/[0.5] leading-[1.75] mb-8 flex-1">{t(p.desc)}</p>
-
-                {/* Bottom stat highlight */}
-                <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-5">
-                  <span className="text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
-                  <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
-                </div>
-              </motion.div>
-            );
-          })}
+        {/* Desktop: grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-5">
+          {pains.map((p, i) => renderCard(p, i))}
         </div>
       </div>
     </section>

--- a/components/solutions/pr/PRConsulting.tsx
+++ b/components/solutions/pr/PRConsulting.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { TrendingUp, Award, RefreshCw } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -35,54 +35,79 @@ export default function PRConsulting() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderCard = (p, i) => {
+    const Icon = p.icon;
+    return (
+      <motion.div
+        key={p.title}
+        className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-6 md:p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col h-full"
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
+      >
+        <div className="flex items-center justify-between mb-6 md:mb-8">
+          <span className="text-[36px] md:text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
+          <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
+            <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
+          </div>
+        </div>
+
+        <h3 className="text-[18px] md:text-[20px] font-bold text-[#121212] mb-2 md:mb-3 leading-tight">{t(p.title)}</h3>
+        <p className="text-[14px] md:text-[15px] text-[#121212]/[0.5] leading-[1.7] mb-5 md:mb-8 flex-1">{t(p.desc)}</p>
+
+        <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-4 md:p-5">
+          <span className="text-[24px] md:text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
+          <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
+        </div>
+      </motion.div>
+    );
+  };
 
   return (
-    <section id="pr-consulting" data-testid="pr-consulting" className="section-breathe relative flex items-center" style={{ minHeight: '100vh' }} ref={ref}>
-      <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12 w-full py-20 lg:py-28">
+    <section id="pr-consulting" data-testid="pr-consulting" className="section-breathe relative md:flex md:items-center" style={{ minHeight: '100vh' }} ref={ref}>
+      <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-20 lg:py-28">
 
         {/* Header */}
-        <motion.div className="max-w-3xl mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
+        <motion.div className="max-w-3xl mb-12 md:mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">
             {t('Built for organizations where people are')}{' '}
             <span className="font-bold gradient-text-on-light">{t('the product')}</span>
           </h2>
-          <p className="text-[17px] text-[#121212]/[0.45] leading-[1.75] max-w-2xl">
+          <p className="text-[15px] md:text-[17px] text-[#121212]/[0.45] leading-[1.75] max-w-2xl">
             {t('In consulting, professional services, and project-driven organizations, the quality of every engagement depends on the quality of the team. Skillvue gives you objective skills data to staff smarter.')}
           </p>
         </motion.div>
 
-        {/* Cards */}
-        <div className="grid lg:grid-cols-3 gap-5">
-          {points.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <motion.div
-                key={p.title}
-                className="group rounded-2xl border border-[#121212]/[0.08] bg-white p-8 lg:p-10 hover:border-[#4B4DF7]/[0.18] hover:shadow-xl hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 flex flex-col"
-                initial={{ opacity: 0, y: 30 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.5, delay: 0.1 + i * 0.12 }}
-              >
-                {/* Top: number + icon */}
-                <div className="flex items-center justify-between mb-8">
-                  <span className="text-[42px] font-bold text-[#121212]/[0.1] leading-none tracking-[-0.03em]">{p.num}</span>
-                  <div className="w-11 h-11 rounded-xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.08] flex items-center justify-center group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.15] transition-all duration-500">
-                    <Icon className="h-5 w-5 text-[#4B4DF7]/50 group-hover:text-[#4B4DF7] transition-colors duration-500" strokeWidth={1.5} />
-                  </div>
-                </div>
+        {/* Mobile: horizontal scroll */}
+        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+          {points.map((p, i) => (
+            <div key={p.title} className="shrink-0 w-[80vw] snap-center">
+              {renderCard(p, i)}
+            </div>
+          ))}
+        </div>
+        {/* Progress bar */}
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+        </div>
 
-                {/* Title + desc */}
-                <h3 className="text-[20px] font-bold text-[#121212] mb-3 leading-tight">{t(p.title)}</h3>
-                <p className="text-[15px] text-[#121212]/[0.5] leading-[1.75] mb-8 flex-1">{t(p.desc)}</p>
-
-                {/* Bottom stat */}
-                <div className="rounded-xl bg-[#F7F7F7] border border-[#121212]/[0.06] p-5">
-                  <span className="text-[28px] font-bold text-[#121212] leading-none tracking-[-0.02em] block mb-1.5">{p.stat}</span>
-                  <span className="text-[12px] text-[#121212]/[0.4] leading-[1.5]">{t(p.statLabel)}</span>
-                </div>
-              </motion.div>
-            );
-          })}
+        {/* Desktop: grid */}
+        <div className="hidden md:grid lg:grid-cols-3 gap-5">
+          {points.map((p, i) => renderCard(p, i))}
         </div>
       </div>
     </section>

--- a/components/solutions/ta/TAFunnel.tsx
+++ b/components/solutions/ta/TAFunnel.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { motion, useInView, AnimatePresence } from 'framer-motion';
 import { Zap, BarChart3, Plug, FileText, Calendar, MessageSquare, Users, Filter, Trophy, Brain, Search, ArrowDown } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
@@ -157,19 +157,6 @@ export default function TAFunnel() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-80px' });
   const stage = stages[active];
-  const scrollRef = useRef(null);
-  const [scrollProgress, setScrollProgress] = useState(0);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      const max = el.scrollWidth - el.clientWidth;
-      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
-      setScrollProgress(pct);
-    };
-    el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
-  }, [active]);
 
   return (
     <section id="ta-funnel" data-testid="ta-funnel" className="section-breathe relative py-20 lg:py-28" ref={ref}>
@@ -188,9 +175,9 @@ export default function TAFunnel() {
           </h2>
         </motion.div>
 
-        {/* Stage selector — funnel visual */}
+        {/* Stage selector — compact pills on mobile, full cards on desktop */}
         <motion.div
-          className="flex flex-col sm:flex-row items-stretch gap-2 mb-12"
+          className="grid grid-cols-3 gap-2 md:flex md:items-stretch md:gap-2 mb-8 md:mb-12"
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.1 }}
@@ -200,21 +187,21 @@ export default function TAFunnel() {
               key={s.id}
               onClick={() => setActive(i)}
               data-testid={`funnel-${s.id}`}
-              className={`flex-1 relative rounded-xl px-6 py-5 text-left transition-all duration-500 border ${
+              className={`md:flex-1 relative rounded-xl px-3 py-3 md:px-6 md:py-5 text-left transition-all duration-500 border ${
                 i === active
                   ? 'bg-[#1A1A2E] border-[#1A1A2E]'
                   : 'bg-white border-[#1A1A2E]/[0.06] hover:bg-[#1A1A2E]/[0.04] hover:border-[#1A1A2E]/[0.12]'
               }`}
             >
-              <span className={`text-[11px] font-bold tracking-[0.15em] uppercase block mb-1 ${i === active ? 'text-[#9B9DFB]' : 'text-[#1A1A2E]/25'}`}>
+              <span className={`text-[9px] md:text-[11px] font-bold tracking-[0.12em] md:tracking-[0.15em] uppercase block mb-0.5 md:mb-1 ${i === active ? 'text-[#9B9DFB]' : 'text-[#1A1A2E]/25'}`}>
                 {t('Stage')} {s.number}
               </span>
-              <span className={`text-[18px] font-bold ${i === active ? 'text-white' : 'text-[#1A1A2E]/50'}`}>
+              <span className={`text-[13px] md:text-[18px] font-bold leading-tight ${i === active ? 'text-white' : 'text-[#1A1A2E]/50'}`}>
                 {t(s.label)}
               </span>
               {i === active && (
                 <motion.div
-                  className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full"
+                  className="hidden md:block absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   transition={{ duration: 0.3 }}
@@ -235,21 +222,11 @@ export default function TAFunnel() {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            {/* Mobile: horizontal scroll */}
-            <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
-              <div className="shrink-0 w-[85vw] snap-center">
-                <ColumnCard data={stage.automation} delay={0} t={t} />
-              </div>
-              <div className="shrink-0 w-[85vw] snap-center">
-                <ColumnCard data={stage.reporting} delay={0.08} t={t} />
-              </div>
-              <div className="shrink-0 w-[85vw] snap-center">
-                <ColumnCard data={stage.integration} delay={0.16} t={t} />
-              </div>
-            </div>
-            {/* Progress bar */}
-            <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
-              <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+            {/* Mobile: vertical stack */}
+            <div className="md:hidden flex flex-col gap-3">
+              <ColumnCard data={stage.automation} delay={0} t={t} />
+              <ColumnCard data={stage.reporting} delay={0.08} t={t} />
+              <ColumnCard data={stage.integration} delay={0.16} t={t} />
             </div>
 
             {/* Desktop */}

--- a/components/solutions/ta/TAImpact.tsx
+++ b/components/solutions/ta/TAImpact.tsx
@@ -52,8 +52,8 @@ export default function TAImpact() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop */}

--- a/components/solutions/ta/TAProblem.tsx
+++ b/components/solutions/ta/TAProblem.tsx
@@ -28,7 +28,7 @@ export default function TAProblem() {
   }, []);
 
   return (
-    <section id="ta-problem" data-testid="ta-problem" className="section-breathe relative py-20 lg:py-24 flex items-center"  ref={ref}>
+    <section id="ta-problem" data-testid="ta-problem" className="section-breathe relative py-20 lg:py-24 md:flex md:items-center"  ref={ref}>
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <motion.div className="max-w-[900px] mb-16" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] mb-8">
@@ -58,8 +58,8 @@ export default function TAProblem() {
           ))}
         </div>
         {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-[#1A1A2E]/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
+        <div className="md:hidden mx-auto mt-4 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
         </div>
 
         {/* Desktop: Vertical stacked pain cards with large stat on left */}

--- a/components/solutions/ta/TAShift.tsx
+++ b/components/solutions/ta/TAShift.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
-import { X, Check } from 'lucide-react';
+import { X, Check, ArrowDown } from 'lucide-react';
 import { useLanguage } from '@/i18n/LanguageContext';
 
 const oldItems = [
@@ -24,22 +24,9 @@ export default function TAShift() {
   const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
-  const scrollRef = useRef(null);
-  const [scrollProgress, setScrollProgress] = useState(0);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      const max = el.scrollWidth - el.clientWidth;
-      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
-      setScrollProgress(pct);
-    };
-    el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
-  }, []);
 
   return (
-    <section id="ta-shift" data-testid="ta-shift" className="relative py-20 lg:py-28 flex items-center"  ref={ref}>
+    <section id="ta-shift" data-testid="ta-shift" className="relative py-20 lg:py-28 md:flex md:items-center"  ref={ref}>
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full">
         <motion.div className="mb-10 md:mb-20" initial={{ opacity: 0, y: 30 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7 }}>
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.03em] text-white/90">
@@ -48,13 +35,13 @@ export default function TAShift() {
           </h2>
         </motion.div>
 
-        {/* Mobile: horizontal scroll */}
-        <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+        {/* Mobile: vertical stack with transition arrow */}
+        <div className="md:hidden flex flex-col gap-4">
           {/* Old playbook */}
           <motion.div
-            className="shrink-0 w-[85vw] snap-center rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5"
-            initial={{ opacity: 0, x: -20 }}
-            animate={isInView ? { opacity: 1, x: 0 } : {}}
+            className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5"
+            initial={{ opacity: 0, y: 20 }}
+            animate={isInView ? { opacity: 1, y: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.15 }}
           >
             <span className="text-[13px] font-bold text-white/30 tracking-[0.12em] uppercase mb-6 block">{t('The old playbook')}</span>
@@ -69,12 +56,27 @@ export default function TAShift() {
               ))}
             </div>
           </motion.div>
+
+          {/* Transition arrow */}
+          <motion.div
+            className="flex items-center justify-center gap-3 py-1"
+            initial={{ opacity: 0 }}
+            animate={isInView ? { opacity: 1 } : {}}
+            transition={{ duration: 0.6, delay: 0.3 }}
+          >
+            <span className="h-px flex-1 bg-gradient-to-r from-transparent to-white/15" />
+            <span className="w-9 h-9 rounded-full flex items-center justify-center bg-[#4B4DF7]/[0.12] border border-[#4B4DF7]/25">
+              <ArrowDown className="h-4 w-4 text-[#9B9DFB]" strokeWidth={2.5} />
+            </span>
+            <span className="h-px flex-1 bg-gradient-to-l from-transparent to-white/15" />
+          </motion.div>
+
           {/* With Skillvue */}
           <motion.div
-            className="shrink-0 w-[85vw] snap-center rounded-2xl border border-[#4B4DF7]/[0.15] bg-white/[0.06] p-5"
-            initial={{ opacity: 0, x: 20 }}
-            animate={isInView ? { opacity: 1, x: 0 } : {}}
-            transition={{ duration: 0.6, delay: 0.25 }}
+            className="rounded-2xl border border-[#4B4DF7]/[0.15] bg-white/[0.06] p-5"
+            initial={{ opacity: 0, y: 20 }}
+            animate={isInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.4 }}
           >
             <span className="text-[13px] font-bold text-[#9B9DFB]/[0.65] tracking-[0.12em] uppercase mb-6 block">{t('With Skillvue')}</span>
             <div className="space-y-4">
@@ -88,10 +90,6 @@ export default function TAShift() {
               ))}
             </div>
           </motion.div>
-        </div>
-        {/* Progress bar */}
-        <div className="md:hidden mx-auto mt-4 w-36 h-1 rounded-full bg-white/10 relative">
-          <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%`, transition: "left 200ms ease-out" }} />
         </div>
 
         {/* Desktop */}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import Head from 'next/head';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
@@ -30,6 +30,19 @@ export default function AboutPage() {
   const valuesInView = useInView(valuesRef, { once: true, margin: '-100px' });
   const teamRef = useRef(null);
   const teamInView = useInView(teamRef, { once: true, margin: '-100px' });
+  const valuesScrollRef = useRef(null);
+  const [valuesScrollProgress, setValuesScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = valuesScrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setValuesScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <>
@@ -182,32 +195,53 @@ export default function AboutPage() {
         </section>
 
         {/* 6. What Drives Us */}
-        <section className="section-breathe" ref={valuesRef} style={{ minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12 py-16 lg:py-20 w-full">
-            <motion.div className="text-center mb-14" initial={{ opacity: 0, y: 20 }} animate={valuesInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.6 }}>
+        <section className="section-breathe md:flex md:items-center md:min-h-screen" ref={valuesRef}>
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-16 lg:py-20 w-full">
+            <motion.div className="text-center mb-10 md:mb-14" initial={{ opacity: 0, y: 20 }} animate={valuesInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.6 }}>
               <span className="text-[11px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-5 block">{t('Our Values')}</span>
               <h2 className="text-[clamp(1.8rem,3.5vw,2.5rem)] font-bold text-[#121212] tracking-[-0.02em]">{t('What Drives Us')}</h2>
             </motion.div>
-            <div className="grid lg:grid-cols-3 gap-6">
-              {values.map((v, i) => {
+            {(() => {
+              const renderCard = (v, i) => {
                 const Icon = v.icon;
                 return (
                   <motion.div
                     key={v.title}
-                    className="group rounded-2xl border border-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/[0.15] bg-white p-12 lg:p-14 transition-all duration-500 text-center hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04]"
+                    className="group rounded-2xl border border-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/[0.15] bg-white p-8 md:p-12 lg:p-14 transition-all duration-500 text-center hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04] h-full"
                     initial={{ opacity: 0, y: 20 }}
                     animate={valuesInView ? { opacity: 1, y: 0 } : {}}
                     transition={{ duration: 0.5, delay: i * 0.12 }}
                   >
-                    <div className="w-20 h-20 rounded-2xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.1] flex items-center justify-center mx-auto mb-10 group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.2] transition-all duration-500">
-                      <Icon className="h-8 w-8 text-[#4B4DF7]/60 group-hover:text-[#4B4DF7] transition-colors duration-500" />
+                    <div className="w-16 h-16 md:w-20 md:h-20 rounded-2xl bg-[#4B4DF7]/[0.06] border border-[#4B4DF7]/[0.1] flex items-center justify-center mx-auto mb-6 md:mb-10 group-hover:bg-[#4B4DF7]/[0.12] group-hover:border-[#4B4DF7]/[0.2] transition-all duration-500">
+                      <Icon className="h-7 w-7 md:h-8 md:w-8 text-[#4B4DF7]/60 group-hover:text-[#4B4DF7] transition-colors duration-500" />
                     </div>
-                    <h3 className="text-[22px] font-bold text-[#121212] mb-5 leading-tight">{t(v.title)}</h3>
-                    <p className="text-[16px] text-[#121212]/[0.50] leading-[1.85]">{t(v.desc)}</p>
+                    <h3 className="text-[18px] md:text-[22px] font-bold text-[#121212] mb-3 md:mb-5 leading-tight">{t(v.title)}</h3>
+                    <p className="text-[14px] md:text-[16px] text-[#121212]/[0.50] leading-[1.75] md:leading-[1.85]">{t(v.desc)}</p>
                   </motion.div>
                 );
-              })}
-            </div>
+              };
+              return (
+                <>
+                  {/* Mobile: horizontal scroll */}
+                  <div ref={valuesScrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+                    {values.map((v, i) => (
+                      <div key={v.title} className="shrink-0 w-[80vw] snap-center">
+                        {renderCard(v, i)}
+                      </div>
+                    ))}
+                  </div>
+                  {/* Progress bar */}
+                  <div className="md:hidden mx-auto mt-5 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+                    <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${valuesScrollProgress * 0.65}%` }} />
+                  </div>
+
+                  {/* Desktop: grid */}
+                  <div className="hidden md:grid lg:grid-cols-3 gap-6">
+                    {values.map((v, i) => renderCard(v, i))}
+                  </div>
+                </>
+              );
+            })()}
           </div>
         </section>
 

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
 import { motion } from 'framer-motion';
@@ -76,6 +76,53 @@ const articles = [
 export default function BlogPage() {
   const { t, lang } = useLanguage();
   const router = useRouter();
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const renderArticle = (article, i) => {
+    const c = lang === 'it' ? article.it : article.en;
+    return (
+      <motion.article
+        key={article.id}
+        className="group rounded-2xl border border-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/[0.15] bg-white overflow-hidden transition-all duration-500 cursor-pointer hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04] h-full flex flex-col"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5, delay: Math.min(i * 0.06, 0.4) }}
+        data-testid={`blog-article-${article.id}`}
+        onClick={() => { if (article.href) { router.push(article.href); window.scrollTo(0, 0); } }}
+      >
+        <div className="aspect-[16/10] overflow-hidden">
+          <img src={article.image} alt={c.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" />
+        </div>
+        <div className="p-5 md:p-7 flex-1 flex flex-col">
+          <div className="flex items-center gap-3 mb-3 md:mb-4">
+            <span className="inline-flex px-3 py-1 rounded-full text-[11px] font-semibold text-[#4B4DF7] border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide">
+              {c.tag}
+            </span>
+            <span className="text-[12px] text-[#121212]/30">{c.date}</span>
+          </div>
+          <h2 className="text-[16px] md:text-[18px] font-bold text-[#121212] leading-snug mb-3 md:mb-4 group-hover:text-[#4B4DF7] transition-colors duration-300">
+            {c.title}
+          </h2>
+          <span className="text-[13px] font-semibold text-[#4B4DF7] flex items-center gap-1.5 mt-auto md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300">
+            {t('Read more')} <ArrowRight className="h-3.5 w-3.5" />
+          </span>
+        </div>
+      </motion.article>
+    );
+  };
 
   return (
     <>
@@ -112,44 +159,27 @@ export default function BlogPage() {
 
         {/* 2. Article Grid */}
         <section id="articles" className="section-breathe">
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12 py-20 lg:py-28">
-            <motion.div className="mb-12" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.6 }}>
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-28">
+            <motion.div className="mb-8 md:mb-12" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.6 }}>
               <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-bold text-[#121212] tracking-[-0.02em]">{t('All Articles')}</h2>
             </motion.div>
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {articles.map((article, i) => {
-                const c = lang === 'it' ? article.it : article.en;
-                return (
-                  <motion.article
-                    key={article.id}
-                    className="group rounded-2xl border border-[#4B4DF7]/[0.06] hover:border-[#4B4DF7]/[0.15] bg-white overflow-hidden transition-all duration-500 cursor-pointer hover:shadow-lg hover:shadow-[#4B4DF7]/[0.04]"
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true }}
-                    transition={{ duration: 0.5, delay: i * 0.06 }}
-                    data-testid={`blog-article-${article.id}`}
-                    onClick={() => { if (article.href) { router.push(article.href); window.scrollTo(0, 0); } }}
-                  >
-                    <div className="aspect-[16/10] overflow-hidden">
-                      <img src={article.image} alt={c.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" />
-                    </div>
-                    <div className="p-7">
-                      <div className="flex items-center gap-3 mb-4">
-                        <span className="inline-flex px-3 py-1 rounded-full text-[11px] font-semibold text-[#4B4DF7] border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide">
-                          {c.tag}
-                        </span>
-                        <span className="text-[12px] text-[#121212]/30">{c.date}</span>
-                      </div>
-                      <h2 className="text-[18px] font-bold text-[#121212] leading-snug mb-4 group-hover:text-[#4B4DF7] transition-colors duration-300">
-                        {c.title}
-                      </h2>
-                      <span className="text-[13px] font-semibold text-[#4B4DF7] flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                        {t('Read more')} <ArrowRight className="h-3.5 w-3.5" />
-                      </span>
-                    </div>
-                  </motion.article>
-                );
-              })}
+
+            {/* Mobile: horizontal scroll */}
+            <div ref={scrollRef} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+              {articles.map((article, i) => (
+                <div key={article.id} className="shrink-0 w-[80vw] snap-center">
+                  {renderArticle(article, i)}
+                </div>
+              ))}
+            </div>
+            {/* Progress bar */}
+            <div className="md:hidden mx-auto mt-5 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+              <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+            </div>
+
+            {/* Desktop: grid */}
+            <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {articles.map((article, i) => renderArticle(article, i))}
             </div>
           </div>
         </section>

--- a/pages/resources/press.tsx
+++ b/pages/resources/press.tsx
@@ -1,11 +1,36 @@
 // @ts-nocheck
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
 import { motion } from 'framer-motion';
 import { ArrowRight, ArrowUpRight, Download, Mail } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { useLanguage } from '@/i18n/LanguageContext';
+
+function useScrollProgress() {
+  const ref = useRef(null);
+  const [progress, setProgress] = useState(0);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+  return { ref, progress };
+}
+
+function ScrollBar({ progress }) {
+  return (
+    <div className="md:hidden mx-auto mt-5 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+      <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${progress * 0.65}%` }} />
+    </div>
+  );
+}
 
 const pressArticles = [
   {
@@ -141,6 +166,8 @@ const investors = [
 export default function PressPage() {
   const router = useRouter();
   const { t, lang } = useLanguage();
+  const press = useScrollProgress();
+  const pressIt = useScrollProgress();
 
   return (
     <>
@@ -204,13 +231,13 @@ export default function PressPage() {
 
         {/* 2. Press Coverage */}
         <section className="section-breathe py-20 lg:py-28">
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
-              className="mb-12"
+              className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-4 block">
                 {t('Press Coverage')}
@@ -220,53 +247,68 @@ export default function PressPage() {
               </h2>
             </motion.div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-              {pressArticles.map((article, i) => (
+            {(() => {
+              const renderCard = (article, i) => (
                 <motion.a
                   key={article.publication}
                   href={article.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex flex-col justify-between rounded-2xl border border-[#121212]/[0.06] bg-white p-8 hover:border-[#4B4DF7]/[0.18] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500"
+                  className="group flex flex-col justify-between rounded-2xl border border-[#121212]/[0.06] bg-white p-6 md:p-8 hover:border-[#4B4DF7]/[0.18] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 h-full"
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
-                  transition={{ duration: 0.5, delay: i * 0.07 }}
+                  transition={{ duration: 0.5, delay: Math.min(i * 0.07, 0.4) }}
                 >
                   <div>
-                    {/* Logo */}
-                    <div className="mb-6 h-10 flex items-center">
+                    <div className="mb-5 md:mb-6 h-10 flex items-center">
                       <img
                         src={article.logo}
                         alt={article.publication}
                         style={{ height: `${article.logoH}px`, maxWidth: '160px', objectFit: 'contain', objectPosition: 'left center' }}
                       />
                     </div>
-                    {/* Title */}
-                    <p className="text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
+                    <p className="text-[14px] md:text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
                       {article.title}
                     </p>
                   </div>
-                  {/* Arrow */}
-                  <div className="mt-6 flex items-center justify-end">
+                  <div className="mt-5 md:mt-6 flex items-center justify-end">
                     <ArrowUpRight className="h-4 w-4 text-[#4B4DF7]/30 group-hover:text-[#4B4DF7] group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all duration-300" />
                   </div>
                 </motion.a>
-              ))}
-            </div>
+              );
+              return (
+                <>
+                  {/* Mobile: horizontal scroll */}
+                  <div ref={press.ref} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+                    {pressArticles.map((article, i) => (
+                      <div key={article.publication} className="shrink-0 w-[80vw] snap-center">
+                        {renderCard(article, i)}
+                      </div>
+                    ))}
+                  </div>
+                  <ScrollBar progress={press.progress} />
+
+                  {/* Desktop: grid */}
+                  <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-5">
+                    {pressArticles.map((article, i) => renderCard(article, i))}
+                  </div>
+                </>
+              );
+            })()}
           </div>
         </section>
 
         {/* 2b. Italian Press Coverage — only shown in IT */}
         {lang === 'it' && (
           <section className="section-breathe py-16 lg:py-20 border-t border-[#121212]/[0.04]">
-            <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
+            <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="mb-12"
+                className="mb-8 md:mb-12"
               >
                 <span className="text-[11px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-4 block">
                   Stampa italiana
@@ -276,18 +318,18 @@ export default function PressPage() {
                 </h2>
               </motion.div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                {pressArticlesIt.map((article, i) => (
+              {(() => {
+                const renderCard = (article, i) => (
                   <motion.a
                     key={`${article.publication}-${i}`}
                     href={article.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="group flex flex-col justify-between rounded-2xl border border-[#121212]/[0.06] bg-white p-8 hover:border-[#4B4DF7]/[0.18] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500"
+                    className="group flex flex-col justify-between rounded-2xl border border-[#121212]/[0.06] bg-white p-6 md:p-8 hover:border-[#4B4DF7]/[0.18] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.05] transition-all duration-500 h-full"
                     initial={{ opacity: 0, y: 20 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
-                    transition={{ duration: 0.5, delay: i * 0.07 }}
+                    transition={{ duration: 0.5, delay: Math.min(i * 0.07, 0.4) }}
                   >
                     <div>
                       <div className="mb-4">
@@ -295,29 +337,47 @@ export default function PressPage() {
                           {article.publication}
                         </span>
                       </div>
-                      <p className="text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
+                      <p className="text-[14px] md:text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
                         {article.title}
                       </p>
                     </div>
-                    <div className="mt-6 flex items-center justify-end">
+                    <div className="mt-5 md:mt-6 flex items-center justify-end">
                       <ArrowUpRight className="h-4 w-4 text-[#4B4DF7]/30 group-hover:text-[#4B4DF7] group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all duration-300" />
                     </div>
                   </motion.a>
-                ))}
-              </div>
+                );
+                return (
+                  <>
+                    {/* Mobile: horizontal scroll */}
+                    <div ref={pressIt.ref} className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+                      {pressArticlesIt.map((article, i) => (
+                        <div key={`${article.publication}-${i}`} className="shrink-0 w-[80vw] snap-center">
+                          {renderCard(article, i)}
+                        </div>
+                      ))}
+                    </div>
+                    <ScrollBar progress={pressIt.progress} />
+
+                    {/* Desktop: grid */}
+                    <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-5">
+                      {pressArticlesIt.map((article, i) => renderCard(article, i))}
+                    </div>
+                  </>
+                );
+              })()}
             </div>
           </section>
         )}
 
         {/* 3. Interviews */}
         <section className="section-breathe py-16 lg:py-20 border-t border-[#121212]/[0.04]">
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
-              className="mb-12"
+              className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-4 block">
                 {t('Interviews')}
@@ -327,14 +387,14 @@ export default function PressPage() {
               </h2>
             </motion.div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-5 max-w-3xl">
+            <div className="flex flex-col md:grid md:grid-cols-2 gap-3 md:gap-5 md:max-w-3xl">
               {interviews.map((item, i) => (
                 <motion.a
                   key={item.publication}
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex flex-col justify-between rounded-2xl border border-[#4B4DF7]/[0.10] bg-white p-8 hover:border-[#4B4DF7]/[0.25] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.06] transition-all duration-500"
+                  className="group flex flex-col justify-between rounded-2xl border border-[#4B4DF7]/[0.10] bg-white p-6 md:p-8 hover:border-[#4B4DF7]/[0.25] hover:shadow-lg hover:shadow-[#4B4DF7]/[0.06] transition-all duration-500"
                   style={{ background: 'linear-gradient(135deg, #ffffff 0%, #f8f8ff 100%)' }}
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
@@ -342,18 +402,18 @@ export default function PressPage() {
                   transition={{ duration: 0.5, delay: i * 0.1 }}
                 >
                   <div>
-                    <div className="mb-6 h-10 flex items-center">
+                    <div className="mb-5 md:mb-6 h-10 flex items-center">
                       <img
                         src={item.logo}
                         alt={item.publication}
                         style={{ height: `${item.logoH}px`, maxWidth: '160px', objectFit: 'contain', objectPosition: 'left center' }}
                       />
                     </div>
-                    <p className="text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
+                    <p className="text-[14px] md:text-[15px] font-medium text-[#121212]/80 leading-[1.65] group-hover:text-[#121212] transition-colors duration-300">
                       {item.title}
                     </p>
                   </div>
-                  <div className="mt-6 flex items-center gap-2">
+                  <div className="mt-5 md:mt-6 flex items-center gap-2">
                     <span className="text-[12px] font-semibold text-[#4B4DF7]/50 tracking-[0.08em] uppercase group-hover:text-[#4B4DF7]/80 transition-colors duration-300">
                       {t('Read interview')}
                     </span>
@@ -367,13 +427,13 @@ export default function PressPage() {
 
         {/* 4. Press Releases — dark section */}
         <section className="relative py-20 lg:py-28 bg-black">
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
-              className="mb-12"
+              className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7]/40 tracking-[0.2em] uppercase mb-4 block">
                 {t('Press Releases')}
@@ -383,30 +443,30 @@ export default function PressPage() {
               </h2>
             </motion.div>
 
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3 md:gap-4">
               {pressReleases.map((release, i) => (
                 <motion.a
                   key={release.title}
                   href={lang === 'it' && release.urlIt ? release.urlIt : release.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex items-center justify-between gap-6 rounded-2xl border border-white/[0.06] hover:border-white/[0.14] hover:bg-white/[0.03] px-8 py-6 transition-all duration-300"
+                  className="group flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6 rounded-2xl border border-white/[0.06] hover:border-white/[0.14] hover:bg-white/[0.03] px-5 py-5 md:px-8 md:py-6 transition-all duration-300"
                   initial={{ opacity: 0, y: 16 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.5, delay: i * 0.08 }}
                 >
-                  <div className="flex items-start gap-8 min-w-0">
-                    <span className="text-[13px] text-white/25 shrink-0 mt-0.5 font-mono">{release.date}</span>
-                    <span className="text-[15px] font-medium text-white/70 group-hover:text-white/90 leading-[1.55] transition-colors duration-300">
+                  <div className="flex flex-col md:flex-row md:items-start gap-2 md:gap-8 min-w-0 flex-1">
+                    <span className="text-[11px] md:text-[13px] text-[#4B4DF7]/60 md:text-white/25 shrink-0 md:mt-0.5 font-mono tracking-wider uppercase md:normal-case md:tracking-normal">{release.date}</span>
+                    <span className="text-[16px] md:text-[15px] font-semibold md:font-medium text-white/85 md:text-white/70 group-hover:text-white/95 md:group-hover:text-white/90 leading-snug md:leading-[1.55] transition-colors duration-300">
                       {lang === 'it' && release.titleIt ? release.titleIt : release.title}
                     </span>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
-                    <span className="text-[12px] font-semibold text-white/25 tracking-[0.08em] uppercase hidden sm:block group-hover:text-white/50 transition-colors duration-300">
+                    <Download className="h-4 w-4 text-[#4B4DF7]/70 md:text-white/20 group-hover:text-[#4B4DF7] md:group-hover:text-white/50 transition-colors duration-300" />
+                    <span className="text-[12px] font-semibold text-[#4B4DF7]/70 md:text-white/25 tracking-[0.08em] uppercase group-hover:text-[#4B4DF7] md:group-hover:text-white/50 transition-colors duration-300">
                       {t('Download')}
                     </span>
-                    <Download className="h-4 w-4 text-white/20 group-hover:text-white/50 transition-colors duration-300" />
                   </div>
                 </motion.a>
               ))}

--- a/pages/resources/whitepapers/index.tsx
+++ b/pages/resources/whitepapers/index.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
 import { motion } from 'framer-motion';
@@ -16,6 +16,19 @@ export default function WhitepapersPage() {
   const [selIndustry, setSelIndustry] = useState(null);
   const [selTopic, setSelTopic] = useState(null);
   const [selProcess, setSelProcess] = useState(null);
+  const scrollRef = useRef(null);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const pct = max > 0 ? (el.scrollLeft / max) * 100 : 0;
+      setScrollProgress(pct);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
 
   const published = whitepapers
     .filter(w => w.published && w.languageAvailability.includes(lang))
@@ -82,64 +95,85 @@ export default function WhitepapersPage() {
 
         {/* Grid */}
         <section id="wp-grid" className="section-breathe">
-          <div className="max-w-[1400px] mx-auto px-8 lg:px-12 py-20 lg:py-24">
-            {/* Card Grid */}
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-                {published.map((w, i) => {
-                  const c = content(w);
-                  return (
-                    <motion.div
-                      key={w.slug}
-                      className="group cursor-pointer flex flex-col"
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ duration: 0.5, delay: i * 0.1 }}
-                      onClick={() => { router.push(`/resources/whitepapers/${w.slug}`); window.scrollTo(0, 0); }}
-                    >
-                      {/* Cover image in a rounded container */}
-                      <div className="rounded-2xl overflow-hidden mb-5">                        {w.coverBg ? (
-                          <div className="aspect-[4/5] relative overflow-hidden">
-                            <img src={w.coverBg} alt="" className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-700 opacity-50" />
-                            <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
-                            <div className="relative z-10 flex flex-col justify-between h-full p-8">
-                              <div>
-                                <div className="flex items-center gap-2.5 mb-8">
-                                  <img src="/logos/skillvue-logomark.svg" alt="Skillvue" className="h-7 w-7" style={{ filter: 'brightness(0) invert(1)' }} />
-                                  <span className="text-white/90 text-[15px] font-semibold">Skillvue</span>
-                                </div>
-                                <h3 className="text-[clamp(2rem,3vw,2.8rem)] font-bold text-white leading-[1.1] mb-5">{c.title}</h3>
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-24">
+            {(() => {
+              const renderCard = (w, i) => {
+                const c = content(w);
+                return (
+                  <motion.div
+                    key={w.slug}
+                    className="group cursor-pointer flex flex-col h-full"
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.5, delay: i * 0.1 }}
+                    onClick={() => { router.push(`/resources/whitepapers/${w.slug}`); window.scrollTo(0, 0); }}
+                  >
+                    {/* Cover image in a rounded container */}
+                    <div className="rounded-2xl overflow-hidden mb-5">
+                      {w.coverBg ? (
+                        <div className="aspect-[4/5] relative overflow-hidden">
+                          <img src={w.coverBg} alt="" className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-700 opacity-50" />
+                          <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70" />
+                          <div className="relative z-10 flex flex-col justify-between h-full p-6 md:p-8">
+                            <div>
+                              <div className="flex items-center gap-2.5 mb-6 md:mb-8">
+                                <img src="/logos/skillvue-logomark.svg" alt="Skillvue" className="h-7 w-7" style={{ filter: 'brightness(0) invert(1)' }} />
+                                <span className="text-white/90 text-[15px] font-semibold">Skillvue</span>
                               </div>
-                              <span className="text-[11px] text-white/35 font-semibold tracking-[0.15em] uppercase">{t('White Paper')}</span>
+                              <h3 className="text-[clamp(1.5rem,3vw,2.8rem)] font-bold text-white leading-[1.1] mb-5">{c.title}</h3>
                             </div>
+                            <span className="text-[11px] text-white/35 font-semibold tracking-[0.15em] uppercase">{t('White Paper')}</span>
                           </div>
-                        ) : (
-                          <div className="aspect-[4/5] overflow-hidden">
-                            <img src={w.coverImage} alt={c.title} className="w-full h-full object-cover object-top group-hover:scale-[1.03] transition-transform duration-700" />
-                          </div>
-                        )}
+                        </div>
+                      ) : (
+                        <div className="aspect-[4/5] overflow-hidden">
+                          <img src={w.coverImage} alt={c.title} className="w-full h-full object-cover object-top group-hover:scale-[1.03] transition-transform duration-700" />
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Tags */}
+                    <div className="flex flex-wrap gap-1.5 mb-3 content-start">
+                      {w.industry.map(tag => (
+                        <span key={tag} className="inline-flex px-3 py-1.5 rounded-full text-[11px] font-semibold text-[#4B4DF7] border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide h-fit">{tag}</span>
+                      ))}
+                      {w.topic.map(tag => (
+                        <span key={tag} className="inline-flex px-3 py-1.5 rounded-full text-[11px] font-semibold text-[#121212]/55 border border-[#121212]/10 tracking-wide h-fit">{tag}</span>
+                      ))}
+                    </div>
+
+                    {/* Description */}
+                    <p className="text-[14px] md:text-[15px] text-[#121212]/55 leading-[1.7] line-clamp-3 mb-4">{c.shortDesc}</p>
+
+                    {/* CTA */}
+                    <span className="text-[14px] font-semibold text-[#4B4DF7] flex items-center gap-2 group-hover:gap-3 transition-all duration-300 mt-auto">
+                      {labels.read} <ArrowRight className="h-4 w-4" />
+                    </span>
+                  </motion.div>
+                );
+              };
+              return (
+                <>
+                  {/* Mobile: horizontal scroll */}
+                  <div ref={scrollRef} className="md:hidden flex gap-4 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-5 px-5 pb-2">
+                    {published.map((w, i) => (
+                      <div key={w.slug} className="shrink-0 w-[80vw] snap-center">
+                        {renderCard(w, i)}
                       </div>
+                    ))}
+                  </div>
+                  {/* Progress bar */}
+                  <div className="md:hidden mx-auto mt-5 w-48 h-1.5 rounded-full bg-[#1A1A2E]/20 relative">
+                    <div className="absolute top-0 h-full w-[35%] rounded-full skillvue-scroll-fill" style={{ left: `${scrollProgress * 0.65}%` }} />
+                  </div>
 
-                      {/* Tags */}
-                      <div className="flex flex-wrap gap-1.5 mb-3 content-start">
-                        {w.industry.map(tag => (
-                          <span key={tag} className="inline-flex px-3 py-1.5 rounded-full text-[11px] font-semibold text-[#4B4DF7] border border-[#4B4DF7]/[0.12] bg-[#4B4DF7]/[0.04] tracking-wide h-fit">{tag}</span>
-                        ))}
-                        {w.topic.map(tag => (
-                          <span key={tag} className="inline-flex px-3 py-1.5 rounded-full text-[11px] font-semibold text-white/40 border border-white/[0.08] tracking-wide h-fit">{tag}</span>
-                        ))}
-                      </div>
-
-                      {/* Description */}
-                      <p className="text-[15px] text-white/50 leading-[1.7] line-clamp-3 mb-4">{c.shortDesc}</p>
-
-                      {/* CTA */}
-                      <span className="text-[14px] font-semibold text-[#4B4DF7] flex items-center gap-2 group-hover:gap-3 transition-all duration-300 mt-auto">
-                        {labels.read} <ArrowRight className="h-4 w-4" />
-                      </span>
-                    </motion.div>
-                  );
-                })}
-              </div>
+                  {/* Desktop: grid */}
+                  <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    {published.map((w, i) => renderCard(w, i))}
+                  </div>
+                </>
+              );
+            })()}
           </div>
         </section>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,8 +33,29 @@ html, body {
 
 /* Skillvue-branded scroll progress bar fill */
 .skillvue-scroll-fill {
-  background: linear-gradient(90deg, #4B4DF7 0%, #7577F8 50%, #FF5F24 100%);
-  box-shadow: 0 0 8px rgba(75, 77, 247, 0.35);
+  background: linear-gradient(
+    90deg,
+    #4B4DF7 0%,
+    #7577F8 20%,
+    #B57BB0 40%,
+    #FF5F24 60%,
+    #B57BB0 80%,
+    #4B4DF7 100%
+  );
+  background-size: 200% 100%;
+  animation: skillvue-scroll-shimmer 3.5s linear infinite;
+  box-shadow:
+    0 0 10px rgba(75, 77, 247, 0.45),
+    0 0 22px rgba(117, 119, 248, 0.25),
+    0 0 32px rgba(255, 95, 36, 0.15);
+  will-change: transform, background-position;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+}
+
+@keyframes skillvue-scroll-shimmer {
+  from { background-position: 0% 50%; }
+  to { background-position: -200% 50%; }
 }
 
 #emergent-badge,


### PR DESCRIPTION
## Summary

Major mobile UX pass on the marketing site: rebuilt the scroll-progress bar to track finger movement 1:1 with an animated brand gradient, and reworked layouts across 18+ sections so they feel right on small screens.

### Scroll-progress bar
- Animated gradient (blue → pink → orange shimmer loop) with multi-layer glow
- 1:1 finger tracking — removed transition lag, GPU-composited
- Track upsized to 6×192px at 20% opacity for visibility on light backgrounds

### Layout bug fix
- `flex items-center` on `<section>` was making the inner div expand to fit horizontal-scroll children (flex `min-width: auto`), pushing the scroll bar off-screen at x=404 on a 390px viewport
- Swapped to `md:flex md:items-center` on TAProblem, TAShift, PMProblem, LDHowSolves, LDImpact, PRConsulting, about-values
- Mobile padding aligned to `px-5` across pages

### Per-section redesigns (mobile)
- **TAShift / SolutionCrossLinks** (2 cards): horizontal scroll → vertical stack, with brand-color transition divider where it tells a before/after story
- **TAFunnel**: stage selector → compact 3-pill grid; detail cards stack vertically per active stage (no nested horizontal scroll)
- **PMProblem / LDHowSolves / LDImpact / IMProblem / PRConsulting / CustomersROI / about-values / blog / whitepapers / press**: vertical stacks → horizontal snap-scroll + bar
- **Press releases**: cramped horizontal flex → vertical stack on mobile (date label, prominent title, brand-colored Download CTA)
- **Whitepapers**: fixed invisible tags/description (`text-white/40` on light bg → `text-[#121212]/55`)

## Test plan
- [ ] Verify scroll bar follows finger 1:1 on iOS Safari and Android Chrome
- [ ] Check all redesigned sections at 360px, 390px, 414px viewports
- [ ] Confirm desktop layouts (≥768px) are unchanged
- [ ] Smoke-test interactive sections (TAFunnel stage selector, blog/whitepaper card taps)
- [ ] Verify no horizontal page overflow (`document.body.scrollWidth === window.innerWidth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)