### PR TITLE
IT hero refresh, new product video, publish Mediaset story

### DIFF
--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -42,8 +42,14 @@ const allStories = [
     headlineEn: 'How Unicomm is building a new talent management system across a network of 250 stores and growing',
     bgImage: '/logos/unicomm-background-explore-stories.jpg',
   },
+  {
+    id: 'mediaset', company: 'Mediaset', industry: 'Media & Telecom', useCases: ['Hiring'],
+    headlineIt: 'Mediaset: da 3.000 candidature a 15 top talent, come selezionare e far crescere il talento su scala',
+    headlineEn: 'Mediaset: from 3,000 applications to 15 top talents, how to identify and develop talent at scale',
+    bgImage: '/logos/mediaset-background-explore-stories.jpg',
+  },
   // Temporarily removed from listing pending approval (restore when ready):
-  // credem, mediaset, douglas, eataly
+  // credem, douglas, eataly
 ];
 
 const filters = {

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -72,9 +72,8 @@ export default function HeroSection() {
                   </>
                 ) : (
                   <>
-                    {t('Every talent')}<br />
-                    {t('decision,')} <span className="italic font-bold gradient-text">{t('finally')}</span><br />
-                    {t('backed by science.')}
+                    Lo <span className="italic font-bold gradient-text">Skills OS</span><br />
+                    della tua organizzazione
                   </>
                 )}
               </motion.h1>
@@ -87,7 +86,7 @@ export default function HeroSection() {
               >
                 {lang === 'en'
                   ? 'Skillvue is the objective skills data layer for your enterprise, bespoke to your competency framework, grounded in science, scaled by AI, embedded into the HR systems you already run, so every talent decision, from hiring to transformation, is finally the right one.'
-                  : t('Skillvue combines psychometric rigour with modern AI to assess skills, predict performance, and guide every talent decision, from hiring to promotion to transformation readiness.')}
+                  : 'Skillvue mappa, misura e riporta dati oggettivi sulle competenze: costruito sul tuo framework interno, fondato sulla scienza, potenziato dall’AI e integrato nei sistemi HR che già utilizzi, per trasformare ogni decisione sul talento, dall’assunzione allo sviluppo.'}
               </motion.p>
             </div>
 
@@ -103,7 +102,7 @@ export default function HeroSection() {
                 style={{ boxShadow: '0 20px 60px -15px rgba(75, 77, 247, 0.45), 0 0 0 1px rgba(255,255,255,0.05)' }}
               >
                 <iframe
-                  src="https://www.youtube-nocookie.com/embed/Y8Oo5HBVl-Q?autoplay=1&mute=1&loop=1&playlist=Y8Oo5HBVl-Q&rel=0&modestbranding=1&vq=hd2160&hd=1&playsinline=1&enablejsapi=1"
+                  src="https://www.youtube-nocookie.com/embed/g2Ju7COKZrM?autoplay=1&mute=1&loop=1&playlist=g2Ju7COKZrM&rel=0&modestbranding=1&vq=hd2160&hd=1&playsinline=1&enablejsapi=1"
                   title="Skillvue product video"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                   allowFullScreen

--- a/pages/customers/mediaset.tsx
+++ b/pages/customers/mediaset.tsx
@@ -390,6 +390,15 @@ export default function MediasetStoryPage() {
                     ))}
                   </div>
                 </div>
+                <div className="mt-4 rounded-2xl border border-white/[0.08] overflow-hidden" style={{ aspectRatio: '16/9' }}>
+                  <iframe
+                    className="w-full h-full"
+                    src="https://www.youtube.com/embed/AAnpWEHhWuE?autoplay=1&mute=1&rel=0&modestbranding=1"
+                    title="Mediaset interview"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
               </motion.div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- IT hero copy refresh: "Lo *Skills OS* della tua organizzazione" + new sub-hero paragraph
- Homepage product video swapped to new YouTube ID `g2Ju7COKZrM`
- Mediaset customer story now has interview video embedded under the client card (same pattern as Unicomm)
- Mediaset added to ExploreStories listing (introduces new "Media & Telecom" industry filter); sitemap entry already present

## Test plan
- [ ] Visit `/it` and confirm new hero/sub-hero copy + correct line breaks
- [ ] Confirm new product video plays autoplay+mute on `/` and `/it`
- [ ] Visit `/it/clienti/mediaset` and `/customers/mediaset` and confirm interview video plays under the client card
- [ ] Visit `/it/clienti` and `/customers` and confirm Mediaset card appears in the listing with "Media & Telecom" filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)