### PR TITLE
Increase 'Ready to explore' label size in customers CTA

### DIFF
--- a/components/customers/CustomersFinalCTA.tsx
+++ b/components/customers/CustomersFinalCTA.tsx
@@ -23,7 +23,7 @@ export default function CustomersFinalCTA() {
 
         <motion.div className="grid lg:grid-cols-12 gap-4 mb-6" initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.7, delay: 0.2 }}>
           <div className="lg:col-span-12 group rounded-2xl border border-white/[0.06] hover:border-white/[0.14] bg-white/[0.04] hover:bg-white/[0.06] backdrop-blur-sm p-10 lg:p-14 transition-all duration-500">
-            <span className="text-[11px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.15em] uppercase">{t('Ready to explore')}</span>
+            <span className="text-[13px] font-semibold text-[#9B9DFB]/[0.65] tracking-[0.15em] uppercase">{t('Ready to explore')}</span>
             <h3 className="text-2xl font-bold text-white/90 mt-4 mb-3">{t('Book a Demo')}</h3>
             <p className="text-[15px] text-white/[0.65] mb-8 max-w-md">{t('See Skillvue live with your specific use case')}</p>
             <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} className="group/btn inline-flex items-center justify-between w-full max-w-sm px-8 py-5 text-[14px] font-semibold text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500">


### PR DESCRIPTION
## Summary
- Bumped font size of the "Ready to explore" label in the Book a Demo box from `11px` to `13px` for slightly better readability

## Test plan
- [ ] Verify the "Ready to explore" text appears slightly larger above the Book a Demo heading
- [ ] Confirm layout is not broken on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)