### PR TITLE
Make food retail one-pager language-aware (EN/IT)

### DIFF
--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -1125,4 +1125,11 @@ export const translations = {
   'GDPR, EU AI Act, multi-country operations, multi-language workforces. Designed for the regulatory and cultural complexity European enterprises face every day.': "Regolamento generale sulla protezione dei dati, normativa europea sull'intelligenza artificiale, operatività in più Paesi, forza lavoro multilingue. Skillvue è progettata per affrontare ogni giorno la complessità normativa e culturale delle imprese europee.",
   'Ready to make talent decisions you can defend?': 'Pronto a prendere decisioni sui talenti che puoi davvero difendere?',
   'Book a demo with our team and see how Skillvue can transform your hiring, performance, and development processes.': 'Prenota una demo con il nostro team e scopri come Skillvue può trasformare i tuoi processi di assunzione, gestione delle prestazioni e sviluppo.',
+
+  // ===== FOOD RETAIL ONE-PAGER =====
+  'Get the one-pager for': 'Scarica il one pager per',
+  'food retail HR.': "l'HR del food retail",
+  'How an objective read of skills sharpens hiring, promotion, and development decisions.': 'Scopri come una valutazione oggettiva delle competenze rende più efficaci le decisioni di selezione, promozione e sviluppo del personale.',
+  'One standard across every store, the same for new hires and the people you grow from within.': "Un unico standard per tutti i punti vendita, valido sia per i nuovi assunti sia per le persone che crescono all'interno dell'azienda.",
+  'Fill in the form to download it.': 'Compila il modulo per scaricare la guida.',
 };

--- a/pages/lp/food-retail.tsx
+++ b/pages/lp/food-retail.tsx
@@ -10,38 +10,16 @@ const FORM_IDS = {
   it: '174b15c8-58eb-497d-bed1-0506bcbfda5c',
 };
 
-// Each title is an array of lines; each line is an array of segments.
-// A segment with `gradient: true` renders in the gradient style.
-const COPY = {
-  en: {
-    titleLines: [
-      [{ text: 'Get the one-pager for ' }, { text: 'food retail HR.', gradient: true }],
-    ],
-    paragraphs: [
-      'How an objective read of skills sharpens hiring, promotion, and development decisions.',
-      'One standard across every store, the same for new hires and the people you grow from within.',
-      'Fill in the form to download it.',
-    ],
-  },
-  it: {
-    titleLines: [
-      [{ text: 'Scarica il one pager' }],
-      [{ text: 'per ' }, { text: "l'HR", gradient: true }],
-      [{ text: 'del food retail', gradient: true }],
-    ],
-    paragraphs: [
-      'Scopri come una valutazione oggettiva delle competenze rende più efficaci le decisioni di selezione, promozione e sviluppo del personale.',
-      "Un unico standard per tutti i punti vendita, valido sia per i nuovi assunti sia per le persone che crescono all'interno dell'azienda.",
-      'Compila il modulo per scaricare la guida.',
-    ],
-  },
-};
+const PARAGRAPHS = [
+  'How an objective read of skills sharpens hiring, promotion, and development decisions.',
+  'One standard across every store, the same for new hires and the people you grow from within.',
+  'Fill in the form to download it.',
+];
 
 export default function FoodRetailPage() {
-  const { lang } = useLanguage();
+  const { t, lang } = useLanguage();
   const formRef = useRef(null);
   const isIt = lang === 'it';
-  const copy = isIt ? COPY.it : COPY.en;
 
   useEffect(() => {
     const formId = isIt ? FORM_IDS.it : FORM_IDS.en;
@@ -79,6 +57,40 @@ export default function FoodRetailPage() {
     };
   }, [isIt]);
 
+  // Title strings come from the shared translation dictionary.
+  const titleLead = t('Get the one-pager for');
+  const titleHighlight = t('food retail HR.');
+
+  // IT is laid out on three fixed lines; EN wraps naturally on one line.
+  const renderTitle = () => {
+    if (!isIt) {
+      return (
+        <>
+          {titleLead}{' '}
+          <span className="font-bold gradient-text">{titleHighlight}</span>
+        </>
+      );
+    }
+
+    const leadWords = titleLead.split(' ');
+    const leadFirst = leadWords.slice(0, -1).join(' ');
+    const leadLast = leadWords[leadWords.length - 1];
+    const hlWords = titleHighlight.split(' ');
+    const hlFirst = hlWords[0];
+    const hlRest = hlWords.slice(1).join(' ');
+
+    return (
+      <>
+        <span className="block whitespace-nowrap">{leadFirst}</span>
+        <span className="block whitespace-nowrap">
+          {leadLast}{' '}
+          <span className="font-bold gradient-text">{hlFirst}</span>
+        </span>
+        <span className="block whitespace-nowrap font-bold gradient-text">{hlRest}</span>
+      </>
+    );
+  };
+
   return (
     <>
       <Navbar />
@@ -92,27 +104,16 @@ export default function FoodRetailPage() {
                   className="text-[clamp(1.75rem,4.2vw,3.5rem)] font-bold tracking-[-0.03em] text-white/95 mb-4"
                   style={{ lineHeight: 1.1 }}
                 >
-                  {copy.titleLines.map((line, li) => (
-                    <span
-                      key={li}
-                      className={copy.titleLines.length > 1 ? 'block whitespace-nowrap' : 'block'}
-                    >
-                      {line.map((seg, si) => (
-                        <span key={si} className={seg.gradient ? 'font-bold gradient-text' : undefined}>
-                          {seg.text}
-                        </span>
-                      ))}
-                    </span>
-                  ))}
+                  {renderTitle()}
                 </h1>
 
-                {copy.paragraphs.map((text, i) => (
+                {PARAGRAPHS.map((text, i) => (
                   <p
                     key={i}
                     className={`text-[18px] text-white/95 leading-[1.65] max-w-md${i > 0 ? ' mt-4' : ''}`}
                     style={{ fontWeight: 300 }}
                   >
-                    {text}
+                    {t(text)}
                   </p>
                 ))}
               </div>

--- a/pages/lp/food-retail.tsx
+++ b/pages/lp/food-retail.tsx
@@ -3,26 +3,73 @@ import React, { useEffect, useRef } from 'react';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
 import TrustLogosBar from '@/components/landing/TrustLogosBar';
+import { useLanguage } from '@/i18n/LanguageContext';
+
+const FORM_IDS = {
+  en: '824a40f6-57e6-46eb-bada-ca5d6f8122ea',
+  it: '174b15c8-58eb-497d-bed1-0506bcbfda5c',
+};
+
+// Each title is an array of lines; each line is an array of segments.
+// A segment with `gradient: true` renders in the gradient style.
+const COPY = {
+  en: {
+    titleLines: [
+      [{ text: 'Get the one-pager for ' }, { text: 'food retail HR.', gradient: true }],
+    ],
+    paragraphs: [
+      'How an objective read of skills sharpens hiring, promotion, and development decisions.',
+      'One standard across every store, the same for new hires and the people you grow from within.',
+      'Fill in the form to download it.',
+    ],
+  },
+  it: {
+    titleLines: [
+      [{ text: 'Scarica il one pager' }],
+      [{ text: 'per ' }, { text: "l'HR", gradient: true }],
+      [{ text: 'del food retail', gradient: true }],
+    ],
+    paragraphs: [
+      'Scopri come una valutazione oggettiva delle competenze rende più efficaci le decisioni di selezione, promozione e sviluppo del personale.',
+      "Un unico standard per tutti i punti vendita, valido sia per i nuovi assunti sia per le persone che crescono all'interno dell'azienda.",
+      'Compila il modulo per scaricare la guida.',
+    ],
+  },
+};
 
 export default function FoodRetailPage() {
+  const { lang } = useLanguage();
   const formRef = useRef(null);
+  const isIt = lang === 'it';
+  const copy = isIt ? COPY.it : COPY.en;
 
   useEffect(() => {
-    const script = document.createElement('script');
-    script.src = '//js.hsforms.net/forms/embed/v2.js';
-    script.charset = 'utf-8';
-    script.type = 'text/javascript';
-    script.async = true;
-    script.onload = () => {
+    const formId = isIt ? FORM_IDS.it : FORM_IDS.en;
+
+    const createForm = () => {
       if (window.hbspt && formRef.current) {
+        formRef.current.innerHTML = '';
         window.hbspt.forms.create({
           portalId: '48438018',
-          formId: '824a40f6-57e6-46eb-bada-ca5d6f8122ea',
+          formId,
           region: 'na1',
           target: '#lead-form',
         });
       }
     };
+
+    // Script already loaded (e.g. on language switch): just re-create the form.
+    if (window.hbspt) {
+      createForm();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = '//js.hsforms.net/forms/embed/v2.js';
+    script.charset = 'utf-8';
+    script.type = 'text/javascript';
+    script.async = true;
+    script.onload = createForm;
     document.body.appendChild(script);
 
     return () => {
@@ -30,7 +77,7 @@ export default function FoodRetailPage() {
         script.parentNode.removeChild(script);
       }
     };
-  }, []);
+  }, [isIt]);
 
   return (
     <>
@@ -42,24 +89,32 @@ export default function FoodRetailPage() {
               {/* Left. Text */}
               <div className="lg:col-span-5">
                 <h1
-                  className="text-[clamp(2.25rem,4.2vw,3.5rem)] font-bold tracking-[-0.03em] text-white/95 mb-4"
+                  className="text-[clamp(1.75rem,4.2vw,3.5rem)] font-bold tracking-[-0.03em] text-white/95 mb-4"
                   style={{ lineHeight: 1.1 }}
                 >
-                  Get the one-pager for{' '}
-                  <span className="font-bold gradient-text">food retail HR.</span>
+                  {copy.titleLines.map((line, li) => (
+                    <span
+                      key={li}
+                      className={copy.titleLines.length > 1 ? 'block whitespace-nowrap' : 'block'}
+                    >
+                      {line.map((seg, si) => (
+                        <span key={si} className={seg.gradient ? 'font-bold gradient-text' : undefined}>
+                          {seg.text}
+                        </span>
+                      ))}
+                    </span>
+                  ))}
                 </h1>
 
-                <p className="text-[18px] text-white/95 leading-[1.65] max-w-md" style={{ fontWeight: 300 }}>
-                  How an objective read of skills sharpens hiring, promotion, and development decisions.
-                </p>
-
-                <p className="text-[18px] text-white/95 leading-[1.65] max-w-md mt-4" style={{ fontWeight: 300 }}>
-                  One standard across every store, the same for new hires and the people you grow from within.
-                </p>
-
-                <p className="text-[18px] text-white/95 leading-[1.65] max-w-md mt-4" style={{ fontWeight: 300 }}>
-                  Fill in the form to download it.
-                </p>
+                {copy.paragraphs.map((text, i) => (
+                  <p
+                    key={i}
+                    className={`text-[18px] text-white/95 leading-[1.65] max-w-md${i > 0 ? ' mt-4' : ''}`}
+                    style={{ fontWeight: 300 }}
+                  >
+                    {text}
+                  </p>
+                ))}
               </div>
 
               {/* Right. Form */}
@@ -78,7 +133,7 @@ export default function FoodRetailPage() {
             </div>
           </div>
         </section>
-        <TrustLogosBar lang="en" />
+        <TrustLogosBar lang={isIt ? 'it' : 'en'} />
       </div>
       <Footer />
     </>


### PR DESCRIPTION
## Summary
Builds on the merged food retail one-pager (#65). The page at **/lp/food-retail** is now driven by the site locale instead of being EN-only:

- Reads `lang` from `useLanguage()` (Next.js `router.locale`).
- Switches copy **and** the HubSpot form between EN and IT:
  - EN form `824a40f6-…122ea`, IT form `174b15c8-…da5c`.
- The form is re-created on language switch.
- IT title is laid out on three lines (with `whitespace-nowrap`); EN keeps natural wrapping.
- A previously planned separate `/lp/food-retail-it` page was dropped in favor of this single locale-aware page.

URLs:
- 🇬🇧 `/lp/food-retail`
- 🇮🇹 `/it/lp/food-retail`

## Test plan
- [x] Both locales compile and return HTTP 200 on `next dev`.
- [ ] Verify the correct HubSpot form (EN vs IT) renders after switching language in the browser.
- [ ] Confirm the IT title shows on three lines on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)