### PR TITLE
Update food retail one-pager title and gradient

### DIFF
--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -1127,8 +1127,8 @@ export const translations = {
   'Book a demo with our team and see how Skillvue can transform your hiring, performance, and development processes.': 'Prenota una demo con il nostro team e scopri come Skillvue può trasformare i tuoi processi di assunzione, gestione delle prestazioni e sviluppo.',
 
   // ===== FOOD RETAIL ONE-PAGER =====
-  'Get the one-pager for': 'Scarica il one pager per',
-  'food retail HR.': "l'HR del food retail",
+  'Your next store manager is': 'Il tuo prossimo store manager è',
+  'already in your stores.': 'già nei tuoi negozi.',
   'How an objective read of skills sharpens hiring, promotion, and development decisions.': 'Scopri come una valutazione oggettiva delle competenze rende più efficaci le decisioni di selezione, promozione e sviluppo del personale.',
   'One standard across every store, the same for new hires and the people you grow from within.': "Un unico standard per tutti i punti vendita, valido sia per i nuovi assunti sia per le persone che crescono all'interno dell'azienda.",
   'Fill in the form to download it.': 'Compila il modulo per scaricare la guida.',

--- a/pages/lp/food-retail.tsx
+++ b/pages/lp/food-retail.tsx
@@ -58,38 +58,25 @@ export default function FoodRetailPage() {
   }, [isIt]);
 
   // Title strings come from the shared translation dictionary.
-  const titleLead = t('Get the one-pager for');
-  const titleHighlight = t('food retail HR.');
+  const titleLead = t('Your next store manager is');
+  const titleHighlight = t('already in your stores.');
 
-  // IT is laid out on three fixed lines; EN wraps naturally on one line.
-  const renderTitle = () => {
-    if (!isIt) {
-      return (
-        <>
-          {titleLead}{' '}
-          <span className="font-bold gradient-text">{titleHighlight}</span>
-        </>
-      );
-    }
-
-    const leadWords = titleLead.split(' ');
-    const leadFirst = leadWords.slice(0, -1).join(' ');
-    const leadLast = leadWords[leadWords.length - 1];
-    const hlWords = titleHighlight.split(' ');
-    const hlFirst = hlWords[0];
-    const hlRest = hlWords.slice(1).join(' ');
-
-    return (
-      <>
-        <span className="block whitespace-nowrap">{leadFirst}</span>
-        <span className="block whitespace-nowrap">
-          {leadLast}{' '}
-          <span className="font-bold gradient-text">{hlFirst}</span>
-        </span>
-        <span className="block whitespace-nowrap font-bold gradient-text">{hlRest}</span>
-      </>
-    );
-  };
+  const renderTitle = () => (
+    <>
+      {titleLead}{' '}
+      {/* Inline so the highlight flows with the lead ("already" stays next to "is") and wraps naturally.
+          Local gradient override pushes the purple further out so less of it shows. */}
+      <span
+        className="font-bold gradient-text"
+        style={{
+          display: 'inline',
+          backgroundImage: 'linear-gradient(135deg, #FFAF64 0%, #FF5656 62%, #4B4DF7 128%)',
+        }}
+      >
+        {titleHighlight}
+      </span>
+    </>
+  );
 
   return (
     <>
@@ -101,7 +88,7 @@ export default function FoodRetailPage() {
               {/* Left. Text */}
               <div className="lg:col-span-5">
                 <h1
-                  className="text-[clamp(1.75rem,4.2vw,3.5rem)] font-bold tracking-[-0.03em] text-white/95 mb-4"
+                  className="text-[clamp(1.5rem,3.6vw,2.75rem)] font-bold tracking-[-0.03em] text-white/95 mb-4"
                   style={{ lineHeight: 1.1 }}
                 >
                   {renderTitle()}


### PR DESCRIPTION
## Summary
Updates the hero of the food retail one-pager (`/lp/food-retail`, `/it/lp/food-retail`):

- **New headline** (locale-aware, via `t()` / `translations.ts`):
  - 🇬🇧 "Your next store manager is **already in your stores.**"
  - 🇮🇹 "Il tuo prossimo store manager è **già nei tuoi negozi.**" (informal "tu")
- **Same title font size across EN/IT** so switching language doesn't cause a size jump.
- **Inline flowing highlight** so "already" stays next to "is" and wraps naturally.
- **Softer local gradient** (page-only override, purple pushed further out) — global `.gradient-text` untouched.

## Test plan
- [x] Both locales compile and return HTTP 200 on `next dev`.
- [ ] Visually confirm the headline, size parity across languages, and reduced purple in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)