### PR TITLE
Fix number box animation, stretched hero CTAs, and tag styling

### DIFF
--- a/components/landing/CustomerStoriesSection.tsx
+++ b/components/landing/CustomerStoriesSection.tsx
@@ -54,13 +54,13 @@ export default function CustomerStoriesSection() {
           </p>
         </motion.div>
 
-        {/* Story cards — horizontal scroll on mobile, 2-col grid on desktop */}
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-5 mb-8 md:mb-10">
+        {/* Story cards — horizontal scroll on mobile, 3-col grid on desktop */}
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3 md:gap-5 mb-8 md:mb-10">
           {stories.map((s, i) => (
             <motion.div
               key={s.company}
               data-testid={`story-${s.company.toLowerCase().replace(/\s+/g, '-')}`}
-              className="group rounded-2xl border border-white/[0.07] bg-white/[0.04] hover:bg-white/[0.06] hover:border-white/[0.14] backdrop-blur-sm p-5 md:p-10 lg:p-12 transition-all duration-500 cursor-pointer flex flex-col justify-between min-h-[220px] md:min-h-0"
+              className="group rounded-2xl border border-white/[0.07] bg-white/[0.04] hover:bg-white/[0.06] hover:border-white/[0.14] backdrop-blur-sm p-5 md:p-10 lg:p-12 transition-all duration-500 cursor-pointer flex flex-col justify-between gap-5 md:gap-8 min-h-[220px] md:min-h-0"
               initial={{ opacity: 0, y: 25 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: 0.1 + i * 0.1 }}
@@ -68,8 +68,10 @@ export default function CustomerStoriesSection() {
             >
               {/* Company + industry */}
               <div>
-                <h3 className="text-[17px] md:text-[22px] font-semibold text-white/90 mb-1">{t(s.company)}</h3>
-                <span className="text-[13px] md:text-[15px] text-white/40">{t(s.industry)}</span>
+                <h3 className="text-[17px] md:text-[22px] font-semibold text-white/90 mb-4 md:mb-5">{t(s.company)}</h3>
+                <span className="inline-flex px-2.5 py-1 md:px-3 md:py-1.5 rounded-full text-[11px] md:text-[11px] font-semibold text-white/[0.65] border border-white/[0.1] bg-white/[0.03] tracking-wide">
+                  {t(s.industry)}
+                </span>
               </div>
 
               {/* Quote */}

--- a/components/landing/ProblemSection.tsx
+++ b/components/landing/ProblemSection.tsx
@@ -67,7 +67,7 @@ export default function ProblemSection() {
         </AnimatedSection>
 
         {/* Pain cards — horizontal scroll on mobile, 3-col grid on desktop */}
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3 md:gap-4 lg:gap-5">
+        <div ref={ref} className="grid grid-cols-1 gap-3 md:grid-cols-3 md:gap-4 lg:gap-5">
           {painCards.map((card, i) => (
             <motion.div
               key={card.stat + i}

--- a/components/product/AssessmentFormats.tsx
+++ b/components/product/AssessmentFormats.tsx
@@ -68,8 +68,7 @@ export default function AssessmentFormats() {
             >
               {/* Section label */}
               <div className="flex items-center gap-2.5 md:gap-4 mb-5 md:mb-8">
-                <div className="w-1 h-6 md:w-1.5 md:h-8 rounded-full bg-gradient-to-b from-[#FF5F24] to-[#FF5F24]/30" />
-                <span className="text-[12px] md:text-[15px] font-bold text-[#FF5F24] tracking-[0.1em] uppercase">{t(layer.title)}</span>
+                <span className="text-[12px] md:text-[15px] font-bold text-white tracking-[0.1em] uppercase">{t(layer.title)}</span>
                 <span className="text-[12px] md:text-[15px] text-white/35 font-light hidden md:inline">{t(layer.subtitle)}</span>
               </div>
 

--- a/components/product/ProductHero.tsx
+++ b/components/product/ProductHero.tsx
@@ -43,7 +43,7 @@ export default function ProductHero() {
             </motion.h1>
 
             <motion.div
-              className="flex flex-col gap-5 md:gap-8"
+              className="flex flex-col items-start gap-5 md:gap-8"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.5 }}
@@ -55,7 +55,7 @@ export default function ProductHero() {
               <a
                 href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'}
                 data-testid="product-hero-book-demo"
-                className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0"
+                className="group inline-flex items-center justify-between gap-4 w-auto px-6 py-4 md:px-8 md:py-5 text-[13px] md:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0"
               >
                 <span>{t('Book a Demo')}</span>
                 <ArrowRight className="h-4 w-4 md:h-5 md:w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />

--- a/components/solutions/im/IMHero.tsx
+++ b/components/solutions/im/IMHero.tsx
@@ -20,7 +20,7 @@ export default function IMHero() {
           <span className="font-bold gradient-text">{t('work for you.')}</span>
         </motion.h1>
         <motion.div
-          className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
+          className="flex flex-col items-start lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.5 }}
@@ -28,7 +28,7 @@ export default function IMHero() {
           <p className="text-[16px] lg:text-[18px] text-white/[0.65] leading-[1.75] max-w-xl" style={{ fontWeight: 300 }}>
             {t('Skillvue maps skills and potential across your entire workforce, making internal talent visible, succession decisions data-driven, and mobility paths transparent.')}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="im-hero-cta" className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="im-hero-cta" className="group inline-flex items-center justify-between gap-4 w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
             <span>{t('Book a Demo')}</span>
             <ArrowRight className="h-5 w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>

--- a/components/solutions/ld/LDHero.tsx
+++ b/components/solutions/ld/LDHero.tsx
@@ -20,7 +20,7 @@ export default function LDHero() {
           <span className="font-bold gradient-text">{t('real skill gaps.')}</span>
         </motion.h1>
         <motion.div
-          className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
+          className="flex flex-col items-start lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.5 }}
@@ -28,7 +28,7 @@ export default function LDHero() {
           <p className="text-[16px] lg:text-[18px] text-white/[0.65] leading-[1.75] max-w-xl" style={{ fontWeight: 300 }}>
             {t('Skillvue gives L&D leaders objective, measurable data on where the real skill gaps are, at individual, team, and organizational level, so every training investment is targeted, measurable, and aligned to business impact.')}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="ld-hero-cta" className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="ld-hero-cta" className="group inline-flex items-center justify-between gap-4 w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
             <span>{t('Book a Demo')}</span>
             <ArrowRight className="h-5 w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>

--- a/components/solutions/pm/PMHero.tsx
+++ b/components/solutions/pm/PMHero.tsx
@@ -20,7 +20,7 @@ export default function PMHero() {
           <span className="font-bold gradient-text">{t('opinions?')}</span>
         </motion.h1>
         <motion.div
-          className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
+          className="flex flex-col items-start lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.5 }}
@@ -28,7 +28,7 @@ export default function PMHero() {
           <p className="text-[16px] lg:text-[18px] text-white/[0.65] leading-[1.75] max-w-xl" style={{ fontWeight: 300 }}>
             {t('Skillvue integrates objective skill verifications into your performance cycles. reducing bias, improving calibration, and giving every manager a data-backed starting point before they write a single review.')}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="pm-hero-cta" className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="pm-hero-cta" className="group inline-flex items-center justify-between gap-4 w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
             <span>{t('Book a Demo')}</span>
             <ArrowRight className="h-5 w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>

--- a/components/solutions/pr/PRHero.tsx
+++ b/components/solutions/pr/PRHero.tsx
@@ -20,7 +20,7 @@ export default function PRHero() {
           <span className="font-bold gradient-text">{t('not availability.')}</span>
         </motion.h1>
         <motion.div
-          className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
+          className="flex flex-col items-start lg:flex-row lg:items-end lg:justify-between gap-8 lg:gap-12"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.5 }}
@@ -28,7 +28,7 @@ export default function PRHero() {
           <p className="text-[16px] lg:text-[18px] text-white/[0.65] leading-[1.75] max-w-xl" style={{ fontWeight: 300 }}>
             {t('Skillvue gives project leaders and resourcing teams an objective view of who has the skills to deliver, replacing "who\'s free" with "who\'s fit." Reduce delivery risk, improve team composition, and stop staffing in the dark.')}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="pr-hero-cta" className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="pr-hero-cta" className="group inline-flex items-center justify-between gap-4 w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
             <span>{t('Book a Demo')}</span>
             <ArrowRight className="h-5 w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>

--- a/components/solutions/ta/TAHero.tsx
+++ b/components/solutions/ta/TAHero.tsx
@@ -21,7 +21,7 @@ export default function TAHero() {
           <span className="font-bold gradient-text">{t('perform.')}</span>
         </motion.h1>
         <motion.div
-          className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-5 md:gap-8 lg:gap-12"
+          className="flex flex-col items-start lg:flex-row lg:items-end lg:justify-between gap-5 md:gap-8 lg:gap-12"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.5 }}
@@ -29,7 +29,7 @@ export default function TAHero() {
           <p className="text-[14px] md:text-[16px] lg:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-xl font-normal md:font-light">
             {t('Skillvue replaces guesswork with science at scale. AI-powered verifications customized to your roles and leadership model surface top candidates, cut early turnover, and make every hiring decision defensible.')}
           </p>
-          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="ta-hero-cta" className="group inline-flex items-center justify-between w-full lg:w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
+          <a href={lang === 'it' ? '/prenota-incontro' : '/book-meeting'} data-testid="ta-hero-cta" className="group inline-flex items-center justify-between gap-4 w-auto lg:max-w-xl px-6 py-4 lg:px-8 lg:py-5 text-[14px] lg:text-[15px] font-semibold tracking-wide text-white rounded-full border border-white/10 hover:border-[#4B4DF7]/40 hover:bg-[#4B4DF7]/[0.08] transition-all duration-500 shrink-0">
             <span>{t('Book a Demo')}</span>
             <ArrowRight className="h-5 w-5 text-white/30 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-500" />
           </a>


### PR DESCRIPTION
## Summary
- Restore the missing `isInView` ref wiring on ProblemSection so the "Your Biggest Opportunity" pain-stat cards actually animate into view (they were stuck at `opacity: 0`).
- Change the proof/testimonial section on the landing page to a 3-column row, add spacing between card elements, and restyle the industry label as a neutral pill tag consistent with the ISO/GDPR badges.
- Fix hero CTA buttons stretching full width on mobile/tablet across the Product page and all Solution pages (Talent Acquisition, Internal Mobility, Learning & Development, Performance, Project Resourcing); add a consistent 16px gap between the label and arrow icon now that the buttons are content-sized.
- Remove the thick accent bar and switch section titles (Interaction Format, Assessment Method, Response Format) to white in the Assessment Formats section on the product page.

## Test plan
- [ ] Visually verify the "Your Biggest Opportunity" stat cards animate in on scroll on the homepage.
- [ ] Verify the proof/testimonial cards display in a single row on desktop with proper spacing on the homepage.
- [ ] Verify hero CTA buttons are not stretched full-width and have proper icon spacing on Product page and each Solutions page, across mobile/tablet/desktop breakpoints.
- [ ] Verify Assessment Formats section labels on the product page have no accent bar and are white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)