### PR TITLE
Align /lp/europ-assistance landing with finalized customer story

### DIFF
--- a/pages/lp/europ-assistance.tsx
+++ b/pages/lp/europ-assistance.tsx
@@ -1,8 +1,8 @@
-﻿// @ts-nocheck
+// @ts-nocheck
 import React, { useRef } from 'react';
 import Footer from '@/components/Footer';
 import { motion, useInView } from 'framer-motion';
-import { ArrowRight, Users, Shield, Scale, TrendingUp, Target, Layers, Zap, Eye, BarChart3, Heart, CheckCircle, Wrench } from 'lucide-react';
+import { ArrowRight, Users, Shield, Scale, TrendingUp, Target, Layers, Zap, Eye, BarChart3, Heart, CheckCircle, Wrench, Clock, Search } from 'lucide-react';
 import { useRouter } from 'next/router';
 import Navbar from '@/components/landing/Navbar';
 import SolutionFinalCTA from '@/components/shared/SolutionFinalCTA';
@@ -26,15 +26,15 @@ const content = {
     breadcrumb: 'Clienti',
     badge: 'CUSTOMER STORY',
     headline: {
-      before: 'Europ Assistance: come riconoscere il ',
+      before: 'Europ Assistance: come cogliere il ',
       highlight1: 'potenziale che resiste alla prova del tempo',
-      middle: ' in un business fondato sulla ',
-      highlight2: 'componente umana',
+      middle: ' in un business fondato sul ',
+      highlight2: 'fattore umano',
       after: '',
     },
-    subtitle: "Con Skillvue, Europ Assistance ha trasformato il pre-screening dei candidati in un processo scalabile e strategico per l'intero talent lifecycle, lavorando sulla valorizzazione delle competenze trasversali fin dal primo step della selezione.",
+    subtitle: "Con Skillvue, Europ Assistance ha trasformato il pre-screening dei candidati in un processo scalabile e strategico per l'intero talent lifecycle, mettendo le soft skill al centro fin dal primo step della selezione.",
     heroMetrics: [
-      { value: '10.000', label: 'centri nella rete in Italia' },
+      { value: '10.000', label: 'centri di servizio nella rete in Italia' },
       { value: '900+', label: 'dipendenti' },
     ],
     ctaPrimary: 'Contattaci',
@@ -45,7 +45,7 @@ const content = {
       facts: [
         { label: 'Settore', value: 'Financial Services' },
         { label: 'Gruppo', value: 'Generali' },
-        { label: 'Centri nella rete in Italia', value: '10.000' },
+        { label: 'Centri di servizio in Italia', value: '10.000' },
         { label: 'Use Case', value: 'Hiring' },
       ],
     },
@@ -53,45 +53,45 @@ const content = {
       badge: 'CONTESTO',
       title: 'In un business fondato sull\'interazione umana, la qualità della selezione non può accettare compromessi.',
       paragraph: <>
-        Europ Assistance, parte del <strong className="text-[#121212]/80 font-semibold">Gruppo Generali</strong> e da pochissimo rientrata insieme a Generali Employee Benefits sotto il nuovo brand di global care <strong className="text-[#121212]/80 font-semibold">Redion</strong>, è uno dei leader mondiali nei servizi di assistenza e assicurazione viaggi. La sua è una crescita costante: è in corso infatti l'espansione delle operazioni in nuovi mercati e la convergenza con Generali Care in un <strong className="text-[#121212]/80 font-semibold">hub integrato di assistenza</strong>.<br /><br />In Italia, opera con un modello di business fondato sulla qualità dell'interazione umana: <strong className="text-[#121212]/80 font-semibold">assistenza 24/7, gestione sinistri, customer care multilingue</strong>. <strong className="text-[#121212]/80 font-semibold">La scelta e la crescita delle persone</strong> rappresenta un punto chiave per il corretto funzionamento e l'espansione del business, soprattutto vista l'instabilità del settore assicurativo, che <strong className="text-[#121212]/80 font-semibold">non sempre riesce ad attrarre i profili più qualificati</strong> e al tempo stesso richiede <strong className="text-[#121212]/80 font-semibold">profili professionali molto specifici e capaci di evolvere nel tempo</strong>. In questo contesto, ogni assunzione sbagliata costa di più e ogni persona giusta che resta vale ancora di più.
+        Europ Assistance, parte del <strong className="text-[#121212]/80 font-semibold">Gruppo Generali</strong>, è uno dei leader mondiali nei servizi di assistenza e assicurazione viaggi. La sua è una crescita costante: è in corso l'espansione delle operazioni in nuovi mercati e la convergenza con Generali Care in un <strong className="text-[#121212]/80 font-semibold">hub integrato di assistenza</strong>.<br /><br />In Italia, opera con un modello di business fondato sulla qualità dell'interazione umana: <strong className="text-[#121212]/80 font-semibold">assistenza 24/7, gestione sinistri, customer care multilingue</strong>. La scelta e la crescita delle <strong className="text-[#121212]/80 font-semibold">persone</strong> è un fattore chiave per il corretto funzionamento e l'espansione del business, soprattutto vista l'instabilità del settore assicurativo, che <strong className="text-[#121212]/80 font-semibold">non sempre riesce ad attrarre i profili più qualificati</strong> e al tempo stesso richiede <strong className="text-[#121212]/80 font-semibold">profili professionali molto specifici e capaci di evolvere nel tempo</strong>. In questo contesto, ogni assunzione sbagliata costa di più e ogni persona giusta che resta vale ancora di più.
       </>,
     },
     challenge: {
       badge: 'LA SFIDA',
       title: 'Migliaia di candidature, 2 picchi stagionali, 3 persone nel team recruiting.',
-      intro: 'Le assunzioni di Europ Assistance Italia si concentrano in due picchi stagionali l\'anno, generando volumi nell\'ordine delle migliaia di candidature in pochi mesi. Per i ruoli di assistenza e customer care, le soft skill sono il primo predittore di successo — problem solving, orientamento al cliente, gestione dello stress — ma sono completamente invisibili nel CV.',
-      businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR & PEOPLE IMPACT',
+      intro: 'Le assunzioni di Europ Assistance Italia si concentrano in due picchi stagionali l\'anno, generando volumi nell\'ordine delle migliaia di candidature in pochi mesi. Per i ruoli di assistenza e customer care, le soft skill sono il primo predittore di successo: problem solving, orientamento al cliente, gestione dello stress, eppure sono completamente invisibili nel CV.',
+      businessLabel: 'SFIDE DI BUSINESS',
+      hrLabel: 'SFIDE HR & PEOPLE',
       businessChallenges: [
         {
           icon: TrendingUp,
-          title: 'Necessità di crescere al ritmo del business',
+          title: 'La necessità di crescere al ritmo del business',
           text: 'Le esigenze crescevano costantemente e la velocità di risposta richiesta aumentava. Essere più veloci ed efficaci per HR nel raggiungere i risultati attesi era diventata una necessità operativa.',
         },
         {
           icon: Users,
           title: 'Gestione complessa nei picchi stagionali',
-          text: 'Con volumi elevati concentrati in finestre temporali ristrette, non c\'era margine per processi lenti. Ogni ritardo si traduceva in posizioni scoperte nel momento in cui il business ne aveva più bisogno.',
+          text: 'Con volumi elevati concentrati in finestre temporali ristrette, non c\'era margine per processi lenti. Ogni ritardo si traduceva in posizioni scoperte proprio quando il business ne aveva più bisogno.',
         },
         {
           icon: BarChart3,
-          title: 'Richiesta di maggiore anticipo sui need futuri',
-          text: 'Identificare già nel pre-screening le competenze predittive di crescita era fondamentale per portarsi a casa informazioni utili alla costruzione di una pipeline di talento interna.',
+          title: 'Una richiesta di maggiore anticipo sui bisogni futuri',
+          text: 'Identificare le competenze predittive di crescita già in fase di pre-screening era essenziale per raccogliere informazioni utili alla costruzione di una pipeline di talento interna.',
         },
       ],
       hrChallenges: [
         {
-          icon: Zap,
+          icon: Clock,
           title: 'Troppo tempo intrappolato nello screening',
           text: 'Con migliaia di candidature da gestire, lo screening manuale assorbiva la maggior parte delle risorse disponibili, lasciando poco spazio all\'analisi approfondita e alla relazione con i candidati.',
         },
         {
-          icon: CheckCircle,
-          title: 'Difficoltà di individuazione del potenziale futuro',
+          icon: Eye,
+          title: 'Difficoltà nell\'individuare il potenziale futuro',
           text: 'Portare in azienda persone con il potenziale giusto per percorsi di sviluppo interno richiedeva dati strutturati che il CV da solo non era in grado di fornire.',
         },
         {
-          icon: Target,
+          icon: Search,
           title: 'Profili di nicchia difficili da intercettare',
           text: 'Alcuni ruoli strategici richiedevano competenze molto specifiche, difficili da rilevare tramite CV. Senza strumenti di valutazione oggettivi, il processo si allungava e il rischio di mancato match aumentava.',
         },
@@ -101,27 +101,27 @@ const content = {
       badge: 'OBIETTIVI DI COLLABORAZIONE',
       title: 'Cosa doveva cambiare',
       items: [
-        { icon: Zap, text: 'Scalare il pre-screening senza scalare il team: gestire migliaia di candidature con 3 FTE, liberando i recruiter dallo screening per concentrarli su colloqui e valutazione del potenziale' },
-        { icon: Eye, text: 'Rendere visibili le soft skill dal primo step: dati oggettivi su competenze trasversali e lingua inglese prima di impegnare ore di tempo del team recruiting' },
-        { icon: Shield, text: 'Sfruttare l\'AI come supporto al recruiter: garantendo maggiore velocità ed efficacia decisionale e mantenendo pieno controllo decisionale in ogni step' },
-        { icon: Target, text: 'Selezionare per il potenziale, non solo per la performance immediata: identificare candidati con competenze promettenti e indicative di una futura crescita all\'interno dell\'organizzazione' },
+        { icon: Zap, text: 'Scalare il pre-screening senza scalare il team: gestire migliaia di candidature con 3 FTE, liberando i recruiter dallo screening per concentrarli su colloqui e valutazione del potenziale.' },
+        { icon: Eye, text: 'Rendere visibili le soft skill dal primo step: dati oggettivi su soft skill e lingua inglese prima di impegnare ore di tempo del team recruiting.' },
+        { icon: Shield, text: 'Usare l\'AI come supporto al recruiter: garantendo maggiore velocità ed efficacia decisionale mantenendo pieno controllo decisionale in ogni step.' },
+        { icon: Target, text: 'Selezionare per il potenziale, non solo per la performance immediata: individuare candidati con competenze promettenti e indicative di una futura crescita nell\'organizzazione.' },
       ],
     },
     solution: {
       badge: 'LA SOLUZIONE',
-      title: 'Assessment AI con Skillvue',
+      title: 'Assessment AI scalabile con Skillvue',
       intro: "Skillvue è stato integrato nel processo di selezione di Europ Assistance Italia come primo step strutturato del funnel, gestendo il pre-screening su più profili e su più sedi geografiche. Il deployment è ricorrente, legato soprattutto ai due picchi stagionali annuali.",
       skillsLabel: 'COMPETENZE VALUTATE',
       skills: [
-        { icon: Heart, label: 'Soft skill — problem solving, orientamento al cliente, orientamento agli obiettivi, teamworking' },
-        { icon: Wrench, label: 'Lingua inglese — test B1/B2/C1, competenza critica per un\'azienda che opera in 39 paesi e gestisce assistenza multilingue' },
-        { icon: Layers, label: 'Hard skill role-specific — es. Compensation & Benefits sui ruoli HR' },
+        { icon: Heart, label: 'Soft skill — problem solving, orientamento al cliente, orientamento agli obiettivi, teamworking.' },
+        { icon: Wrench, label: 'Lingua inglese — test B1/B2/C1, competenza critica per un\'azienda che opera in 39 paesi e gestisce assistenza multilingue.' },
+        { icon: Layers, label: 'Hard skill role-specific — es. Compensation & Benefits sui ruoli HR.' },
       ],
       methodologyLabel: 'COME È STATO COSTRUITO',
       methodology: [
         {
           title: 'Assessment in autonomia come primo step',
-          text: 'Dopo la candidatura, ogni candidato completa l\'assessment in autonomia da qualsiasi dispositivo — telefono, tablet o laptop.',
+          text: 'Dopo la candidatura, ogni candidato completa l\'assessment in autonomia da qualsiasi dispositivo: telefono, tablet o laptop.',
         },
         {
           title: 'Report strutturato per il recruiter',
@@ -135,16 +135,15 @@ const content = {
     },
     results: {
       badge: 'RISULTATI',
-      title: 'Cosa sta cambiando.',
-      pillars: [
-        { icon: Target, value: <>Candidati<br />più qualificati</>, label: 'meno rumore, più segnali concreti per il team HR' },
-        { icon: Zap, value: <>Più tempo<br />per ciò che conta</>, label: 'colloqui più personalizzati e mirati, basati su dati reali' },
-        { icon: TrendingUp, value: <>Pipeline di talento<br />per il futuro</>, label: 'si seleziona guardando già al domani, non solo al fit immediato' },
-      ],
-      qualitative: [
-        { icon: BarChart3, title: 'Visibilità sul potenziale fin dal primo step', text: 'HR e line manager dispongono di dati strutturati sulle soft skill di ogni candidato già prima del colloquio — non solo fit immediato, ma segnali concreti di crescita nel tempo.' },
-        { icon: Scale, title: 'Recruiter liberati per il lavoro ad alto valore', text: 'Il tempo recuperato è reinvestito in colloqui più approfonditi e analisi del potenziale — attività che incidono direttamente sulla qualità delle assunzioni e sulla retention.' },
-        { icon: Heart, title: 'Candidate experience ottimizzata', text: 'L\'assessment pre-colloquio offre un momento di maggiore espressione personale rispetto al solo invio di CV: quando viene data la possibilità di mettersi alla prova, i candidati rispondono positivamente.' },
+      title: 'Cosa sta cambiando',
+      intro: 'L\'impatto concreto che Europ Assistance Italia ha ottenuto integrando Skillvue durante i picchi stagionali di selezione più intensi.',
+      cards: [
+        { icon: Target, title: 'Candidati più qualificati', text: 'meno rumore, più segnali concreti per il team HR' },
+        { icon: Zap, title: 'Decisioni di selezione basate sui dati', text: 'colloqui più personalizzati, decisioni basate su dati reali' },
+        { icon: TrendingUp, title: 'Pipeline di talento per il futuro', text: 'si assume guardando già al domani, non solo al fit immediato' },
+        { icon: BarChart3, title: 'Visibilità sul potenziale reale prima del colloquio', text: 'dati sulle soft skill con segnali chiari di potenziale e crescita' },
+        { icon: Scale, title: 'Più tempo per il recruiting ad alto valore', text: 'focus sul miglioramento della qualità delle assunzioni e della retention' },
+        { icon: Heart, title: 'Candidate experience migliorata', text: 'più spazio ai candidati per esprimersi' },
       ],
     },
     quote: {
@@ -166,15 +165,15 @@ const content = {
     breadcrumb: 'Customers',
     badge: 'CUSTOMER STORY',
     headline: {
-      before: 'Europ Assistance: how to recognise the ',
+      before: 'Europ Assistance: how to spot the ',
       highlight1: 'potential that stands the test of time',
-      middle: ' in a business built on ',
-      highlight2: 'human interaction',
+      middle: ' in a business built on the ',
+      highlight2: 'human factor',
       after: '',
     },
-    subtitle: "With Skillvue, Europ Assistance transformed candidate pre-screening into a scalable, strategic process for the entire talent lifecycle — developing cross-functional skills from the very first step of the recruitment journey.",
+    subtitle: "With Skillvue, Europ Assistance turned candidate pre-screening into a scalable, strategic process for the entire talent lifecycle, putting soft skills at the center from the very first step of hiring.",
     heroMetrics: [
-      { value: '10,000', label: 'centres in Italy\'s network' },
+      { value: '10,000', label: 'service centers in the network in Italy' },
       { value: '900+', label: 'employees' },
     ],
     ctaPrimary: 'Contact Us',
@@ -185,55 +184,55 @@ const content = {
       facts: [
         { label: 'Industry', value: 'Financial Services' },
         { label: 'Group', value: 'Generali' },
-        { label: 'Centres in Italy\'s network', value: '10,000' },
+        { label: 'Service centers in Italy', value: '10,000' },
         { label: 'Use Case', value: 'Hiring' },
       ],
     },
     context: {
       badge: 'CONTEXT',
-      title: 'In a business built on human interaction, the quality of hiring cannot afford to compromise.',
+      title: 'In a business built on human interaction, hiring quality can\'t accept compromises.',
       paragraph: <>
-        Europ Assistance, part of the <strong className="text-[#121212]/80 font-semibold">Generali Group</strong> and recently rebranded alongside Generali Employee Benefits under the new global care brand <strong className="text-[#121212]/80 font-semibold">Redion</strong>, is one of the world's leading providers of assistance and travel insurance services. Its growth is constant: operations are expanding into new markets and converging with Generali Care into an <strong className="text-[#121212]/80 font-semibold">integrated assistance hub</strong>.<br /><br />In Italy, it operates with a business model built on the quality of human interaction: <strong className="text-[#121212]/80 font-semibold">24/7 assistance, claims management, multilingual customer care</strong>. <strong className="text-[#121212]/80 font-semibold">Hiring and developing the right people</strong> is a critical lever for the business to function and grow, especially given the instability of the insurance sector — which <strong className="text-[#121212]/80 font-semibold">doesn't always attract top talent</strong> and at the same time demands <strong className="text-[#121212]/80 font-semibold">very specific professional profiles capable of evolving over time</strong>. In this context, every wrong hire costs more and every right person who stays is worth even more.
+        Europ Assistance, part of the <strong className="text-[#121212]/80 font-semibold">Generali Group</strong>, is one of the world leaders in assistance services and travel insurance. Its growth is steady: it is expanding operations into new markets and converging with Generali Care into an <strong className="text-[#121212]/80 font-semibold">integrated assistance hub</strong>.<br /><br />In Italy, it operates with a business model built on the quality of human interaction: <strong className="text-[#121212]/80 font-semibold">24/7 assistance, claims management, multilingual customer care</strong>. Choosing and growing <strong className="text-[#121212]/80 font-semibold">people</strong> is a key factor for the proper functioning and expansion of the business, especially given the instability of the insurance sector, which <strong className="text-[#121212]/80 font-semibold">does not always manage to attract the most qualified profiles</strong> and at the same time requires <strong className="text-[#121212]/80 font-semibold">very specific professional profiles able to evolve over time</strong>. In this context, every wrong hire costs more and every right person who stays is worth even more.
       </>,
     },
     challenge: {
       badge: 'THE CHALLENGE',
-      title: 'Thousands of applications, 2 seasonal peaks, 3 people in the recruiting team.',
-      intro: "Europ Assistance Italia's hires are concentrated in 2 seasonal peaks per year, generating volumes in the order of thousands of applications in just a few months. For assistance and customer care roles, soft skills are the top predictor of success — problem solving, customer orientation, stress management — but are completely invisible in a CV.",
-      businessLabel: 'BUSINESS IMPACT',
-      hrLabel: 'HR & PEOPLE IMPACT',
+      title: 'Thousands of applications, 2 seasonal peaks, 3 people on the recruiting team.',
+      intro: "Europ Assistance Italia's hiring is concentrated in two seasonal peaks a year, generating volumes in the order of thousands of applications in a few months. For assistance and customer care roles, soft skills are the leading predictor of success: problem solving, customer orientation, stress management, yet they are completely invisible on a CV.",
+      businessLabel: 'BUSINESS CHALLENGES',
+      hrLabel: 'HR & PEOPLE CHALLENGES',
       businessChallenges: [
         {
           icon: TrendingUp,
-          title: 'Need to grow at the pace the business demands',
-          text: "Business needs were constantly increasing and the speed of response required was always higher. Being faster and more effective for HR in delivering expected results had become an operational necessity.",
+          title: 'The need to grow at the pace of the business',
+          text: "Needs grew constantly and the required response speed increased. Being faster and more effective for HR in achieving expected results had become an operational necessity.",
         },
         {
           icon: Users,
-          title: 'Managing complexity at seasonal peaks',
-          text: "With high volumes concentrated in narrow time windows, there was no room for slow processes. Every delay meant open positions at precisely the moment the business needed them filled.",
+          title: 'Complex management during seasonal peaks',
+          text: "With high volumes concentrated in narrow time windows, there was no room for slow processes. Every delay translated into open positions exactly when the business needed them most.",
         },
         {
           icon: BarChart3,
-          title: 'Need for greater foresight on future needs',
-          text: "Identifying predictive growth skills already at the pre-screening stage was key to building useful information for an internal talent pipeline.",
+          title: 'A demand for more foresight on future needs',
+          text: "Identifying growth-predictive skills as early as pre-screening was essential to gather information useful for building an internal talent pipeline.",
         },
       ],
       hrChallenges: [
         {
-          icon: Zap,
+          icon: Clock,
           title: 'Too much time trapped in screening',
-          text: "With thousands of applications to manage, manual screening absorbed most of the available resources, leaving little room for in-depth analysis and candidate relationship building.",
+          text: "With thousands of applications to handle, manual screening absorbed most of the available resources, leaving little room for in-depth analysis and the relationship with candidates.",
         },
         {
-          icon: CheckCircle,
-          title: 'Difficulty identifying future potential',
-          text: "Bringing in people with the right potential for internal development paths required structured data that a CV alone was not able to provide.",
+          icon: Eye,
+          title: 'Difficulty in spotting future potential',
+          text: "Bringing in people with the right potential for internal development paths required structured data that the CV alone couldn't provide.",
         },
         {
-          icon: Target,
+          icon: Search,
           title: 'Niche profiles hard to identify',
-          text: "Some strategic roles required very specific skills, difficult to assess from a CV. Without objective evaluation tools, the process slowed down and the risk of a poor match increased.",
+          text: "Some strategic roles required very specific skills, hard to detect via CV. Without objective assessment tools, the process dragged on and the risk of a mismatch increased.",
         },
       ],
     },
@@ -241,54 +240,53 @@ const content = {
       badge: 'COLLABORATION OBJECTIVES',
       title: 'What needed to change',
       items: [
-        { icon: Zap, text: 'Scale pre-screening without scaling the team: manage thousands of applications with 3 FTE, freeing recruiters from screening to focus on interviews and potential evaluation' },
-        { icon: Eye, text: 'Make soft skills visible from the first step: objective data on cross-functional skills and English language needed to be available before committing hours of the recruiting team\'s time' },
-        { icon: Shield, text: 'Leverage AI as support to the recruiter: ensuring greater speed and decision-making effectiveness while maintaining full decision-making control at every step' },
-        { icon: Target, text: 'Select for potential, not just immediate performance: identify candidates with promising skills indicative of future growth within the organisation' },
+        { icon: Zap, text: 'Scale pre-screening without scaling the team: handle thousands of applications with 3 FTEs, freeing recruiters from screening to focus on interviews and potential assessment.' },
+        { icon: Eye, text: 'Make soft skills visible from the first step: objective data on soft skills and English language before committing hours of the recruiting team\'s time.' },
+        { icon: Shield, text: 'Use AI as support for the recruiter: ensuring greater speed and decision-making effectiveness while keeping full decision control at every step.' },
+        { icon: Target, text: 'Hire for potential, not just immediate performance: identify candidates with promising skills indicative of future growth within the organization.' },
       ],
     },
     solution: {
       badge: 'THE SOLUTION',
-      title: 'AI Assessment with Skillvue',
-      intro: "Skillvue was integrated into Europ Assistance Italia's hiring process as the first structured step of the funnel, managing pre-screening across multiple profiles and geographic locations. Deployment is recurring, tied primarily to the two annual seasonal peaks.",
+      title: 'AI-scaled assessment with Skillvue',
+      intro: "Skillvue was integrated into Europ Assistance Italia's hiring process as the first structured step of the funnel, handling pre-screening across multiple profiles and multiple locations. The deployment is recurring, tied mainly to the two annual seasonal peaks.",
       skillsLabel: 'SKILLS ASSESSED',
       skills: [
-        { icon: Heart, label: 'Soft skills — problem solving, customer orientation, goal orientation, teamworking' },
-        { icon: Wrench, label: 'English language — B1/B2/C1 tests, a critical skill for a company operating in 39 countries with multilingual customer care' },
-        { icon: Layers, label: 'Role-specific hard skills — e.g. Compensation & Benefits for HR roles' },
+        { icon: Heart, label: 'Soft skills — problem solving, customer orientation, goal orientation, teamworking.' },
+        { icon: Wrench, label: 'English language — B1/B2/C1 test, a critical skill for a company operating in 39 countries and managing multilingual assistance.' },
+        { icon: Layers, label: 'Role-specific hard skills — e.g. Compensation & Benefits for HR roles.' },
       ],
       methodologyLabel: 'HOW IT WAS BUILT',
       methodology: [
         {
-          title: 'Assessment is done independently as first step',
-          text: "After applying, every candidate completes the assessment independently from any device — phone, tablet or laptop.",
+          title: 'Self-serve assessment as the first step',
+          text: "After applying, each candidate completes the assessment independently from any device: phone, tablet or laptop.",
         },
         {
           title: 'Structured report for the recruiter',
-          text: "The HR team receives an objective, in-depth skills analysis. The first interview is based on data, not impressions.",
+          text: "The HR team receives an initial objective, in-depth analysis of the skills. The first interview is based on data, not impressions.",
         },
         {
           title: 'Human-in-the-loop at every stage',
-          text: "The HR team maintains full decision-making control throughout. Skillvue data structures and informs the judgement, without ever replacing the recruiter's evaluation.",
+          text: "The HR team keeps full decision control at every stage. Skillvue data structures and informs the judgment, without ever replacing the recruiter's assessment.",
         },
       ],
     },
     results: {
       badge: 'RESULTS',
-      title: 'What is changing.',
-      pillars: [
-        { icon: Target, value: <>Higher-quality<br />candidates</>, label: 'less noise, more concrete signals for the HR team' },
-        { icon: Zap, value: <>More time<br />for what matters</>, label: 'more personalised and targeted interviews, based on real data' },
-        { icon: TrendingUp, value: <>Talent pipeline<br />for the future</>, label: 'hiring with tomorrow already in mind, not just immediate fit' },
-      ],
-      qualitative: [
-        { icon: BarChart3, title: 'Visibility on true potential from the first step', text: 'HR and line managers have structured soft skill data on every candidate before the interview — not just immediate fit, but concrete signals of growth over time.' },
-        { icon: Scale, title: 'Recruiters free to do high-value work', text: 'Time saved in pre-screening is reinvested in more in-depth interviews and potential analysis — activities that directly impact hiring quality and retention.' },
-        { icon: Heart, title: 'Enhanced candidate experience', text: 'More room for self-expression: when given the chance to prove themselves, candidates respond positively and enthusiastically.' },
+      title: 'What is changing',
+      intro: 'The remarkable impact Europ Assistance Italia unlocked by deploying Skillvue during their most intense seasonal hiring peaks.',
+      cards: [
+        { icon: Target, title: 'More higher-quality candidates', text: 'less noise, more concrete signals for the HR team' },
+        { icon: Zap, title: 'Data-driven hiring decisions', text: 'more personalised interviews, decisions based on real data' },
+        { icon: TrendingUp, title: 'Talent pipeline for the future', text: 'hiring with tomorrow already in mind, not just immediate fit' },
+        { icon: BarChart3, title: 'Visibility on true potential before interview', text: 'soft-skill data with clear signals of potential and growth' },
+        { icon: Scale, title: 'More time for high-value recruiting', text: 'focus on improving hiring quality and retention' },
+        { icon: Heart, title: 'Enhanced candidate experience', text: 'more room for candidates to express themselves' },
       ],
     },
     quote: {
-      text: 'I believe hiring and development must speak the same language: the data collected today becomes the foundation for tomorrow\'s growth.',
+      text: 'I believe hiring and development must speak the same language: the data gathered today becomes the foundation for tomorrow\'s growth.',
       author: 'Nicole Cerruti',
       role: 'Recruitment Manager, Europ Assistance Italia',
     },
@@ -508,36 +506,21 @@ export default function EuropAssistanceLandingPage() {
 
             {/* RESULTS */}
             <Section className="mb-24">
-              <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{c.results.badge}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{c.results.title}</h2>
-
-              {/* Qualitative pillars */}
-              <div className="rounded-2xl bg-[#0E0E0E] p-10 lg:p-14 mb-10">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-10 max-w-3xl mx-auto">
-                  {c.results.pillars.map(({ icon: Icon, value, label }) => (
-                    <div key={label} className="text-center flex flex-col items-center">
-                      <div className="w-16 h-16 mb-5 flex items-center justify-center rounded-2xl" style={{ background: 'rgba(75,77,247,0.12)' }}>
-                        <Icon className="h-8 w-8" style={{ color: '#4b4df7' }} />
-                      </div>
-                      <span className="block text-white font-bold mb-2 leading-tight" style={{ fontSize: 'clamp(0.95rem,1.8vw,1.15rem)', letterSpacing: '-0.02em' }}>{value}</span>
-                      <span className="text-[13px] text-white/[0.55] leading-[1.4]">{label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
+              <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#16a34a' }}>{c.results.badge}</span>
+              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{c.results.title}</h2>
+              <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-10">{c.results.intro}</p>
 
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">
-                {c.results.qualitative.map((q) => (
-                  <div key={q.title} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
-                    <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-5" style={{ background: 'rgba(75,77,247,0.08)' }}>
-                      <q.icon className="h-5 w-5" style={{ color: '#4b4df7' }} />
+                {c.results.cards.map((r) => (
+                  <div key={r.title} className="rounded-2xl border border-[#16a34a]/[0.14] bg-[#16a34a]/[0.03] p-7">
+                    <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-5" style={{ background: 'rgba(22,163,74,0.1)' }}>
+                      <r.icon className="h-5 w-5" style={{ color: '#16a34a' }} />
                     </div>
-                    <h4 className="text-[15px] font-semibold text-[#121212] mb-3 leading-[1.4]">{q.title}</h4>
-                    <p className="text-[14px] text-[#121212]/55 leading-[1.65]">{q.text}</p>
+                    <h4 className="text-[15px] font-semibold text-[#121212] mb-3 leading-[1.4]">{r.title}</h4>
+                    <p className="text-[14px] text-[#121212]/55 leading-[1.65]">{r.text}</p>
                   </div>
                 ))}
               </div>
-
             </Section>
 
             {/* QUOTE */}


### PR DESCRIPTION
## Summary
Updates the standalone landing page `/lp/europ-assistance` so its copy and structure match the finalized customer story document. Only the landing page is touched — the live customer story at `/customers/europ-assistance` is unaffected.

## Changes (1 file)
- `M pages/lp/europ-assistance.tsx`
  - Hero: headline ("spot" / "human factor"), new subtitle, updated metrics label
  - Context / Challenge / Objectives / Solution: copy aligned to the final wording; challenge labels renamed to "Business challenges" / "HR & People challenges"
  - Results: restructured into a six-card grid with an intro line (green accent)
  - Quote wording updated ("gathered")
  - Applied to both IT and EN

Kept as web elements (not present in a static PDF): hero video, Related Stories, final CTA.

## Test plan
- [ ] `/lp/europ-assistance` renders with the updated copy and 6-card results grid
- [ ] `/customers/europ-assistance` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)