### PR TITLE
Fix mobile layout issues across hero, cards, and customer pages

### DIFF
--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -14,7 +14,7 @@ export default function CTASection() {
     <section id="cta" data-testid="cta-section" className="relative pt-20 pb-16 md:pt-28 md:pb-20 lg:pt-36 lg:pb-24" ref={ref}>
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <m.div
-          className="mb-6 md:mb-8"
+          className="mb-8 md:mb-8"
           initial={{ opacity: 0, y: 40 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.8 }}
@@ -26,7 +26,7 @@ export default function CTASection() {
         </m.div>
 
         <m.div
-          className="grid grid-cols-2 lg:grid-cols-12 gap-3 md:gap-4"
+          className="grid grid-cols-2 lg:grid-cols-12 gap-5 md:gap-4"
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.8, delay: 0.2 }}
@@ -42,7 +42,7 @@ export default function CTASection() {
               <h3 className="text-[20px] md:text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-white/85 mt-3 md:mt-5 mb-2 md:mb-4 leading-tight">
                 {t('Book a 30-min Demo')}
               </h3>
-              <p className="text-[12px] md:text-[17px] text-white/[0.65] mb-0 md:mb-8 max-w-md leading-[1.5] md:leading-normal">
+              <p className="text-[12px] md:text-[17px] text-white/[0.65] mb-5 md:mb-8 max-w-md leading-[1.5] md:leading-normal">
                 {t('See Skillvue live with your specific use case')}
               </p>
             </div>
@@ -62,7 +62,7 @@ export default function CTASection() {
             data-testid="cta-track-b"
             className="col-span-2 md:col-span-1 lg:col-span-6 group relative rounded-2xl md:rounded-3xl border border-white/[0.04] hover:border-white/[0.08] bg-white/[0.01] backdrop-blur-sm transition-all duration-700 p-5 md:p-10"
           >
-            <span className="text-[11px] font-bold text-[#9B9DFB] tracking-[0.1em] uppercase mb-0 md:mb-10 block">{t('Our Customers')}</span>
+            <span className="text-[11px] font-bold text-[#9B9DFB] tracking-[0.1em] uppercase mb-5 md:mb-10 block">{t('Our Customers')}</span>
             {(() => {
               const ctaLogos = [
                     { name: 'Moncler', src: '/logos/client-moncler.svg' },
@@ -76,7 +76,7 @@ export default function CTASection() {
                     { name: 'Europ Assistance', src: '/logos/client-europ-assistance.svg' },
                   ];
               return (
-                <div className="grid grid-cols-3 gap-x-4 gap-y-3 md:gap-x-10 md:gap-y-8 mb-3 md:mb-8">
+                <div className="grid grid-cols-3 gap-x-4 gap-y-5 md:gap-x-10 md:gap-y-8 mb-3 md:mb-8">
                   {ctaLogos.map((logo) => (
                     <div key={logo.name} className="flex items-center justify-center h-8 md:h-12">
                       <img

--- a/components/landing/CustomerStoriesSection.tsx
+++ b/components/landing/CustomerStoriesSection.tsx
@@ -60,7 +60,7 @@ export default function CustomerStoriesSection() {
             <m.div
               key={s.company}
               data-testid={`story-${s.company.toLowerCase().replace(/\s+/g, '-')}`}
-              className="group rounded-2xl border border-white/[0.07] bg-white/[0.04] hover:bg-white/[0.06] hover:border-white/[0.14] backdrop-blur-sm p-5 md:p-10 transition-all duration-500 cursor-pointer flex flex-col justify-between gap-5 md:gap-8 min-h-[220px] md:min-h-0"
+              className="group rounded-2xl border border-white/[0.07] bg-white/[0.04] hover:bg-white/[0.06] hover:border-white/[0.14] backdrop-blur-sm p-5 md:p-10 transition-all duration-500 cursor-pointer flex flex-col justify-between gap-5 md:gap-8"
               initial={{ opacity: 0, y: 25 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: 0.1 + i * 0.1 }}

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -57,9 +57,9 @@ export default function HeroSection() {
               >
                 {lang === 'en' ? (
                   <>
-                    <span className="whitespace-nowrap">The Skills</span><br />
-                    <span className="italic font-bold gradient-text whitespace-nowrap">Operating System</span><br />
-                    <span className="whitespace-nowrap">for your organization</span>
+                    <span className="md:whitespace-nowrap">The Skills</span><br />
+                    <span className="italic font-bold gradient-text md:whitespace-nowrap">Operating System</span><br />
+                    <span className="md:whitespace-nowrap">for your organization</span>
                   </>
                 ) : (
                   <>

--- a/components/landing/ProblemSection.tsx
+++ b/components/landing/ProblemSection.tsx
@@ -72,7 +72,7 @@ export default function ProblemSection() {
             <m.div
               key={card.stat + i}
               data-testid={`pain-card-${card.stat.replace('%', '')}`}
-              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col min-h-[240px] md:min-h-0"
+              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col"
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: i * 0.12, ease: 'easeOut' }}

--- a/components/landing/ROISection.tsx
+++ b/components/landing/ROISection.tsx
@@ -68,7 +68,7 @@ export default function ROISection() {
             <m.div
               key={stat.value}
               data-testid={`roi-stat-${stat.value}`}
-              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-10 flex flex-col min-h-[240px] md:min-h-0"
+              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-10 flex flex-col"
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: 0.15 + i * 0.12, ease: 'easeOut' }}

--- a/components/science/ScienceTeam.tsx
+++ b/components/science/ScienceTeam.tsx
@@ -72,7 +72,7 @@ export default function ScienceTeam() {
           transition={{ duration: 0.6, delay: 0.1 }}
         >
           <div className="flex flex-col md:flex-row gap-5 md:gap-8 lg:gap-12 items-start">
-            <div className="shrink-0 w-[clamp(6rem,25vw,12rem)] aspect-square rounded-xl md:rounded-2xl overflow-hidden bg-[#F5F5FA]">
+            <div className="shrink-0 w-full md:w-[clamp(6rem,25vw,12rem)] aspect-square rounded-xl md:rounded-2xl overflow-hidden bg-[#F5F5FA]">
               <img src={lead.photo} alt={lead.name} className="w-full h-full object-cover" />
             </div>
             <div className="flex-1 pt-0 md:pt-2">

--- a/components/solutions/pr/PRProblem.tsx
+++ b/components/solutions/pr/PRProblem.tsx
@@ -32,7 +32,7 @@ export default function PRProblem() {
             <motion.div
               key={p.title}
               data-testid={`pr-pain-${i}`}
-              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col min-h-[240px] md:min-h-0"
+              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col"
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: i * 0.12, ease: 'easeOut' }}

--- a/components/solutions/ta/TAProblem.tsx
+++ b/components/solutions/ta/TAProblem.tsx
@@ -33,7 +33,7 @@ export default function TAProblem() {
             <motion.div
               key={p.stat}
               data-testid={`ta-pain-${i}`}
-              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col min-h-[240px] md:min-h-0"
+              className="group bg-white border border-[#E5E7EB] rounded-2xl p-5 md:p-6 lg:p-10 flex flex-col"
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: i * 0.12, ease: 'easeOut' }}

--- a/pages/customers/adr-2.tsx
+++ b/pages/customers/adr-2.tsx
@@ -316,7 +316,7 @@ export default function AdRStoryPage2() {
             </div>
 
             {/* Full-width metrics */}
-            <motion.div className="grid grid-cols-3 gap-2 md:gap-4 mt-12" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.6 }}>
+            <motion.div className="grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4 mt-12" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.6 }}>
               {c.heroMetrics.map(m => (
                 <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                   <span className="block text-white text-[19px] break-words stat-value md:text-[1.7rem]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/adr.tsx
+++ b/pages/customers/adr.tsx
@@ -366,7 +366,7 @@ export default function ADRStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/carrefour.tsx
+++ b/pages/customers/carrefour.tsx
@@ -360,7 +360,7 @@ export default function CarrefourStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/credem.tsx
+++ b/pages/customers/credem.tsx
@@ -330,7 +330,7 @@ export default function CredemStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/douglas.tsx
+++ b/pages/customers/douglas.tsx
@@ -330,7 +330,7 @@ export default function DouglasStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/eataly-2.tsx
+++ b/pages/customers/eataly-2.tsx
@@ -333,7 +333,7 @@ export default function EatalyStoryPage() {
                     {c.headline.before}<span style={{ color: '#7b7df9' }}>{c.headline.highlight1}</span>{c.headline.middle}{c.headline.highlight2 && <span style={{ color: '#7b7df9' }}>{c.headline.highlight2}</span>}{c.headline.after}
                   </h1>
                   <p className="text-[17px] text-white/[0.60] leading-[1.75] mb-12 max-w-2xl">{c.subtitle}</p>
-                  <div className="grid grid-cols-3 gap-2 md:gap-4 mb-12">
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4 mb-12">
                     {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                         <span className="block text-white text-[19px] break-words stat-value md:text-[1.7rem]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/eataly-3.tsx
+++ b/pages/customers/eataly-3.tsx
@@ -333,7 +333,7 @@ export default function EatalyStoryPage() {
                     {c.headline.before}<span style={{ color: '#7b7df9' }}>{c.headline.highlight1}</span>{c.headline.middle}{c.headline.highlight2 && <span style={{ color: '#7b7df9' }}>{c.headline.highlight2}</span>}{c.headline.after}
                   </h1>
                   <p className="text-[16px] text-white/[0.60] leading-[1.75] mb-10 max-w-2xl">{c.subtitle}</p>
-                  <div className="grid grid-cols-3 gap-2 md:gap-4 mb-10">
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4 mb-10">
                     {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-2.5 py-2.5 md:px-5 md:py-4">
                         <span className="block text-white text-[19px] break-words stat-value md:text-[1.5rem]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/eataly.tsx
+++ b/pages/customers/eataly.tsx
@@ -338,7 +338,7 @@ export default function EatalyStoryPage() {
                     </Button>
                   </div>
                   {/* Metrics — pinned to bottom, aligned with client card */}
-                  <div className="mt-auto pt-6 grid grid-cols-2 gap-2 md:gap-4">
+                  <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4">
                     {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                         <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/europ-assistance-2.tsx
+++ b/pages/customers/europ-assistance-2.tsx
@@ -347,7 +347,7 @@ export default function EuropAssistance2StoryPage() {
                     {c.headline.before}<span style={{ color: '#7b7df9' }}>{c.headline.highlight1}</span>{c.headline.middle}<span style={{ color: '#7b7df9' }}>{c.headline.highlight2}</span>{c.headline.after}
                   </h1>
                   <p className="text-[17px] text-white/[0.60] leading-[1.75] mb-12 max-w-2xl">{c.subtitle}</p>
-                  <div className="grid grid-cols-3 gap-2 md:gap-4 mb-12">
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4 mb-12">
                     {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                         <span className="block text-white text-[19px] break-words stat-value md:text-[1.7rem]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/europ-assistance.tsx
+++ b/pages/customers/europ-assistance.tsx
@@ -360,7 +360,7 @@ export default function EuropAssistanceStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-2 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/fidia-farmaceutici.tsx
+++ b/pages/customers/fidia-farmaceutici.tsx
@@ -332,7 +332,7 @@ export default function FidiaFarmaceuticiStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/mediaset-1.tsx
+++ b/pages/customers/mediaset-1.tsx
@@ -376,7 +376,7 @@ export default function Mediaset1StoryPage() {
 
             {/* Hero metrics — horizontal row */}
             <motion.div className="mt-12" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.8 }}>
-              <div className="grid grid-cols-3 gap-2 md:gap-5">
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-5">
                 {c.heroMetrics.map(m => (
                   <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-5 text-center">
                     <span className="block text-white text-[19px] break-words stat-value md:text-[1.7rem]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/mediaset-2.tsx
+++ b/pages/customers/mediaset-2.tsx
@@ -339,7 +339,7 @@ export default function Mediaset2StoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-2.5 py-2 md:px-5 md:py-3.5 text-center">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.3rem,2.2vw,1.5rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/mediaset.tsx
+++ b/pages/customers/mediaset.tsx
@@ -338,7 +338,7 @@ export default function MediasetStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/subdued.tsx
+++ b/pages/customers/subdued.tsx
@@ -366,7 +366,7 @@ export default function SubduedStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>

--- a/pages/customers/unicomm.tsx
+++ b/pages/customers/unicomm.tsx
@@ -336,7 +336,7 @@ export default function UnicommStoryPage() {
                     </Button>
                   </div>
                     {/* Metrics — pinned to bottom, aligned with client card */}
-                    <div className="mt-auto pt-6 grid grid-cols-3 gap-2 md:gap-4">
+                    <div className="mt-auto pt-6 grid grid-cols-1 gap-2 md:grid-cols-3 md:gap-4">
                       {c.heroMetrics.map(m => (
                       <div key={m.value} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 md:px-6 md:py-4">
                       <span className="block text-white text-[19px] break-words stat-value md:text-[clamp(1.4rem,2.4vw,1.9rem)]" style={{ lineHeight: 1, letterSpacing: '-0.03em' }}>{m.value}</span>


### PR DESCRIPTION
## Summary
- Hero headline no longer overflows the viewport on mobile — `whitespace-nowrap` on the three headline lines was forcing text wider than the screen; now only applied from `md` up.
- Removed hardcoded mobile `min-h` on ROI, Problem, and Customer Stories cards (homepage + PR/TA solution pages) that left large empty space below shorter card content.
- Science team lead photo now fills the card width on mobile instead of staying capped at a small clamp size meant for the desktop side-by-side layout.
- CTA section: restored vertical spacing between stacked cards and between text/CTA elements that felt clustered on mobile.
- All 16 customer story pages: hero metric cards (2-3 stat tiles) now stack vertically on mobile instead of squeezing into a cramped fixed-column grid.

## Test plan
- [x] Verified hero section on 390px viewport: no horizontal overflow (scrollWidth == clientWidth)
- [x] Verified ROI/Problem/Story cards hug their content height on mobile (no dead space)
- [x] Verified science team lead photo fills container width on mobile
- [x] Verified CTA section spacing reads cleanly on mobile
- [x] Verified Carrefour customer page metric cards stack vertically on mobile with no overflow
- [ ] Spot-check remaining 15 customer pages in browser (same shared pattern, mechanically identical fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)