### PR TITLE
Standardize CTA arrow icons to 16px, refine Mediaset hero quote

### DIFF
--- a/components/customers/CustomerStoriesShowcase.tsx
+++ b/components/customers/CustomerStoriesShowcase.tsx
@@ -56,10 +56,9 @@ export default function CustomerStoriesShowcase() {
                 }}
               >
                 {/* Decorative circular scroll-indicator badge — kept custom since it isn't
-                    the standard trailing arrow icon Button expects; size pinned with
-                    !size-4 so Button's own [&_svg]:size-6 rule doesn't blow it up. */}
+                    the standard trailing arrow icon Button expects. */}
                 <span className="w-10 h-10 rounded-full border border-white/[0.1] flex items-center justify-center group-hover:border-white/[0.25] transition-all duration-300">
-                  <ChevronDown className="!size-4" />
+                  <ChevronDown className="size-4" />
                 </span>
                 {t('Explore all stories')}
               </a>

--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -148,7 +148,7 @@ export default function ExploreStories() {
                     <span className="text-[clamp(1.8rem,3.5vw,3rem)] font-bold text-white/90 tracking-tight">{s.company}</span>
                   </div>
                   <div className="absolute bottom-5 right-5 opacity-0 group-hover:opacity-100 transition-opacity duration-400">
-                    <ArrowRight className="h-5 w-5 text-white/50" />
+                    <ArrowRight className="h-4 w-4 text-white/50" />
                   </div>
                 </div>
                 {/* Title below. left aligned with card, with left padding */}

--- a/components/product/HowSkillvueWorks.tsx
+++ b/components/product/HowSkillvueWorks.tsx
@@ -88,14 +88,14 @@ export default function HowSkillvueWorks() {
               aria-label="Previous step"
               className="group flex items-center justify-center h-9 w-9 md:h-11 md:w-11 rounded-full border border-white/10 text-white/40 hover:text-white/80 hover:border-white/25 transition-all duration-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
-              <ChevronLeft className="h-3.5 w-3.5 md:h-4 md:w-4" />
+              <ChevronLeft className="h-4 w-4" />
             </button>
             <button
               onClick={() => setActive((p) => (p + 1) % steps.length)}
               aria-label="Next step"
               className="group flex items-center justify-center h-9 w-9 md:h-11 md:w-11 rounded-full border border-white/15 text-white/60 hover:text-white/90 hover:border-white/30 transition-all duration-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
-              <ChevronRight className="h-3.5 w-3.5 md:h-4 md:w-4" />
+              <ChevronRight className="h-4 w-4" />
             </button>
           </div>
         </div>

--- a/components/science/MethodologyLifecycle.tsx
+++ b/components/science/MethodologyLifecycle.tsx
@@ -116,14 +116,14 @@ export default function MethodologyLifecycle() {
                 aria-label="Previous principle"
                 className="flex items-center justify-center h-8 w-8 rounded-full border border-white/10 text-white/40 active:text-white/80 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
               >
-                <ChevronLeft className="h-3.5 w-3.5" />
+                <ChevronLeft className="h-4 w-4" />
               </button>
               <button
                 onClick={() => setActivePrinciple((p) => (p + 1) % principles.length)}
                 aria-label="Next principle"
                 className="flex items-center justify-center h-8 w-8 rounded-full border border-white/15 text-white/60 active:text-white/90 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
               >
-                <ChevronRight className="h-3.5 w-3.5" />
+                <ChevronRight className="h-4 w-4" />
               </button>
             </div>
           </div>

--- a/components/shared/ProductCrossLinks.tsx
+++ b/components/shared/ProductCrossLinks.tsx
@@ -41,7 +41,7 @@ export default function ProductCrossLinks() {
                     <span className="text-[15px] md:text-[15px] font-semibold text-white/85 block mb-0.5 md:mb-1 leading-tight">{t(s.name)}</span>
                     <span className="text-[12px] md:text-[13px] text-white/40">{t(s.desc)}</span>
                   </div>
-                  <ArrowRight className="h-3 w-3 md:h-4 md:w-4 text-white/20 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-300 shrink-0 hidden md:block" />
+                  <ArrowRight className="h-4 w-4 text-white/20 group-hover:text-[#9B9DFB] group-hover:translate-x-1 transition-all duration-300 shrink-0 hidden md:block" />
                 </div>
               </motion.button>
             ))}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
  * default background is dark).
  */
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-full text-[15px] font-medium leading-6 whitespace-nowrap transition-colors duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-6 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 rounded-full text-[15px] font-medium leading-6 whitespace-nowrap transition-colors duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -1144,7 +1144,7 @@ export const translations = {
   'ABOUT SKILLVUE': 'ABOUT SKILLVUE',
   "Founded in Milan in 2021, at the heart of one of Europe's most dynamic startup hubs, Skillvue is an HR-Tech company that helps organizations make every talent decision objective. Backed by €9M in funding, Skillvue supports 30+ languages and serves 100+ mid-to-large enterprises across industries such as retail, financial services, pharma, and energy.": "Fondata a Milano nel 2021, nel cuore di uno degli ecosistemi startup più dinamici d'Europa, Skillvue è un'azienda HR Tech che aiuta le organizzazioni a rendere ogni decisione sul talento oggettiva. Sostenuta da €9M di finanziamenti, Skillvue supporta oltre 30 lingue e serve più di 100 aziende medio-grandi in settori come retail, servizi finanziari, farmaceutico ed energia.",
   'With a team of 50+ professionals across Milan, Berlin, and London, Skillvue brings together expertise in psychometrics, AI, product design, and enterprise go-to-market. Its platform combines psychometric rigour with modern AI to transform static and unstructured talent data into reliable, predictive insights, supporting decisions across hiring, performance management, internal mobility, and learning & development.': "Con un team di oltre 50 professionisti tra Milano, Berlino e Londra, Skillvue unisce la solidità della scienza psicometrica con la potenza dell'AI moderna, product design e go-to-market enterprise. La sua piattaforma combina rigore psicometrico con AI moderna per trasformare dati statici e non strutturati sul talento in insight affidabili e predittivi, supportando decisioni in ambito di assunzioni, performance management, mobilità interna e formazione e sviluppo.",
-  'Learn more about Skillvue →': 'Scopri di più su Skillvue →',
+  'Learn more about Skillvue': 'Scopri di più su Skillvue',
   'OUR MISSION': 'LA NOSTRA MISSIONE',
   'Make skills the most': 'Rendi le competenze il dato più',
   'reliable data': 'affidabile',
@@ -1165,7 +1165,7 @@ export const translations = {
   'Psychometricians': 'Psicometristi',
   'Engineers': 'Ingegneri',
   'Designers': 'Designer',
-  'Join us →': 'Unisciti a noi →',
+  'Join us': 'Unisciti a noi',
   'Life at Skillvue': 'La vita in Skillvue',
   '50+ people across Milan, Berlin & London.': '50+ persone tra Milano, Berlino e Londra.',
 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -6,6 +6,7 @@ import Navbar from '@/components/landing/Navbar';
 import { useRouter } from 'next/router';
 import { useLanguage } from '@/i18n/LanguageContext';
 import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
 
 const stats = [
   { value: '€9M+', label: 'Raised' },
@@ -607,7 +608,8 @@ export default function AboutPage() {
                     href="/resources/press"
                     onClick={(e) => { e.preventDefault(); router.push('/resources/press'); }}
                   >
-                    {t('Learn more about Skillvue →')}
+                    {t('Learn more about Skillvue')}
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
                   </a>
                 </Button>
               </div>
@@ -924,7 +926,8 @@ export default function AboutPage() {
                     href="/careers"
                     onClick={(e) => { e.preventDefault(); router.push('/careers'); }}
                   >
-                    {t('Join us →')}
+                    {t('Join us')}
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
                   </a>
                 </Button>
               </div>

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -104,7 +104,7 @@ export default function BlogPage() {
             {c.title}
           </h3>
           <span className="text-[13px] font-semibold text-[#4B4DF7] flex items-center gap-1.5 mt-auto md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300">
-            {t('Read more')} <ArrowRight className="h-3.5 w-3.5" />
+            {t('Read more')} <ArrowRight className="h-4 w-4" />
           </span>
         </div>
       </motion.article>

--- a/pages/customers/ins-mercato.tsx
+++ b/pages/customers/ins-mercato.tsx
@@ -419,7 +419,7 @@ export default function InsMercatoStoryPage() {
                     {/* Arrow */}
                     <div className="hidden lg:flex items-center justify-center">
                       <div className="w-7 h-7 rounded-full border border-[#e2e8f0] bg-white flex items-center justify-center">
-                        <ArrowRight className="h-3 w-3 text-[#121212]/25" />
+                        <ArrowRight className="h-4 w-4 text-[#121212]/25" />
                       </div>
                     </div>
 
@@ -434,7 +434,7 @@ export default function InsMercatoStoryPage() {
                     {/* Arrow */}
                     <div className="hidden lg:flex items-center justify-center">
                       <div className="w-7 h-7 rounded-full border border-[#e2e8f0] bg-white flex items-center justify-center">
-                        <ArrowRight className="h-3 w-3 text-[#121212]/25" />
+                        <ArrowRight className="h-4 w-4 text-[#121212]/25" />
                       </div>
                     </div>
 
@@ -606,7 +606,7 @@ export default function InsMercatoStoryPage() {
                   </div>
                   <div className="hidden md:flex items-center justify-center">
                     <div className="w-7 h-7 rounded-full border border-[#e2e8f0] bg-white flex items-center justify-center">
-                      <ArrowRight className="h-3 w-3 text-[#121212]/25" />
+                      <ArrowRight className="h-4 w-4 text-[#121212]/25" />
                     </div>
                   </div>
                   <div className="rounded-xl bg-[#4B4DF7]/[0.06] p-6 text-center">

--- a/pages/customers/mediaset-2.tsx
+++ b/pages/customers/mediaset-2.tsx
@@ -373,7 +373,7 @@ export default function Mediaset2StoryPage() {
                 </div>
                 {/* Quote */}
                 <div className="rounded-2xl border border-white/[0.08] bg-white/[0.04] backdrop-blur-sm px-5 py-4">
-                  <p className="text-[12px] text-white/[0.65] leading-[1.6] italic mb-3">"{c.quote.text}"</p>
+                  <p className="text-[24px] font-medium text-white leading-[1.4] italic mb-5 pb-5 border-b border-white/[0.08]">"{c.quote.text}"</p>
                   <div className="flex items-center gap-3">
                     <div className="w-8 h-8 rounded-full shrink-0 border border-white/[0.15] bg-white/[0.08] flex items-center justify-center">
                       <span className="text-[11px] font-bold text-white/60">LV</span>

--- a/pages/resources/press.tsx
+++ b/pages/resources/press.tsx
@@ -368,7 +368,7 @@ export default function PressPage() {
                     <span className="text-[12px] font-semibold text-[#4B4DF7]/50 tracking-[0.08em] uppercase group-hover:text-[#4B4DF7]/80 transition-colors duration-300">
                       {t('Read interview')}
                     </span>
-                    <ArrowUpRight className="h-3.5 w-3.5 text-[#4B4DF7]/40 group-hover:text-[#4B4DF7] group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all duration-300" />
+                    <ArrowUpRight className="h-4 w-4 text-[#4B4DF7]/40 group-hover:text-[#4B4DF7] group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all duration-300" />
                   </div>
                 </motion.a>
               ))}

--- a/pages/resources/whitepapers/index.tsx
+++ b/pages/resources/whitepapers/index.tsx
@@ -73,7 +73,7 @@ export default function WhitepapersPage() {
                   className="group inline-flex items-center gap-3"
                 >
                   <span className="w-10 h-10 rounded-full border border-white/[0.1] flex items-center justify-center group-hover:border-white/[0.25] transition-all duration-300">
-                    <ArrowRight className="!h-4 !w-4 rotate-90" />
+                    <ArrowRight className="h-4 w-4 rotate-90" />
                   </span>
                   {t('Explore the library')}
                 </a>


### PR DESCRIPTION
## Summary
- Fixed the root cause of inconsistent CTA arrow icon sizes: the shared `Button` component forced all icons to 24px via a high-specificity `[&_svg]:size-6` rule that silently overrode per-instance size classes. Now standardized to 16px (`size-4`) across every button-driven CTA site-wide.
- Fixed the remaining hand-rolled arrow/chevron instances that weren't going through `Button` (hero cross-links, blog/press cards, carousel chevrons, `ins-mercato` step arrows) to the same 16px standard.
- Converted the two `about.tsx` CTAs ("Learn more about Skillvue", "Join us") from a literal `→` text character baked into the copy to the standard `ArrowRight` icon, for true visual consistency with the rest of the site.
- Refined the Mediaset hero quote card (`pages/customers/mediaset-2.tsx`): 24px medium-weight text, full white color, tighter line height, and a light divider with more spacing before the author line.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [ ] Visually spot-check a few CTA buttons across pages (landing, solutions, customer stories) to confirm arrows render at 16px
- [ ] Visually check the Mediaset customer page hero quote card
