### PR TITLE
Fix 404 when switching language away from /it/clienti

### DIFF
--- a/i18n/LanguageContext.tsx
+++ b/i18n/LanguageContext.tsx
@@ -16,11 +16,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const lang = router.locale || 'en';
 
   const switchLang = useCallback((newLang: string) => {
-    // router.asPath has the locale stripped, so on /it/clienti it's just
-    // "/clienti" — pushing that straight through under the "en" locale would
-    // resolve to "/clienti" with no locale prefix, which isn't a real page
-    // (only "/customers" is in English) and 404s. Translate the IT-only
-    // slugs to their EN equivalents (and back) before navigating.
+    // asPath has the locale stripped: on /it/clienti it's just "/clienti", which isn't a real EN page.
     const targetPath = newLang === 'it' ? toItPath(router.asPath) : toEnPath(router.asPath);
     router.push(targetPath, targetPath, { locale: newLang });
   }, [router]);

--- a/i18n/LanguageContext.tsx
+++ b/i18n/LanguageContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { translations } from './translations';
+import { toEnPath, toItPath } from './localePaths';
 
 interface LanguageContextType {
   lang: string;
@@ -15,7 +16,13 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const lang = router.locale || 'en';
 
   const switchLang = useCallback((newLang: string) => {
-    router.push(router.asPath, router.asPath, { locale: newLang });
+    // router.asPath has the locale stripped, so on /it/clienti it's just
+    // "/clienti" — pushing that straight through under the "en" locale would
+    // resolve to "/clienti" with no locale prefix, which isn't a real page
+    // (only "/customers" is in English) and 404s. Translate the IT-only
+    // slugs to their EN equivalents (and back) before navigating.
+    const targetPath = newLang === 'it' ? toItPath(router.asPath) : toEnPath(router.asPath);
+    router.push(targetPath, targetPath, { locale: newLang });
   }, [router]);
 
   const t = useCallback((key: string): string => {

--- a/i18n/localePaths.ts
+++ b/i18n/localePaths.ts
@@ -1,15 +1,25 @@
 // Maps IT-only slugs to their EN equivalents and vice versa. Shared between
 // the language switcher (which must navigate to a real path) and the
 // hreflang tags (which must point search engines at a real path).
-const itToEn: Record<string, string> = { '/clienti': '/customers' };
-const enToIt: Record<string, string> = { '/customers': '/clienti' };
+const itToEn: Record<string, string> = { '/clienti': '/customers', '/prenota-incontro': '/book-meeting' };
+const enToIt: Record<string, string> = { '/customers': '/clienti', '/book-meeting': '/prenota-incontro' };
+
+// asPath can carry a query string or hash (e.g. from a UTM-tagged link);
+// those need to ride along untouched while only the path portion is mapped.
+function translate(asPath: string, map: Record<string, string>, fromPrefix: string, toPrefix: string): string {
+  const splitIndex = asPath.search(/[?#]/);
+  const path = splitIndex === -1 ? asPath : asPath.slice(0, splitIndex);
+  const suffix = splitIndex === -1 ? '' : asPath.slice(splitIndex);
+  const mappedPath = path.startsWith(fromPrefix + '/')
+    ? toPrefix + path.slice(fromPrefix.length)
+    : map[path] ?? path;
+  return mappedPath + suffix;
+}
 
 export function toEnPath(asPath: string): string {
-  if (asPath.startsWith('/clienti/')) return '/customers/' + asPath.slice('/clienti/'.length);
-  return itToEn[asPath] ?? asPath;
+  return translate(asPath, itToEn, '/clienti', '/customers');
 }
 
 export function toItPath(asPath: string): string {
-  if (asPath.startsWith('/customers/')) return '/clienti/' + asPath.slice('/customers/'.length);
-  return enToIt[asPath] ?? asPath;
+  return translate(asPath, enToIt, '/customers', '/clienti');
 }

--- a/i18n/localePaths.ts
+++ b/i18n/localePaths.ts
@@ -1,0 +1,15 @@
+// Maps IT-only slugs to their EN equivalents and vice versa. Shared between
+// the language switcher (which must navigate to a real path) and the
+// hreflang tags (which must point search engines at a real path).
+const itToEn: Record<string, string> = { '/clienti': '/customers' };
+const enToIt: Record<string, string> = { '/customers': '/clienti' };
+
+export function toEnPath(asPath: string): string {
+  if (asPath.startsWith('/clienti/')) return '/customers/' + asPath.slice('/clienti/'.length);
+  return itToEn[asPath] ?? asPath;
+}
+
+export function toItPath(asPath: string): string {
+  if (asPath.startsWith('/customers/')) return '/clienti/' + asPath.slice('/customers/'.length);
+  return enToIt[asPath] ?? asPath;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,15 +28,15 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     return {
+      // None of these set locale:false, so Next matches them with the locale
+      // prefix already stripped — "/it/clienti" is tested as "clienti" under
+      // the it locale and matches the same rule as plain "/clienti". No
+      // separate afterFiles entry needed for the IT-prefixed form.
       beforeFiles: [
         { source: '/customers/mediaset', destination: '/customers/mediaset-2' },
         { source: '/clienti/mediaset', destination: '/customers/mediaset-2' },
         { source: '/clienti', destination: '/customers' },
         { source: '/clienti/:slug', destination: '/customers/:slug' },
-      ],
-      afterFiles: [
-        { source: '/it/clienti', destination: '/it/customers', locale: false },
-        { source: '/it/clienti/:slug', destination: '/it/customers/:slug', locale: false },
       ],
     };
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,7 @@ const nextConfig: NextConfig = {
       beforeFiles: [
         { source: '/customers/mediaset', destination: '/customers/mediaset-2' },
         { source: '/clienti/mediaset', destination: '/customers/mediaset-2' },
+        { source: '/clienti', destination: '/customers' },
         { source: '/clienti/:slug', destination: '/customers/:slug' },
       ],
       afterFiles: [

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,25 +4,15 @@ import Head from "next/head";
 import Script from "next/script";
 import { useRouter } from "next/router";
 import { LanguageProvider } from "@/i18n/LanguageContext";
+import { toEnPath, toItPath } from "@/i18n/localePaths";
 
 const BASE_URL = 'https://skillvue.ai';
-
-// Maps IT-only slugs to their EN equivalents and vice versa
-const itToEn: Record<string, string> = { '/clienti': '/customers' };
-const enToIt: Record<string, string> = { '/customers': '/clienti' };
 
 function HreflangTags() {
   const { asPath } = useRouter();
 
-  let enPath = itToEn[asPath] ?? asPath;
-  let itPath = enToIt[asPath] ?? asPath;
-
-  // Handle /customers/:slug <-> /clienti/:slug
-  if (asPath.startsWith('/customers/')) {
-    itPath = '/clienti/' + asPath.slice('/customers/'.length);
-  } else if (asPath.startsWith('/clienti/')) {
-    enPath = '/customers/' + asPath.slice('/clienti/'.length);
-  }
+  const enPath = toEnPath(asPath);
+  const itPath = toItPath(asPath);
 
   const enUrl = `${BASE_URL}${enPath}`;
   const itUrl = itPath === '/' ? `${BASE_URL}/it` : `${BASE_URL}/it${itPath}`;


### PR DESCRIPTION
## Summary
- On `/it/clienti`, clicking the EN language-switcher button 404'd.
- Root cause: `router.asPath` has the locale prefix stripped, so on `/it/clienti` it is just `/clienti`. `switchLang` pushed that path straight through under the `en` locale, resolving to the bare URL `/clienti` -- not a real page in English (only `/customers` is), and no rewrite covered that case.

## Fix
- Extracted the `/clienti` <-> `/customers` mapping (previously duplicated only inside `_app.tsx`'s hreflang logic) into a shared `i18n/localePaths.ts`.
- `switchLang` (`i18n/LanguageContext.tsx`) now translates the path through that mapping before navigating, so it always lands on a real URL.
- Added the missing bare `/clienti` -> `/customers` rewrite in `next.config.ts` (only `/clienti/:slug` existed before) as defense in depth, independent of the switcher fix -- covers any direct link/bookmark to `/clienti`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Verified via Playwright by actually clicking the EN/IT buttons (not just curling URLs):
  - `/it/clienti` -> click EN -> `/customers` (was 404)
  - `/customers` -> click IT -> `/it/clienti`
  - `/it/clienti/adr` -> click EN -> `/customers/adr`
  - `/customers/adr` -> click IT -> `/it/clienti/adr`
- [x] Direct-URL check: `/clienti`, `/it/clienti`, `/clienti/adr`, `/it/clienti/adr`, `/customers`, `/it/customers` all resolve to 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
