### PR TITLE
Install next-intl and settle the message-loading strategy

### DIFF
--- a/harness/docs/architecture.md
+++ b/harness/docs/architecture.md
@@ -16,12 +16,30 @@ change here is almost always **a page**, and the risk is almost always
 
 ## Principles
 
-1. **Pages Router. Stay there.**
-   `pages/` with file-based routing, `_app.tsx` as the only shell (background
-   layers, GTM, hreflang, `LanguageProvider`). Do not introduce `app/`, Server
-   Components, or a route-group migration without an Issue that documents a
-   concrete reason. React 19 and Next 16 are installed; that is not permission
-   to migrate.
+1. **Migrating to the App Router. Follow the phases, don't freelance.**
+   The site is on the Pages Router today and is moving to `app/`, interleaved
+   with the copy migration so each page is visited once. Decided 2026-09-01.
+
+   **The order is not negotiable, and it is not a preference.** The built-in
+   `i18n` block in `next.config.ts` does not exist in the App Router, and
+   leaving it in place while an `app/` directory appears makes incremental
+   adoption 404 ([vercel/next.js#57704](https://github.com/vercel/next.js/issues/57704)).
+   So:
+
+   1. **Phase 0 first** (#124-#127): locale routing moves to next-intl
+      middleware, `nextConfig.i18n` is deleted, and all 61 routes are
+      regression-tested in both locales — all while still on the Pages Router.
+      `useRouter().locale` stops being populated the moment that block goes, and
+      with `@ts-nocheck` on 157 files nothing will tell you. It fails as "the
+      Italian page renders in English".
+   2. **Then the App Router shell** (#128-#132).
+   3. **Then pages, one at a time**, each moving its copy and its file together.
+
+   Until Phase 0 is green, **do not create `app/`**. A page added there earlier
+   does not fail loudly — it 404s in one locale.
+
+   During the migration both routers coexist, which Next supports. A page under
+   `pages/` is not stale: it has not been reached yet.
 
 2. **Every page renders its own `Navbar` and `Footer`.**
    There is no shared layout component and no `getLayout` pattern. Follow the

--- a/harness/docs/architecture.md
+++ b/harness/docs/architecture.md
@@ -44,6 +44,35 @@ change here is almost always **a page**, and the risk is almost always
    - **Never add a bare `lang === 'it' ? … : …` ternary** outside a content
      object. There are 417 of them; that number goes down, not up.
 
+3b. **How messages reach a page (next-intl, Pages Router).**
+   Decided in #97; this is the contract every migrated page follows.
+
+   ```tsx
+   export const getStaticProps = messagesFor('customers/adr');  // the route id
+   const t = useTranslations('customers.adr');
+   ```
+
+   - **Per-page namespaces, never the whole catalogue.** `_app.tsx` mounts
+     `NextIntlClientProvider` but imports no messages of its own. Each page
+     loads only what it renders, through `getStaticProps`. This is the whole
+     reason the loader exists: the finished catalogue is ~19k words per locale,
+     and importing it in `_app.tsx` would ship every page's copy, in both
+     languages, to every visitor. `scripts/check-messages.mjs` asserts a page
+     receives its own namespace plus `common`, and nothing else.
+   - **The argument is the route's `id` in `routes.json`**, not a free-form
+     string, so a page cannot key off a namespace no route claims.
+     `namespaceOf()` maps it: `index` → `home`, `customers/adr` →
+     `customers.adr`, `[slug]` loses its brackets.
+   - **A missing key throws in dev, degrades in production.** `onError` in
+     `_app.tsx` rethrows outside production, so whoever introduced the gap sees
+     a 500 on the page they are already looking at rather than an English string
+     sitting quietly on the Italian site. Production logs and falls back —
+     one absent string is not a reason to take the site down. `check:i18n` and
+     `check:messages` in CI are what keep them out of production.
+   - **The JSON import carries `with { type: 'json' }`.** Turbopack does not
+     need it; bare Node does. Without it the gate script could only test the
+     pure helpers and never the loading path a page actually uses.
+
 4. **Italian apostrophes are `’`, never `'`.**
    A straight apostrophe inside a single-quoted JS string breaks the parser.
    Use the curly `’` (or `’`), or a double-quoted string. This is the most

--- a/harness/init.sh
+++ b/harness/init.sh
@@ -131,6 +131,7 @@ GATES=(
   "typecheck"
   "check:i18n"
   "check:routes"
+  "check:messages"
 )
 
 for g in "${GATES[@]}"; do

--- a/i18n/messages.ts
+++ b/i18n/messages.ts
@@ -1,0 +1,97 @@
+// Message loading for Pages Router.
+//
+// The constraint that shapes this file: the catalogue is roughly 19k words per
+// locale. Importing all of it into _app.tsx would ship every page's copy to
+// every visitor, in both languages. So a page loads only the namespaces it
+// actually renders, through getStaticProps, and next-intl gets exactly those.
+//
+// Usage, one line per page:
+//
+//   export const getStaticProps = messagesFor('customers/adr');
+//
+// The argument is the route's `id` in routes.json — the same identifier the
+// sitemap and the hreflang tags key off, so a page cannot drift into using a
+// namespace no route claims.
+
+import type { GetStaticProps } from 'next';
+
+/** Namespaces every page renders, because every page has a navbar and a footer. */
+const SHARED = ['common'];
+
+/**
+ * Route id -> message namespace.
+ *
+ * `customers/adr` -> `customers.adr`, so the catalogue nests the same way the
+ * routes do. Two adjustments: the homepage is `home` rather than the
+ * meaningless `index`, and a dynamic segment loses its brackets because
+ * `[slug]` is not a legal thing to type in an ICU key path.
+ */
+export function namespaceOf(routeId: string): string {
+  if (routeId === 'index') return 'home';
+  return routeId.replace(/\[|\]/g, '').replace(/\//g, '.');
+}
+
+/** Rebuilds `{a: {b: …}}` from a dotted path, dropping everything else.
+ *  Exported for scripts/check-messages.mjs — pure, and it has had a bug. */
+export function pick(source: Record<string, unknown>, dotted: string) {
+  const segments = dotted.split('.');
+  const out: Record<string, unknown> = {};
+
+  let from: unknown = source;
+  let to = out;
+  for (const [i, segment] of segments.entries()) {
+    if (typeof from !== 'object' || from === null) return {};
+    const next = (from as Record<string, unknown>)[segment];
+    if (next === undefined) return {};
+    if (i === segments.length - 1) {
+      to[segment] = next;
+    } else {
+      to[segment] = {};
+      to = to[segment] as Record<string, unknown>;
+    }
+    from = next;
+  }
+  return out;
+}
+
+/**
+ * Deep-merges the picked namespaces.
+ *
+ * A shallow spread would be wrong the moment one page wants two namespaces
+ * under the same root — `customers.adr` and `customers.list` would each carry
+ * their own `customers` object and the second would replace the first.
+ */
+export function merge(a: Record<string, unknown>, b: Record<string, unknown>) {
+  const out = { ...a };
+  for (const [key, value] of Object.entries(b)) {
+    const existing = out[key];
+    const bothPlainObjects =
+      typeof existing === 'object' && existing !== null && !Array.isArray(existing) &&
+      typeof value === 'object' && value !== null && !Array.isArray(value);
+    out[key] = bothPlainObjects
+      ? merge(existing as Record<string, unknown>, value as Record<string, unknown>)
+      : value;
+  }
+  return out;
+}
+
+export function messagesFor(routeId: string, extra: string[] = []): GetStaticProps {
+  return async function getStaticProps({ locale }) {
+    // A literal path prefix keeps the bundler able to see the whole directory,
+    // so both catalogues are emitted and only the requested one is fetched.
+    // The import attribute is not decoration: without it Node refuses to load
+    // JSON through a dynamic import, and scripts/check-messages.mjs could only
+    // ever test the pure helpers, never the loading path a page actually uses.
+    // Turbopack accepts it too, so one line of code serves both runtimes.
+    const all = (await import(`../messages/${locale ?? 'en'}.json`, { with: { type: 'json' } }))
+      .default;
+
+    const wanted = [...SHARED, namespaceOf(routeId), ...extra];
+    const messages = wanted.reduce<Record<string, unknown>>(
+      (acc, ns) => merge(acc, pick(all, ns)),
+      {},
+    );
+
+    return { props: { messages } };
+  };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,11 @@
+{
+  "common": {
+    "brand": "Skillvue"
+  },
+  "home": {
+    "meta": {
+      "title": "Skillvue | AI Talent Intelligence Platform",
+      "description": "Verify skills, predict performance and make every hiring and promotion decision defensible. Skillvue combines psychometric rigour with AI for European enterprises."
+    }
+  }
+}

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,0 +1,11 @@
+{
+  "common": {
+    "brand": "Skillvue"
+  },
+  "home": {
+    "meta": {
+      "title": "Skillvue | Piattaforma di Talent Intelligence con AI",
+      "description": "Valuta le competenze, prevedi le performance e rendi ogni decisione di hiring e promozione difendibile. Skillvue combina la scienza psicometrica con l’AI per le aziende europee."
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.577.0",
         "next": "16.2.6",
+        "next-intl": "^4.14.2",
         "next-themes": "^0.4.6",
         "ogl": "^1.0.11",
         "react": "19.2.4",
@@ -89,6 +90,31 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@eloqnt/config": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eloqnt/config/-/config-0.1.0.tgz",
+      "integrity": "sha512-SLR6ZSHxu6XdZtmOz3xRmC3gsY/sCzqtLMD1gxbW2I3XXPBbupwL5RZbkLU/NcZm74AKZrIUPfz3CtEJfxUKqQ==",
+      "license": "MIT"
+    },
+    "node_modules/@eloqnt/format-json": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eloqnt/format-json/-/format-json-0.1.0.tgz",
+      "integrity": "sha512-4Pkb+HyzgWNJXoU48aJhUyNZSjZvMGooPCNG1ZFmBm55xTiNNPQCNXH66Ob6sXS6RvbWZrRpCf+Uo/Jz9K9g+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@eloqnt/config": "^0.1.0"
+      }
+    },
+    "node_modules/@eloqnt/format-po": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eloqnt/format-po/-/format-po-0.1.0.tgz",
+      "integrity": "sha512-odgtuICWs67GdkNqY51/d2vaIukuOdlGalKASUGkI5c4cyWOmv/WIVyk5gZyn3xr614RzwWp57s9WB40lRLlBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@eloqnt/config": "^0.1.0",
+        "po-parser": "^2.2.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.0",
@@ -137,6 +163,36 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.11"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.13.tgz",
+      "integrity": "sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.7"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -829,6 +885,280 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2464,6 +2794,12 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2476,6 +2812,204 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.1.tgz",
+      "integrity": "sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.1.tgz",
+      "integrity": "sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.1.tgz",
+      "integrity": "sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.1.tgz",
+      "integrity": "sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.1.tgz",
+      "integrity": "sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.1.tgz",
+      "integrity": "sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.1.tgz",
+      "integrity": "sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.1.tgz",
+      "integrity": "sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.1.tgz",
+      "integrity": "sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.1.tgz",
+      "integrity": "sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.1.tgz",
+      "integrity": "sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.1.tgz",
+      "integrity": "sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2483,6 +3017,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tabby_ai/hijri-converter": {
@@ -3310,6 +3853,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/critters": {
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.23.tgz",
@@ -3528,7 +4084,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4060,6 +4615,21 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.14.2.tgz",
+      "integrity": "sha512-2eJ9ooR8xXWbe0IivG58TFL96AUp5ts8FJ4qSMzn8YRJXpLmtPNWcUkIZ8t3iz0+eaVzG+mN+rdNIigHDvYa2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -4087,6 +4657,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/is-binary-path": {
@@ -4581,6 +5161,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/next": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
@@ -4634,6 +5230,80 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.14.2.tgz",
+      "integrity": "sha512-rIq8me1uOa2qXnttJ6dUGYnHHL63Rh1FAIIDTJP5av5KSBmUzNBS17QAi07QDrUMY6KxFNeoCTRzSZRPUc97lg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eloqnt/config": "^0.1.0",
+        "@eloqnt/format-json": "^0.1.0",
+        "@eloqnt/format-po": "^0.1.0",
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "~1.16.0",
+        "icu-minify": "^4.14.2",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "4.14.2",
+        "use-intl": "^4.14.2"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.14.2.tgz",
+      "integrity": "sha512-R+i9Xw6XKyn1QVx+I5IDZQNGQBwT79ugGwzbuJudgejob/IYnXXrRKMlLhmMxLdKH8jUWh92nqwNnp+5rtSVJA==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.1.tgz",
+      "integrity": "sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.28"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.16.1",
+        "@swc/core-darwin-x64": "1.16.1",
+        "@swc/core-linux-arm-gnueabihf": "1.16.1",
+        "@swc/core-linux-arm64-gnu": "1.16.1",
+        "@swc/core-linux-arm64-musl": "1.16.1",
+        "@swc/core-linux-ppc64-gnu": "1.16.1",
+        "@swc/core-linux-s390x-gnu": "1.16.1",
+        "@swc/core-linux-x64-gnu": "1.16.1",
+        "@swc/core-linux-x64-musl": "1.16.1",
+        "@swc/core-win32-arm64-msvc": "1.16.1",
+        "@swc/core-win32-ia32-msvc": "1.16.1",
+        "@swc/core-win32-x64-msvc": "1.16.1"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -4671,6 +5341,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -4736,9 +5412,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4811,6 +5487,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.2.0.tgz",
+      "integrity": "sha512-NdTrKgh0oO7+y+RFX8KKhOB438x/j94UGXEFzl/7pHH0JjWSn42iJ9tgmPksIO6n1JKDHmNDcejPJfKspljB9g==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -5673,6 +6355,27 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.14.2.tgz",
+      "integrity": "sha512-XffvbD4q4uZjRbuO8CgK6Ei8hvYn7aegoSad2YPho1ZRjYEs+k4erhYq0vfm5ttF4lnja3riXCeJrtUdNdQG3g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.14.2",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:routes": "node scripts/check-routes.mjs",
+    "check:messages": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-messages.mjs",
     "start": "next start"
   },
   "dependencies": {
@@ -51,6 +52,7 @@
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.577.0",
     "next": "16.2.6",
+    "next-intl": "^4.14.2",
     "next-themes": "^0.4.6",
     "ogl": "^1.0.11",
     "react": "19.2.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
 import { useRouter } from "next/router";
+import { NextIntlClientProvider } from "next-intl";
 import { LanguageProvider } from "@/i18n/LanguageContext";
 import { toEnPath, toItPath } from "@/i18n/localePaths";
 
@@ -25,8 +26,31 @@ function HreflangTags() {
   );
 }
 
+// A missing key must not read as a silent English fallback. In dev it throws, so
+// whoever introduced it sees it on the page they are already looking at. In
+// production it degrades instead, because one absent string is not a reason to
+// take the site down — `npm run check:i18n` in CI is what keeps them out of
+// production in the first place.
+function onIntlError(error: unknown) {
+  if (process.env.NODE_ENV === 'production') {
+    console.error(error);
+    return;
+  }
+  throw error;
+}
+
 export default function App({ Component, pageProps }: AppProps) {
+  const { locale } = useRouter();
   return (
+    <NextIntlClientProvider
+      locale={locale ?? 'en'}
+      timeZone="Europe/Rome"
+      // Pages migrated to next-intl provide these from getStaticProps via
+      // i18n/messages.ts. The rest of the site has not been migrated yet
+      // (#106-#118), so an absent `messages` is expected, not an error.
+      messages={pageProps.messages ?? {}}
+      onError={onIntlError}
+    >
     <LanguageProvider>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -69,5 +93,6 @@ export default function App({ Component, pageProps }: AppProps) {
         </div>
       </div>
     </LanguageProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useTranslations } from 'next-intl';
+import { messagesFor } from '@/i18n/messages';
 import { LazyMotion } from 'framer-motion';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
@@ -14,19 +16,21 @@ import CTASection from '@/components/landing/CTASection';
 
 const loadMotionFeatures = () => import('@/lib/motion-features').then((res) => res.default);
 
+// One line per page is the whole contract: the argument is this route's `id` in
+// routes.json, and i18n/messages.ts turns it into the namespaces to load.
+export const getStaticProps = messagesFor('index');
+
 export default function HomePage() {
   const { locale } = useRouter();
   const isIT = locale === 'it';
   const canonical = isIT ? 'https://skillvue.ai/it' : 'https://skillvue.ai/';
+  const t = useTranslations('home.meta');
 
   return (
     <>
       <Head>
-        <title>{isIT ? 'Skillvue | Piattaforma di Talent Intelligence con AI' : 'Skillvue | AI Talent Intelligence Platform'}</title>
-        <meta name="description" content={isIT
-          ? "Valuta le competenze, prevedi le performance e rendi ogni decisione di hiring e promozione difendibile. Skillvue combina la scienza psicometrica con l'AI per le aziende europee."
-          : 'Verify skills, predict performance and make every hiring and promotion decision defensible. Skillvue combines psychometric rigour with AI for European enterprises.'
-        } />
+        <title>{t('title')}</title>
+        <meta name="description" content={t('description')} />
         <link rel="canonical" href={canonical} />
         {/* Hero's italic gradient span needs Bold Italic; only this page (and /science) does. */}
         <link rel="preload" href="/fonts/MonaSans-BoldItalic.woff2" as="font" type="font/woff2" crossOrigin="anonymous" />

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -1,0 +1,98 @@
+// check-messages — proves the message loader hands a page the namespaces it
+// asked for, and nothing else.
+//
+// Why this exists: the whole reason messages load per-page instead of from
+// _app.tsx is payload size — the catalogue is ~19k words per locale. If `pick`
+// silently widened, or `merge` dropped a namespace, nothing would look broken:
+// the page would still render, just with the wrong bytes on the wire or a
+// missing string in one language. Both failures are invisible without this.
+//
+// Run: npm run check:messages
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { messagesFor, namespaceOf, pick, merge } = await import(join(ROOT, 'i18n/messages.ts'));
+
+// ── Route id -> namespace ──────────────────────────────────────────────────
+assert.equal(namespaceOf('index'), 'home', 'the homepage namespace is `home`, not `index`');
+assert.equal(namespaceOf('about'), 'about');
+assert.equal(namespaceOf('customers/adr'), 'customers.adr', 'path separators become dots');
+assert.equal(
+  namespaceOf('resources/whitepapers/[slug]'),
+  'resources.whitepapers.slug',
+  'a dynamic segment loses its brackets — `[slug]` is not a legal ICU key path',
+);
+
+// ── The loader returns only what was asked for ─────────────────────────────
+const run = async (routeId, locale, extra) =>
+  (await messagesFor(routeId, extra)({ locale })).props.messages;
+
+const home = await run('index', 'en');
+assert.deepEqual(
+  Object.keys(home).sort(),
+  ['common', 'home'],
+  'a page must receive its own namespace plus the shared one, and nothing else',
+);
+assert.ok(home.home.meta.title, 'the picked namespace keeps its nested shape');
+
+// The degradation path: asking for a namespace the catalogue does not have must
+// yield nothing for it, not throw and not leak the rest of the catalogue.
+const missing = await run('customers/does-not-exist', 'en');
+assert.deepEqual(
+  Object.keys(missing).sort(),
+  ['common'],
+  'an unknown namespace contributes nothing — and must not drag the catalogue in with it',
+);
+
+// Two namespaces under one root is the case a shallow spread gets wrong: the
+// second `customers` object would replace the first instead of joining it.
+// This is a real bug that was in `merge` before it was a merge.
+assert.deepEqual(
+  merge({ customers: { alpha: { k: 'A' } } }, { customers: { beta: { k: 'B' } } }),
+  { customers: { alpha: { k: 'A' }, beta: { k: 'B' } } },
+  'sibling namespaces under one root must both survive the merge',
+);
+assert.deepEqual(
+  merge({ a: { b: 1 } }, { a: { b: 2 } }),
+  { a: { b: 2 } },
+  'a leaf collision resolves to the later value, it does not merge into an object',
+);
+assert.deepEqual(
+  merge({ list: ['a'] }, { list: ['b'] }),
+  { list: ['b'] },
+  'arrays replace rather than merge — an ICU message list is one value',
+);
+
+// `pick` on its own: the shape it rebuilds, and what it does with an absent path.
+const catalogue = JSON.parse(readFileSync(join(ROOT, 'messages/en.json'), 'utf8'));
+assert.deepEqual(
+  pick(catalogue, 'home.meta'),
+  { home: { meta: catalogue.home.meta } },
+  'pick rebuilds the full nesting, not just the leaf',
+);
+assert.deepEqual(pick(catalogue, 'nope.at.all'), {}, 'an absent path picks nothing');
+assert.deepEqual(pick(catalogue, 'home.meta.title.deeper'), {}, 'walking past a leaf picks nothing');
+
+// ── Catalogue parity ───────────────────────────────────────────────────────
+// A key in one locale only renders `undefined` in production, in one language,
+// which is exactly the failure nobody notices until a customer does.
+const flatten = (obj, prefix = '') =>
+  Object.entries(obj).flatMap(([k, v]) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? flatten(v, `${prefix}${k}.`)
+      : [`${prefix}${k}`],
+  );
+
+const en = flatten(JSON.parse(readFileSync(join(ROOT, 'messages/en.json'), 'utf8')));
+const it = flatten(JSON.parse(readFileSync(join(ROOT, 'messages/it.json'), 'utf8')));
+
+const onlyEn = en.filter((k) => !it.includes(k));
+const onlyIt = it.filter((k) => !en.includes(k));
+assert.deepEqual(onlyEn, [], `messages/en.json has keys missing from it.json:\n  ${onlyEn.join('\n  ')}`);
+assert.deepEqual(onlyIt, [], `messages/it.json has keys missing from en.json:\n  ${onlyIt.join('\n  ')}`);
+
+console.log(`[OK] messages: ${en.length} keys, en/it at parity, namespaces isolated`);


### PR DESCRIPTION
Closes #97

Stacked on #121 (the routes registry), because the loader keys off route ids from `routes.json`. Merge #121 first and this retargets to `main`.

## The decision this Issue existed to make

**Per-page namespaces via `getStaticProps`, not a catalogue import in `_app.tsx`.**

The finished catalogue is ~19k words per locale. Importing it in `_app.tsx` would ship every page's copy, in both languages, to every visitor. So each page loads only what it renders:

```tsx
export const getStaticProps = messagesFor('customers/adr');  // the route id
const t = useTranslations('customers.adr');
```

The argument is the route's `id` in `routes.json`, not a free-form string, so a page cannot key off a namespace no route claims. Written up in `harness/docs/architecture.md`.

## What's here

- `next-intl@4.14.2`, `NextIntlClientProvider` in `_app.tsx` reading `router.locale` — the existing Next i18n routing is untouched.
- `i18n/messages.ts` — the loader. `messages/{en,it}.json` — the catalogue, seeded.
- `scripts/check-messages.mjs`, registered as `check:messages` in the `GATES` array.
- Homepage `<title>` and `<meta description>` migrated as the proof of concept — which also retires 2 of the 49 `locale === 'it'` ternaries found in #99.

## Verification

`./harness/init.sh` exits 0 on the full run: `typecheck`, `check:i18n`, `check:routes`, `check:messages`, `build`.

**The payload constraint is asserted, not assumed.** Inspecting `__NEXT_DATA__` in the prerendered output: both locales carry `['common', 'home']` and nothing else.

**A missing key fails loudly in dev.** Verified by deleting `home.meta.title` from `it.json` and running the dev server: `/it` → **HTTP 500 with a visible error**, `/` → **200, unaffected**. Production logs and falls back instead, because one absent string is not a reason to take the site down.

**Bilingual smoke test**, dev server, both locales:

| Route | | Route | |
|---|---|---|---|
| `/` | 200 · *AI Talent Intelligence Platform* | `/it` | 200 · *Piattaforma di Talent Intelligence con AI* |
| `/customers` | 200 · *Customer Stories* | `/it/clienti` | 200 · *Storie di Successo* |
| `/customers/adr` | 200 · EN headline | `/it/clienti/adr` | 200 · IT headline |
| `/book-meeting` | 200 | `/it/prenota-incontro` | 200 |

## Notes

- The JSON import carries `with { type: 'json' }`. Turbopack does not need it; bare Node does — without it the gate script could only test the pure helpers, never the loading path a page actually uses. Both runtimes verified.
- `merge()` had a real bug caught before commit: a shallow spread dropped sibling namespaces under a shared root (`customers.alpha` + `customers.beta`). `check:messages` covers it.
- **Pre-existing, not from this PR:** `/book-meeting` and `/it/prenota-incontro` render no `<title>` at all. Worth its own Issue.