### PR TITLE
Fix language switcher on the Italian homepage, and a background mismatch

### DIFF
--- a/components/solutions/ta/TAImpact.tsx
+++ b/components/solutions/ta/TAImpact.tsx
@@ -23,7 +23,7 @@ export default function TAImpact() {
   const t = useTranslations('solutions.talent-acquisition');
 
   return (
-    <section id="ta-impact" data-testid="ta-impact" className="relative pb-20 lg:pb-24" style={{ background: '#F5F5FA' }}>
+    <section id="ta-impact" data-testid="ta-impact" className="relative pb-20 lg:pb-24" style={{ background: '#F7F7F7' }}>
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('taImpact.heading', {

--- a/i18n/switch-locale.ts
+++ b/i18n/switch-locale.ts
@@ -31,6 +31,17 @@ export function useSwitchLocale() {
       // switch to then, and guessing '/' would move the visitor off the page.
       if (pathname === null) return;
 
+      // proxy.ts runs locale *detection* on '/' only, so a first-time visitor
+      // lands on their browser's language. next-intl's middleware sets
+      // NEXT_LOCALE on every request to whatever locale it resolved — so after
+      // visiting /it that cookie is 'it', and an explicit switch back to
+      // English lands on '/', the one path detection still applies to: it
+      // reads the stale cookie and immediately redirects back to /it, and the
+      // button appears to do nothing. next-intl's own Link/useRouter keep this
+      // cookie in sync automatically; this hook bypasses those, so it has to
+      // do it here instead.
+      document.cookie = `NEXT_LOCALE=${locale};path=/;max-age=31536000;samesite=lax`;
+
       // A route with no content in the target locale (10 Italian-only pages,
       // 1 English-only one) has nothing to switch to — internalPathIn +
       // localizePathIn round-trip through an English-keyed path that doesn't

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -31,6 +31,22 @@ try {
   await desktop.getByRole('button', { name: 'EN', exact: true }).click();
   await desktop.waitForURL('**/solutions/talent-acquisition');
 
+  // The homepage specifically, landed on directly — a shared /it link, not a
+  // client-side switch into it. proxy.ts runs locale detection only on '/',
+  // reading the NEXT_LOCALE cookie next-intl's middleware sets on every visit;
+  // arriving straight at /it leaves that cookie at 'it'. Switching to English
+  // then pushes to '/', which is the one path detection still applies to:
+  // without the switcher syncing the cookie itself, detection reads the stale
+  // 'it' value and immediately redirects back to /it, and the button does
+  // nothing. A prior client-side visit to '/' would prefetch it and mask this
+  // — the RSC cache serves the switch without a live request through the
+  // middleware — so this needs a fresh page landing on /it as its first hit.
+  const italian = await browser.newPage();
+  await visit(italian, '/it');
+  await italian.getByRole('button', { name: 'EN', exact: true }).click();
+  await italian.waitForFunction(() => location.pathname === '/', undefined, { timeout: 5_000 });
+  await italian.close();
+
   const mobile = await browser.newPage({ viewport: { width: 390, height: 844 } });
   mobile.setDefaultNavigationTimeout(10_000);
   await visit(mobile, '/');


### PR DESCRIPTION
## Summary
- Language switcher silently failed to leave the Italian homepage: clicking EN on `/it` (landed on directly, e.g. from a shared link) redirected right back because `proxy.ts`'s homepage-only locale detection read a stale `NEXT_LOCALE` cookie. The switcher now keeps that cookie in sync when it navigates, the way next-intl's own router does automatically.
- `#ta-impact` on the talent-acquisition solutions page had a background (`#F5F5FA`) that didn't match the section right before it, `#ta-funnel` (`#F7F7F7`), producing a visible seam. Matched the two.

## Test plan
- [x] `npm run test:smoke` — added a regression case for the language-switcher bug (fresh visit to `/it`, click EN, confirm it lands on `/`); confirmed it fails on the old code and passes with the fix
- [x] `./harness/init.sh` — full gate suite green, including the build gate
- [x] Manually verified the switcher round-trip and the `#ta-impact` background against the local dev server
