### PR TITLE
Show the Credem story in the customer listing

### DIFF
--- a/app/[locale]/customers/credem/body.tsx
+++ b/app/[locale]/customers/credem/body.tsx
@@ -41,7 +41,7 @@ const SOLUTION_SKILLS = [
 const RESULTS_METRICS = [
   { id: 'n30k' },
   { id: 'n30' },
-  { id: 'drastic' },
+  { id: 'recruiterTime' },
 ];
 
 const RESULTS_QUALITATIVE = [

--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -41,13 +41,10 @@ const allStories = [
     id: 'fidia-farmaceutici', company: 'Fidia Farmaceutici', industry: 'pharmaceutical', useCases: ['learningDevelopment'],
     bgImage: '/logos/fidia-farmaceutici explore stories.avif',
   },
-  // Temporarily removed from listing pending approval (restore when ready):
-  // {
-  //   id: 'credem', company: 'Gruppo Credem', industry: 'Financial Services', useCases: ['Hiring'],
-  //   headlineIt: 'Gruppo Credem: come trovare i migliori talenti tra 30.000 candidature per seguire la crescita del business',
-  //   headlineEn: 'Gruppo Credem: how to find the best talent among 30,000 applications to support business growth',
-  //   bgImage: '/logos/credem_customer_story_cover.avif',
-  // },
+  {
+    id: 'credem', company: 'Gruppo Credem', industry: 'financialServices', useCases: ['hiring'],
+    bgImage: '/logos/credem_customer_story_cover.avif',
+  },
   // douglas, eataly
 ];
 

--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -45,7 +45,9 @@ const allStories = [
     id: 'credem', company: 'Gruppo Credem', industry: 'financialServices', useCases: ['hiring'],
     bgImage: '/logos/credem_customer_story_cover.avif',
   },
-  // douglas, eataly
+  // Not listed yet, pending client approval: douglas, eataly. Listing one
+  // means adding explore.stories.<id>.headline to en.json and it.json too —
+  // the entry here carries ids and an image, and no copy at all.
 ];
 
 // Still derived from the stories, so a new story cannot arrive without its

--- a/messages/en.json
+++ b/messages/en.json
@@ -1360,6 +1360,9 @@
         },
         "fidia-farmaceutici": {
           "headline": "Fidia Farmaceutici: how to map the real skills of the sales network to drive future growth"
+        },
+        "credem": {
+          "headline": "Gruppo Credem: how to find the best talent among 30,000 applications to support business growth"
         }
       }
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -2063,7 +2063,7 @@
             "value": "-30%",
             "label": "<b>Reduction in unsuccessful interviews</b><br></br>at the second step"
           },
-          "drastic": {
+          "recruiterTime": {
             "value": "Significant",
             "label": "<b>Recruiter time</b><br></br>optimization"
           }
@@ -2108,7 +2108,7 @@
       "headline": "Gruppo Credem: how to find the best talent among <hl>30,000 applications</hl> to support <hl2>business growth</hl2>",
       "meta": {
         "title": "Gruppo Credem: how to find the best talent among 30,000 applications to support business growth | Skillvue",
-        "description": "With Skillvue, Gruppo Credem processes tens of thousands of applications every year while keeping candidate experience quality high and significantly reducin..."
+        "description": "Gruppo Credem processes 30,000 applications a year with Skillvue, protecting candidate experience and cutting unsuccessful second-stage interviews by 30%."
       }
     },
     "douglas": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -2063,7 +2063,7 @@
             "value": "-30%",
             "label": "<b>Riduzione dei colloqui non in linea</b><br></br>al secondo step"
           },
-          "drastic": {
+          "recruiterTime": {
             "value": "Significativa",
             "label": "<b>Ottimizzazione dei tempi</b><br></br>di lavoro del recruiter"
           }
@@ -2108,7 +2108,7 @@
       "headline": "Gruppo Credem: come trovare i migliori talenti tra <hl>30.000 candidature</hl> per seguire la <hl2>crescita del business</hl2>",
       "meta": {
         "title": "Gruppo Credem: come trovare i migliori talenti tra 30.000 candidature per seguire la crescita del business | Skillvue",
-        "description": "Con Skillvue, Gruppo Credem processa ogni anno decine di migliaia di candidature mantenendo alta la qualità della candidate experience e riducendo significat..."
+        "description": "Con Skillvue, Gruppo Credem processa 30.000 candidature l’anno, tutelando la candidate experience e riducendo del 30% i colloqui non in linea al secondo step."
       }
     },
     "douglas": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -1360,6 +1360,9 @@
         },
         "fidia-farmaceutici": {
           "headline": "Fidia Farmaceutici: come fotografare su scala globale le reali competenze della rete vendita per supportare la crescita futura"
+        },
+        "credem": {
+          "headline": "Gruppo Credem: come trovare i migliori talenti tra 30.000 candidature per seguire la crescita del business"
         }
       }
     },

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -47,6 +47,42 @@ try {
   await italian.waitForFunction(() => location.pathname === '/', undefined, { timeout: 5_000 });
   await italian.close();
 
+  // The Credem card in the customer listing. Two things can break here without
+  // a single request going red: the card's headline is a catalogue key of its
+  // own (customers.explore.stories.credem), separate from the story page's
+  // copy, so a missing one renders the key path as visible text; and the card
+  // builds its href from the active locale, so an English path on the Italian
+  // listing still navigates — to a URL with no Italian page behind it.
+  const listing = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+  listing.setDefaultNavigationTimeout(10_000);
+
+  for (const [path, headline] of [
+    ['/customers', /^Gruppo Credem: how to find the best talent among 30,000 applications/],
+    ['/it/clienti', /^Gruppo Credem: come trovare i migliori talenti tra 30\.000 candidature/],
+  ]) {
+    const response = await visit(listing, path);
+    assert.equal(response?.status(), 200, `${path} should render`);
+    const credem = listing.getByTestId('story-credem');
+    await credem.scrollIntoViewIfNeeded({ timeout: 10_000 });
+    // <Reveal> renders at opacity 0 and flips it in a useEffect, so an opaque
+    // card is both the visibility assertion and the proof that the component
+    // hydrated — which is what attached the onClick the click below needs.
+    await listing.waitForFunction(
+      () => getComputedStyle(document.querySelector('[data-testid="story-credem"]')).opacity === '1',
+      undefined,
+      { timeout: 10_000 },
+    );
+    assert.match(await credem.locator('h3').innerText(), headline, `${path} should show the Credem headline from the catalogue`);
+  }
+
+  // Still on the Italian listing, so the card has to reach the Italian story.
+  await Promise.all([
+    listing.waitForURL('**/clienti/credem'),
+    listing.getByTestId('story-credem').click(),
+  ]);
+  assert.match(await listing.locator('h1').innerText(), /^Gruppo Credem/, 'the Credem card should open the Italian story');
+  await listing.close();
+
   const mobile = await browser.newPage({ viewport: { width: 390, height: 844 } });
   mobile.setDefaultNavigationTimeout(10_000);
   await visit(mobile, '/');
@@ -60,4 +96,4 @@ try {
   await browser.close();
 }
 
-console.log('[OK] browser smoke: navigation, locale and mobile menu');
+console.log('[OK] browser smoke: navigation, locale, customer listing and mobile menu');


### PR DESCRIPTION
Restores the Gruppo Credem entry in `allStories`, so the story is reachable from the customer listing in both locales.

Rebuilt on current `main` after review. The first version of this branch was cut from a pre-App-Router base; it has been reset onto `main` and the change reapplied against the catalogue contract in use today.

## The change

- **`components/customers/ExploreStories.tsx`** — the commented block predated the migration and still carried its display strings inline (`Financial Services`, `Hiring`, `headlineIt`, `headlineEn`). Restored as `industry: 'financialServices'`, `useCases: ['hiring']`, headline from the catalogue. Background is `credem_customer_story_cover.avif` (40 KB), already tracked on `main`.
- **`messages/en.json` / `messages/it.json`** — added `customers.explore.stories.credem.headline`. `explore.industries.financialServices` and `explore.useCases.hiring` already existed (Europ Assistance is a financial services hiring story), so no filter chip is new.
- **`scripts/smoke.mjs`** — a focused assertion for the card in both locales.

Nothing else was needed: the route is already in `i18n/routes.json`, `app/[locale]/customers/credem/` is live, and `customers.credem` already carries the `Significant`/`Significativa` and business-centres wording from #155.

## The smoke assertion

Neither half of this card fails loudly on its own. A missing catalogue key renders the key path as visible text rather than as nothing, and a card whose href is built for the wrong locale still navigates — to a URL with no page in that language. So the assertion loads both listings, checks the headline against the locale's own copy, then clicks through from the Italian listing and asserts it lands on the Italian story.

It waits on the card's computed opacity. `<Reveal>` renders at `opacity: 0` and flips it in a `useEffect`, so the wait that asserts the card is visible also proves the component hydrated — which is what attached the `onClick` the click then depends on.

Both new assertions were mutation-checked: a wrong expected headline fails on the copy, a missing card fails on the locator.

## Verification

`./harness/init.sh` — all 12 gates plus `check:build` green, and the `gates` workflow is green on CI. `npm run test:smoke` green against `npm run start`.

Local `node_modules` and `.next` were stale from the pre-migration tree and had to be rebuilt (`npm ci`, `rm -rf .next`) before the gates could say anything true.


---

## Second commit: finishing the story itself

Checking the story end to end, rather than only the listing entry, turned up three things it would have shipped with.

**The meta description was cut mid-word in both locales.** It was the subtitle truncated at exactly 160 characters: `...significantly reducin...` and `...riducendo significat...`. That string is the page's Google snippet. Rewritten as a complete sentence per language (154 and 158 chars) from the story's own figures — 30,000 applications, the 30% drop in second-step interviews.

Worth raising separately: **17 other descriptions on the site are cut the same way**, all at exactly 160 characters — most customer stories, two blog posts, one LP. Same machine truncation, presumably from the migration. Left alone here rather than buried in this review; happy to open an issue or a follow-up branch.

**`results.metrics.drastic` was named for copy that no longer exists.** #155 softened `Drastica`/`Drastic` to `Significativa`/`Significant` at the client's request; the key kept the old word, so it now contradicts its own value and invites someone to "restore" it. Renamed to `recruiterTime`.

**The `// douglas, eataly` note had lost its meaning** — it used to sit under the "Temporarily removed pending approval" comment that this PR deleted. It now states that itself, and adds the step the stale block was missing: listing a story also needs its `explore.stories.<id>.headline` in both message files.

## Checked, not assumed

Things I verified rather than took on faith, on a clean build served by `npm run start`:

- both locales 200, correct canonical per locale, hreflang cluster `en`/`it`/`x-default`, both URLs in `sitemap.xml`
- the OG image renders and is localized at `/customers/credem/opengraph-image` and `/it/customers/credem/opengraph-image` (the `/it/clienti/...` form 404s, and nothing references it — same as the live `adr` story)
- no unresolved message keys anywhere in either page, scrolled top to bottom
- `Significativa` is not clipped in the metric card: `scrollWidth === clientWidth` at 1280px and 390px. It looked cut in a screenshot, but that was the cookie banner overlapping.

One process note, since it briefly produced a false failure: a `next start` left running from an earlier check kept port 3000, so a rebuilt `.next` was being served by a stale process and the smoke went red on `/it/clienti/credem`. Killing it and rebuilding cleared it — the code was never involved. Both commits are green on `./harness/init.sh` and `npm run test:smoke`.
