### PR TITLE
Sezione /demo fuori indice: campo noindex nel registro, hub, wrapper Chart.js

### DIFF
--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+// The demo hub: what the three dashboards are, and what one of their charts
+// looks like. It is a client component for the same reason every demo page
+// will be — the chart wrapper is loaded with ssr: false, which is only legal
+// inside the client graph.
+
+import { useTranslations } from 'next-intl';
+import { Globe, Store, Users } from 'lucide-react';
+import Footer from '@/components/Footer';
+import Navbar from '@/components/landing/Navbar';
+import { Reveal } from '@/components/ui/reveal';
+import DemoView from '@/components/demo/DemoView';
+import Chart from '@/components/demo/charts/Chart';
+
+// Structure the catalogue cannot hold: which icon belongs to which card. The
+// copy is keyed by the same id under `demo.dashboards`.
+const DASHBOARDS = [
+  { id: 'retail', Icon: Store },
+  { id: 'salesNetwork', Icon: Users },
+  { id: 'crossCountry', Icon: Globe },
+];
+
+// The preview chart's numbers. Illustrative, and said to be illustrative in
+// `preview.caption` — the real figures arrive with the dashboards themselves
+// (issues 169 to 171), aggregated and anonymised.
+const PREVIEW_SCORES = [82, 74, 69, 61, 54];
+
+export default function DemoHub() {
+  const t = useTranslations('demo');
+
+  return (
+    <>
+      <DemoView slug="hub" />
+      <Navbar />
+      <main>
+        <section className="relative pt-[80px]">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-28">
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              className="text-[13px] font-semibold tracking-[0.18em] uppercase text-white/40 mb-6"
+            >
+              {t('hero.eyebrow')}
+            </Reveal>
+            <Reveal
+              as="h1"
+              y={40}
+              duration={0.8}
+              delay={0.1}
+              className="text-[40px] md:text-[56px] font-semibold tracking-[-0.02em] text-white/95 mb-8 max-w-4xl"
+              style={{ lineHeight: 1.15 }}
+            >
+              {t.rich('hero.heading', {
+                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+              })}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.8}
+              delay={0.2}
+              className="text-[18px] text-white/[0.65] leading-[1.75] max-w-2xl mb-8"
+              style={{ fontWeight: 300 }}
+            >
+              {t('hero.body')}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              delay={0.3}
+              className="text-[14px] text-white/40 leading-[1.7] max-w-2xl"
+            >
+              {t('hero.note')}
+            </Reveal>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 pb-20 lg:pb-28">
+            <Reveal
+              as="h2"
+              y={20}
+              duration={0.6}
+              className="text-[24px] md:text-[32px] font-semibold text-white/90 mb-8 md:mb-12"
+            >
+              {t('dashboards.heading')}
+            </Reveal>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
+              {DASHBOARDS.map(({ id, Icon }, i) => (
+                <Reveal
+                  key={id}
+                  as="article"
+                  y={20}
+                  duration={0.5}
+                  delay={0.05 + i * 0.08}
+                  className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-8"
+                >
+                  <Icon className="h-6 w-6 text-white/30 mb-6" />
+                  <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 block mb-3">
+                    {t(`dashboards.${id}.sector`)}
+                  </span>
+                  <h3 className="text-[19px] md:text-[21px] font-semibold text-white/90 mb-3 leading-tight">
+                    {t(`dashboards.${id}.title`)}
+                  </h3>
+                  <p className="text-[14px] text-white/[0.55] leading-[1.7] mb-6">
+                    {t(`dashboards.${id}.body`)}
+                  </p>
+                  {/* Not a link: these three pages do not exist yet,
+                      and a card that navigates nowhere reads as a broken site
+                      rather than as a roadmap. */}
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/50">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[#FFAF64]" />
+                    {t('status.comingSoon')}
+                  </span>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 pb-24 lg:pb-32">
+            <Reveal
+              as="div"
+              y={20}
+              duration={0.6}
+              className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-10"
+            >
+              <h2 className="text-[24px] md:text-[32px] font-semibold text-white/90 mb-3">
+                {t('preview.heading')}
+              </h2>
+              <p className="text-[15px] text-white/[0.55] leading-[1.7] max-w-2xl mb-8">
+                {t('preview.body')}
+              </p>
+
+              <Chart
+                className="h-[260px] md:h-[320px]"
+                type="bar"
+                ariaLabel={t('preview.ariaLabel')}
+                data={{
+                  labels: t.raw('preview.skills'),
+                  datasets: [
+                    {
+                      label: t('preview.axis'),
+                      data: PREVIEW_SCORES,
+                      backgroundColor: '#4B4DF7',
+                      hoverBackgroundColor: '#7B7DF9',
+                      borderRadius: 6,
+                      barThickness: 18,
+                    },
+                  ],
+                }}
+                options={{
+                  indexAxis: 'y',
+                  plugins: { legend: { display: false } },
+                  scales: {
+                    x: {
+                      min: 0,
+                      max: 100,
+                      grid: { color: 'rgba(255,255,255,0.06)' },
+                      ticks: { color: 'rgba(255,255,255,0.4)' },
+                    },
+                    y: {
+                      grid: { display: false },
+                      ticks: { color: 'rgba(255,255,255,0.7)' },
+                    },
+                  },
+                }}
+              />
+
+              <p className="text-[13px] text-white/35 leading-[1.7] mt-6">
+                {t('preview.caption')}
+              </p>
+            </Reveal>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/[locale]/demo/opengraph-image.tsx
+++ b/app/[locale]/demo/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogFor } from '@/i18n/og-card';
+
+export { size, contentType } from '@/i18n/og-card';
+
+export function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'it' }];
+}
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return ogFor('demo', locale);
+}

--- a/app/[locale]/demo/page.tsx
+++ b/app/[locale]/demo/page.tsx
@@ -1,0 +1,34 @@
+// The server half of this route. The page itself is body.tsx.
+//
+// The same eight lines as every other route, with one difference that lives in
+// the registry rather than here: `"noindex": true` in i18n/routes.json, which
+// buildMetadata turns into robots noindex/nofollow and which keeps the route
+// out of the sitemap. Nothing on this page renders a robots tag by hand.
+import { NextIntlClientProvider } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+import { buildMetadata } from '@/i18n/metadata';
+import { messagesForRoute } from '@/i18n/messages';
+import JsonLd from '@/i18n/json-ld';
+import Body from './body';
+
+const ROUTE = 'demo';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return buildMetadata(ROUTE, locale);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={await messagesForRoute(ROUTE, locale)}>
+      <JsonLd routeId={ROUTE} locale={locale} />
+      <Body />
+    </NextIntlClientProvider>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -36,6 +36,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     // belong in search is a marketing call; this only stops the contradiction.
     if (route.id.startsWith("lp/")) continue;
 
+    // The registry's own answer to the same question, for routes that are not
+    // landing pages: the demo dashboards are outbound material sent to one
+    // prospect at a time, and the page tells Google the same thing through
+    // `robots: noindex` in i18n/metadata.ts. Submitting it here would be the
+    // sitemap arguing with the page.
+    if (route.noindex) continue;
+
     const languages = alternatesFor(route);
 
     // A dynamic route's registry entry stands for N real URLs. Substituting the

--- a/components/demo/DemoView.tsx
+++ b/components/demo/DemoView.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+// Renders nothing; reports that this demo page was opened, and by whom.
+//
+// Every demo page mounts one of these with its own slug, so the three
+// dashboards do not each grow their own copy of the effect below.
+
+import { useEffect } from 'react';
+import { demoViewEvent } from '@/components/demo/track';
+
+export default function DemoView({ slug }: { slug: string }) {
+  useEffect(() => {
+    // GTM is loaded `afterInteractive` in the root layout, so this effect can
+    // run before its snippet has created the array. Pushing into one we create
+    // ourselves is what the snippet expects: it keeps whatever is already
+    // there and replays it when the container loads.
+    const w = window as typeof window & { dataLayer?: unknown[] };
+    (w.dataLayer ??= []).push(demoViewEvent(slug, window.location.search));
+  }, [slug]);
+
+  return null;
+}

--- a/components/demo/charts/Chart.tsx
+++ b/components/demo/charts/Chart.tsx
@@ -1,0 +1,31 @@
+// The one chart component the demo dashboards render.
+//
+// It exists to keep chart.js out of every other route: the library is behind a
+// next/dynamic with ssr: false, so it is neither prerendered nor in any page's
+// initial bundle — a browser downloads it only after a demo page has mounted.
+// Measured on the build, no non-demo page's script tags reference it.
+//
+// No 'use client' here on purpose. `ssr: false` is only legal inside the
+// client graph, and this module is in it because the demo bodies that import
+// it are client components; the directive would be gratuitous and
+// `npm run check:client` rejects it. A Server Component importing this file
+// fails the build, loudly, which is the right way to find out.
+
+import dynamic from 'next/dynamic';
+import type { ChartCanvasProps } from '@/components/demo/charts/ChartCanvas';
+
+const ChartCanvas = dynamic(() => import('@/components/demo/charts/ChartCanvas'), {
+  ssr: false,
+  // The canvas has no intrinsic size, so without this the section collapses
+  // and the page reflows when the chart arrives.
+  loading: () => <div className="h-full w-full rounded-xl bg-white/[0.04] animate-pulse" />,
+});
+
+/** `className` sizes the box — the canvas fills it. */
+export default function Chart({ className, ...props }: ChartCanvasProps & { className?: string }) {
+  return (
+    <div className={className}>
+      <ChartCanvas {...props} />
+    </div>
+  );
+}

--- a/components/demo/charts/ChartCanvas.tsx
+++ b/components/demo/charts/ChartCanvas.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+// The canvas half of the chart wrapper: one Chart.js instance, created on
+// mount and destroyed on unmount.
+//
+// Nothing imports this module statically — Chart.tsx reaches it through
+// next/dynamic with ssr: false — which is what keeps chart.js in an async
+// chunk that only a demo page requests. Importing it directly from a page
+// would undo that and put the library in that page's initial bundle.
+
+import { useEffect, useRef } from 'react';
+// ponytail: chart.js/auto registers every controller, scale and element (~70 KB
+// gz) so a dashboard can ask for a bar, a radar or a scatter without editing
+// this file. The upgrade path, if the demo pages ever need to be light, is to
+// register the handful of components the three dashboards actually use.
+import ChartJS from 'chart.js/auto';
+import type { ChartData, ChartOptions, ChartType } from 'chart.js';
+
+export type ChartCanvasProps = {
+  type: ChartType;
+  data: ChartData;
+  options?: ChartOptions;
+  /** What a screen reader is told the chart shows. */
+  ariaLabel: string;
+};
+
+export default function ChartCanvas({ type, data, options, ariaLabel }: ChartCanvasProps) {
+  const canvas = useRef<HTMLCanvasElement>(null);
+
+  // ponytail: the config is compared by identity, so a caller that builds it
+  // inline on every render rebuilds the chart on every render. The demo pages
+  // are static and render once; a dashboard that drives a chart from state
+  // should useMemo its data, or this becomes a deep compare.
+  useEffect(() => {
+    if (!canvas.current) return;
+    const chart = new ChartJS(canvas.current, {
+      type,
+      data,
+      // The container decides the height — every chart here sits in a div with
+      // a height class, and Chart.js's default 2:1 aspect ratio would fight it.
+      options: { responsive: true, maintainAspectRatio: false, ...options },
+    });
+    return () => chart.destroy();
+  }, [type, data, options]);
+
+  return <canvas ref={canvas} role="img" aria-label={ariaLabel} />;
+}

--- a/components/demo/track.ts
+++ b/components/demo/track.ts
@@ -1,0 +1,30 @@
+// The GTM event a demo page fires when it opens.
+//
+// The demo links leave the building one prospect at a time, with `?c=<token>`
+// naming who received it — so "who opened which dashboard" is a question the
+// analytics can answer, and the token is the only thing that carries the
+// answer. Pure and import-free on purpose: scripts/check-demo-event.mjs runs
+// this file directly under Node, so what the page pushes and what the gate
+// asserts are the same function.
+
+export type DemoViewEvent = {
+  event: 'demo_view';
+  demoSlug: string;
+  /** The `?c=` token, absent when the link was opened without one. */
+  demoContact?: string;
+};
+
+/**
+ * `search` is the raw query string — `window.location.search` at the call
+ * site. A missing or blank token omits the key rather than pushing an empty
+ * string: in GTM an empty value is a value, and a trigger conditioned on it
+ * would fire for every direct visit.
+ */
+export function demoViewEvent(slug: string, search: string): DemoViewEvent {
+  const contact = new URLSearchParams(search).get('c')?.trim();
+  return {
+    event: 'demo_view',
+    demoSlug: slug,
+    ...(contact ? { demoContact: contact } : {}),
+  };
+}

--- a/i18n/metadata.ts
+++ b/i18n/metadata.ts
@@ -87,6 +87,11 @@ export async function buildMetadata(routeId: string, locale: string): Promise<Me
     title,
     description,
     alternates: { canonical, languages: alternatesFor(indexed) },
+    // Nine bodies render this tag by hand, and they do not agree: five say
+    // `noindex`, four say `noindex, nofollow`. A page copied from one of them
+    // inherits whichever it happened to copy. The registry says it once, here,
+    // for every locale of the route. Retrofitting those nine is #148.
+    robots: route.noindex ? { index: false, follow: false } : undefined,
     openGraph: {
       title,
       description,

--- a/i18n/routes.json
+++ b/i18n/routes.json
@@ -237,6 +237,14 @@
     }
   },
   {
+    "id": "demo",
+    "paths": {
+      "en": "/demo",
+      "it": "/demo"
+    },
+    "noindex": true
+  },
+  {
     "id": "index",
     "paths": {
       "en": "/",

--- a/i18n/routes.ts
+++ b/i18n/routes.ts
@@ -47,6 +47,22 @@ export type Route = {
    * sitemap.
    */
   canonicalOf?: string;
+  /**
+   * Keep this route out of the index: no sitemap entry, and a
+   * `robots: noindex, nofollow` on the page itself.
+   *
+   * It is a field rather than a per-page `<meta>` because the two halves have
+   * to agree — a URL submitted in the sitemap and marked noindex is the same
+   * contradiction as one submitted and blocked in robots.txt. The site reads
+   * it in exactly two places — i18n/metadata.ts and app/sitemap.ts — and
+   * scripts/check-routes.mjs asserts that both still do, and that robots.txt
+   * does *not* also block the route: a page a crawler may not fetch is a page
+   * whose noindex a crawler never reads.
+   *
+   * The landing pages are noindex by three uncoordinated mechanisms and are
+   * deliberately not retrofitted here — that is #148.
+   */
+  noindex?: boolean;
 };
 
 export const routes: Route[] = data as Route[];

--- a/messages/en.json
+++ b/messages/en.json
@@ -4568,6 +4568,53 @@
       }
     }
   },
+  "demo": {
+    "meta": {
+      "title": "Demo dashboards | Skillvue",
+      "description": "Three interactive dashboards built for live assessment programmes, de-branded and stripped of every individual record. Shared by link, not indexed."
+    },
+    "hero": {
+      "eyebrow": "Interactive demo",
+      "heading": "The output of an assessment, <span>before you run one</span>",
+      "body": "Three dashboards our customer team built for real programmes, with the brand taken out and every individual record removed. What is left is the shape of the result: how a population distributes, where the gaps sit, and what the numbers point at.",
+      "note": "This page is not indexed and nothing on the site links to it. You are reading it because someone sent you the link."
+    },
+    "dashboards": {
+      "heading": "Three programmes, three questions",
+      "retail": {
+        "sector": "Retail",
+        "title": "Store manager capability",
+        "body": "A store network assessed on one frame end to end: how capability distributes across the estate, and which stores carry the gap."
+      },
+      "salesNetwork": {
+        "sector": "Insurance",
+        "title": "Sales network readiness",
+        "body": "An agent network measured before a commercial push: who is ready to sell the new range, and who goes through the training first."
+      },
+      "crossCountry": {
+        "sector": "Manufacturing",
+        "title": "Cross-country talent map",
+        "body": "One competency frame applied in six countries, so a group HR team can compare populations that were never comparable before."
+      }
+    },
+    "status": {
+      "comingSoon": "Coming soon"
+    },
+    "preview": {
+      "heading": "How a result reads",
+      "body": "Every dashboard is made of a handful of chart types, and this is the plainest of them: one competency per row, and the average score the population reached on it.",
+      "ariaLabel": "Bar chart of average scores by competency",
+      "axis": "Average score",
+      "skills": [
+        "Communication",
+        "Problem solving",
+        "Team leadership",
+        "Adaptability",
+        "Commercial drive"
+      ],
+      "caption": "Illustrative figures. The three dashboards run on aggregated data, with every individual record removed."
+    }
+  },
   "home": {
     "meta": {
       "title": "Skillvue | AI Talent Intelligence Platform",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4568,6 +4568,53 @@
       }
     }
   },
+  "demo": {
+    "meta": {
+      "title": "Dashboard demo | Skillvue",
+      "description": "Tre dashboard interattive costruite su programmi di assessment reali, de-brandizzate e senza alcun dato individuale. Si condividono via link, fuori dall’indice."
+    },
+    "hero": {
+      "eyebrow": "Demo interattiva",
+      "heading": "Il risultato di un assessment, <span>prima di farlo</span>",
+      "body": "Tre dashboard nate su programmi reali dei nostri clienti, private del marchio e di ogni dato individuale. Quello che resta è la forma del risultato: come si distribuisce una popolazione, dove sono i divari e su cosa puntano i numeri.",
+      "note": "Questa pagina non è indicizzata e nessun link del sito porta qui: la stai leggendo perché qualcuno te l’ha mandata."
+    },
+    "dashboards": {
+      "heading": "Tre programmi, tre domande",
+      "retail": {
+        "sector": "Retail",
+        "title": "Capability degli store manager",
+        "body": "Una rete di punti vendita valutata con lo stesso schema dall’inizio alla fine: come si distribuisce la capability sul territorio e quali negozi si portano dietro il divario."
+      },
+      "salesNetwork": {
+        "sector": "Assicurazioni",
+        "title": "Prontezza della rete vendita",
+        "body": "Una rete di agenti misurata prima di una spinta commerciale: chi è pronto a vendere la nuova gamma e chi passa prima dalla formazione."
+      },
+      "crossCountry": {
+        "sector": "Manifatturiero",
+        "title": "Mappa dei talenti cross-country",
+        "body": "Un solo schema di competenze applicato in sei paesi, perché l’HR di gruppo possa confrontare popolazioni che prima non erano confrontabili."
+      }
+    },
+    "status": {
+      "comingSoon": "In arrivo"
+    },
+    "preview": {
+      "heading": "Come si legge un risultato",
+      "body": "Ogni dashboard è fatta di pochi tipi di grafico, e questo è il più semplice: una competenza per riga e il punteggio medio che la popolazione ha raggiunto su quella competenza.",
+      "ariaLabel": "Grafico a barre dei punteggi medi per competenza",
+      "axis": "Punteggio medio",
+      "skills": [
+        "Comunicazione",
+        "Problem solving",
+        "Leadership di team",
+        "Adattabilità",
+        "Spinta commerciale"
+      ],
+      "caption": "Valori illustrativi. Le tre dashboard girano su dati aggregati, senza alcun record individuale."
+    }
+  },
   "home": {
     "meta": {
       "title": "Skillvue | Piattaforma di Talent Intelligence con AI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "autoprefixer": "^10.4.27",
+        "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
@@ -655,6 +656,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "16.3.4",
@@ -1903,6 +1910,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "check:untranslated": "node scripts/check-untranslated.mjs",
     "check:build": "node scripts/build-clean.mjs",
     "check:assets": "node scripts/check-assets.mjs",
+    "check:demo-event": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-event.mjs",
     "test:smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "autoprefixer": "^10.4.27",
+    "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",

--- a/scripts/check-demo-event.mjs
+++ b/scripts/check-demo-event.mjs
@@ -1,0 +1,47 @@
+// check-demo-event — the GTM payload a demo page pushes when it opens.
+//
+// The `?c=<token>` in a demo link is the only thing that says which prospect
+// opened which dashboard, and it fails quietly: a token dropped on the way
+// into the dataLayer leaves a `demo_view` event that still fires, still counts,
+// and no longer answers the one question the link exists to answer. Nothing on
+// the page looks wrong either way.
+//
+// Node 24 runs the TypeScript directly, so this asserts against the function
+// components/demo/DemoView.tsx pushes with — not a second copy of the rule.
+//
+// Run: npm run check:demo-event
+
+import assert from 'node:assert/strict';
+import { demoViewEvent } from '../components/demo/track.ts';
+
+assert.deepEqual(
+  demoViewEvent('retail', '?c=test-123'),
+  { event: 'demo_view', demoSlug: 'retail', demoContact: 'test-123' },
+  'the token rides along with the slug of the dashboard that was opened',
+);
+
+// The link shared in a deck, or forwarded by the prospect: no token, and the
+// key is absent rather than empty. In GTM an empty string is a value, and a
+// trigger conditioned on the token would fire for every anonymous visit.
+assert.deepEqual(
+  demoViewEvent('hub', ''),
+  { event: 'demo_view', demoSlug: 'hub' },
+  'no query string means no contact key at all',
+);
+assert.deepEqual(demoViewEvent('hub', '?c='), { event: 'demo_view', demoSlug: 'hub' }, 'an empty token is no token');
+assert.deepEqual(demoViewEvent('hub', '?c=%20%20'), { event: 'demo_view', demoSlug: 'hub' }, 'a blank token is no token');
+assert.deepEqual(
+  demoViewEvent('hub', '?utm_source=nl'),
+  { event: 'demo_view', demoSlug: 'hub' },
+  'another parameter is not the token',
+);
+
+// The token travels through a mail client, so it arrives percent-encoded and
+// in company of whatever the tracker appended.
+assert.equal(
+  demoViewEvent('retail', '?utm_source=nl&c=acme%20corp&utm_medium=email').demoContact,
+  'acme corp',
+  'the token is decoded, and found wherever in the query string it sits',
+);
+
+console.log('[OK] demo event: slug and ?c= token, present and absent');

--- a/scripts/check-routes.mjs
+++ b/scripts/check-routes.mjs
@@ -313,7 +313,7 @@ const disallow = readFileSync(join(ROOT, 'public/robots.txt'), 'utf8')
   .filter(Boolean);
 
 const submitted = routes
-  .filter((r) => r.canonicalOf === undefined && !r.id.startsWith('lp/'))
+  .filter((r) => r.canonicalOf === undefined && !r.id.startsWith('lp/') && r.noindex !== true)
   .flatMap((r) => localesOf(r).map((locale) => new URL(urlFor(r, locale)).pathname));
 
 const contradictions = submitted.filter((path) =>
@@ -327,6 +327,60 @@ assert.deepEqual(
     contradictions.map((p) => '  ' + p).join('\n') +
     '\nDrop them from the sitemap or stop disallowing them — submitting a URL ' +
     'you block gets it indexed as a blank result, which is worse than either.',
+);
+
+// ── A noindex route says so in both places, and only in those ──────────────
+// `"noindex": true` in the registry has to reach two places to mean anything:
+// the page's own robots meta, and the sitemap. Both are read from the field,
+// and neither failure is visible — a page that quietly stops emitting the tag
+// looks exactly like one that emits it.
+const noindexRoutes = routes.filter((r) => r.noindex === true);
+
+if (noindexRoutes.length > 0) {
+  for (const [file, why] of [
+    [
+      'i18n/metadata.ts',
+      'so the pages emit no robots tag at all and every noindex route is indexable. ' +
+        'Return robots: { index: false, follow: false } for it.',
+    ],
+    [
+      'app/sitemap.ts',
+      'so a noindex route is still submitted to Google while its own page asks not to be ' +
+        'indexed. Add the `continue`, next to the one for the landing pages.',
+    ],
+  ]) {
+    assert.match(
+      readFileSync(join(ROOT, file), 'utf8'),
+      /route\.noindex/,
+      `${file} does not read route.noindex, ${why}`,
+    );
+  }
+}
+
+// And robots.txt must NOT block them — this assertion is deliberately the
+// opposite way round from the one above, and it is the one someone will
+// eventually "fix" backwards.
+//
+// Disallow and noindex cancel each other out. A URL blocked in robots.txt is
+// never fetched, so the noindex in its <head> is never read; found linked from
+// anywhere off-site, Google can then index it as a bare, contentless result —
+// the outcome neither instruction asked for, and the one described a few lines
+// up for /lp/. These links are made to be forwarded by mail, so "it ends up
+// public somewhere" is precisely the case the noindex exists to cover, and a
+// Disallow is precisely what would stop it working. The crawl budget argument
+// does not apply either: nothing on the site links to a noindex section.
+const blocked = noindexRoutes.flatMap((r) =>
+  localesOf(r)
+    .map((locale) => new URL(urlFor(r, locale)).pathname)
+    .filter((path) => disallow.some((rule) => path.startsWith(rule) || `${path}/`.startsWith(rule)))
+    .map((path) => `  ${r.id}: ${path}`),
+);
+assert.deepEqual(
+  blocked,
+  [],
+  `${blocked.length} noindex route(s) are also blocked in robots.txt:\n${blocked.join('\n')}\n` +
+    'Drop the Disallow. A crawler that may not fetch the page cannot read the noindex on it, ' +
+    'and the URL gets indexed empty instead of not at all.',
 );
 
 const monolingual = routes.filter((r) => Object.keys(r.paths).length === 1);


### PR DESCRIPTION
Primo passo del programma di dashboard demo per l'outbound (#167 → #171):
l'impalcatura della sezione `/demo`, l'hub, e il wrapper dei grafici che le tre
dashboard riuseranno.

## Il meccanismo noindex

Il sito non ne aveva uno. `lp/*` è tenuto fuori dall'indice in tre modi
scoordinati, e nove body renderizzano un `<meta name="robots">` scritto a mano
che cinque di loro scrivono diversamente dagli altri quattro. Invece di una
decima copia: `"noindex": true` nel registro delle rotte, letto in **due punti
soli** — `i18n/metadata.ts` lo trasforma in `robots: { index: false, follow: false }`,
`app/sitemap.ts` salta la rotta con lo stesso `continue` che già usa per le
landing. `lp/*` non è retrofittato qui: è la #148.

## robots.txt non è stato toccato, ed è deliberato

Un `Disallow` annullerebbe il `noindex`. Una URL che un crawler non può
scaricare è una URL il cui `noindex` non viene mai letto, e se la trova linkata
da fuori la indicizza come risultato spoglio — il caso già descritto nel
commento dentro `app/sitemap.ts` a proposito di `/lp/`. Questi link nascono per
essere inoltrati via mail, quindi «finisce pubblico da qualche parte» è
esattamente lo scenario per cui il `noindex` esiste.

`check-routes.mjs` asserisce la regola inversa — una rotta `noindex` non deve
essere coperta da alcun prefisso `Disallow` — e verifica che entrambi i lettori
del campo lo leggano ancora.

## Costo di chart.js

`chart.js` è l'unica nuova dipendenza. Giustificazione: le tre dashboard
sorgente sono già scritte in Chart.js, quindi la configurazione dei ~29 grafici
si porta quasi 1:1 invece di essere riscritta a mano in SVG. Caricata via
`next/dynamic({ ssr: false })`, finisce in un chunk da 66.5 KB gz che
**nessuno dei 130 documenti prerenderizzati referenzia** — misurato con
`harness/measure-js.mjs`. Nessuna pagina esistente ha guadagnato un byte.

È costruito solo il tipo di grafico che l'hub usa davvero; gli altri quattro
arrivano con le dashboard che ne hanno bisogno.

## Attribuzione per prospect

`?c=<token>` dice quale prospect ha aperto il link. Finisce nel `dataLayer` con
lo slug della dashboard, creando l'array quando lo snippet `afterInteractive` di
GTM non l'ha ancora fatto, e omettendo la chiave del tutto quando il token non
c'è — in GTM la stringa vuota è un valore, e un trigger su quella scatterebbe a
ogni visita anonima.

## Verifica

`./harness/init.sh` completo verde (13 gate, incluso `check:build`). `/demo` e
`/it/demo` servono il `noindex`; il sitemap non contiene `demo`. I due gate
nuovi sono stati rotti apposta e visti rossi, dall'implementer e di nuovo dal
reviewer, prima di essere ripristinati.

Closes #167