### PR TITLE
Dataset demo anonimizzati, e le tre schede tornano al settore vero

### DIFF
--- a/data/demo/cross-country.ts
+++ b/data/demo/cross-country.ts
@@ -10,8 +10,10 @@
 //     as a name. The labels these keys stand for live in `messages/`.
 //   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
 //   - a group carrying a score holds at least 25 people.
-//     Countries are collapsed into three groups: the list of them, and a
-//     group of five, would both identify the customer.
+//     The eight countries ship as three buckets. The two largest stand on
+//     their own and clear the floor; the remaining six are pooled, because
+//     three of them held fewer than ten people. None is named: the list of
+//     countries would identify the customer on its own.
 //   - the industry-specific function name is generalised as
 //     `technicalSpecialist`.
 

--- a/data/demo/cross-country.ts
+++ b/data/demo/cross-country.ts
@@ -1,0 +1,258 @@
+// Cross-country talent map — aggregated assessment results.
+//
+// Aggregates only. The source dashboard runs on individual records —
+// one row per participant, with a name and a manager on it —
+// and none of them are here: every figure below is a group statistic computed
+// once, outside this repository, from data that never entered it.
+//
+// The rules the numbers obey, asserted by `npm run check:demo-anonymity`:
+//   - no strings. Every leaf is a number, so nothing here can read as copy or
+//     as a name. The labels these keys stand for live in `messages/`.
+//   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
+//   - a group carrying a score holds at least 25 people.
+//     Countries are collapsed into three groups: the list of them, and a
+//     group of five, would both identify the customer.
+//   - the industry-specific function name is generalised as
+//     `technicalSpecialist`.
+
+export const crossCountry = {
+  population: {
+    invited: 390,
+    evaluated: 345,
+    evaluatedPct: 88.4,
+  },
+  skillMatching: {
+    mean: 40.4,
+    median: 39.8,
+    min: 0.8,
+    max: 88.8,
+    threshold: 40,
+    binWidth: 10,
+    distribution: [1.5, 7.0, 18.6, 24.1, 22.7, 14.5, 7.8, 2.6, 1.2, 0.0],
+  },
+  competencies: {
+    vision: {
+      mean: 2.62,
+      bands: {
+        veryPoor: 21.2,
+        belowAverage: 21.8,
+        adequate: 35.8,
+        good: 17.4,
+        excellent: 3.8,
+      },
+    },
+    openness: {
+      mean: 2.51,
+      bands: {
+        veryPoor: 16.6,
+        belowAverage: 41.0,
+        adequate: 30.5,
+        good: 10.2,
+        excellent: 1.7,
+      },
+    },
+    leadership: {
+      mean: 2.69,
+      bands: {
+        veryPoor: 7.6,
+        belowAverage: 44.2,
+        adequate: 31.7,
+        good: 14.0,
+        excellent: 2.6,
+      },
+    },
+    accountability: {
+      mean: 2.64,
+      bands: {
+        veryPoor: 15.7,
+        belowAverage: 31.4,
+        adequate: 37.5,
+        good: 13.7,
+        excellent: 1.7,
+      },
+    },
+  },
+  framework: {
+    marketAwareness: {
+      mean: 2.62,
+      bands: {
+        veryPoor: 21.2,
+        belowAverage: 21.8,
+        adequate: 35.8,
+        good: 17.4,
+        excellent: 3.8,
+      },
+    },
+    customerCentricApproach: {
+      mean: 2.63,
+      bands: {
+        veryPoor: 14.2,
+        belowAverage: 33.4,
+        adequate: 31.1,
+        good: 15.7,
+        excellent: 5.5,
+      },
+    },
+    customerRelationshipManagement: {
+      mean: 2.33,
+      bands: {
+        veryPoor: 32.6,
+        belowAverage: 22.7,
+        adequate: 34.3,
+        good: 7.6,
+        excellent: 2.9,
+      },
+    },
+    communicationInfluence: {
+      mean: 2.35,
+      bands: {
+        veryPoor: 22.1,
+        belowAverage: 39.2,
+        adequate: 28.5,
+        good: 9.9,
+        excellent: 0.3,
+      },
+    },
+    emotionalIntelligence: {
+      mean: 2.88,
+      bands: {
+        veryPoor: 9.9,
+        belowAverage: 24.1,
+        adequate: 30.8,
+        good: 27.3,
+        excellent: 7.8,
+      },
+    },
+    negotiation: {
+      mean: 3.26,
+      bands: {
+        veryPoor: 7.8,
+        belowAverage: 13.4,
+        adequate: 33.4,
+        good: 29.4,
+        excellent: 16.0,
+      },
+    },
+    relationshipBuilding: {
+      mean: 2.62,
+      bands: {
+        veryPoor: 18.0,
+        belowAverage: 36.6,
+        adequate: 27.6,
+        good: 11.9,
+        excellent: 5.8,
+      },
+    },
+    solutionsOriented: {
+      mean: 2.72,
+      bands: {
+        veryPoor: 20.3,
+        belowAverage: 22.1,
+        adequate: 34.3,
+        good: 19.8,
+        excellent: 3.5,
+      },
+    },
+    digitalTools: {
+      mean: 2.47,
+      bands: {
+        veryPoor: 28.2,
+        belowAverage: 34.0,
+        adequate: 22.1,
+        good: 10.5,
+        excellent: 5.2,
+      },
+    },
+  },
+  drivers: {
+    vision: {
+      monitoringMarkets: 2.69,
+      identifyingOpportunities: 3.11,
+      anticipatingTrends: 2.07,
+    },
+    openness: {
+      focusingOnCustomers: 3.92,
+      settingQualityStandards: 2.49,
+      workingSystematically: 2.69,
+      maintainingQualityProcesses: 2.21,
+      maintainingProductivity: 1.82,
+      applyingTechnicalExpertise: 2.74,
+      developingTechnicalExpertise: 1.87,
+      usingTechnology: 2.36,
+    },
+    leadership: {
+      speakingFluently: 2.38,
+      explainingConcepts: 2.38,
+      articulatingKeyPoints: 2.35,
+      publicSpeaking: 2.17,
+      projectingCredibility: 2.19,
+      respondingToTheAudience: 2.66,
+      showingConsideration: 3.31,
+      showingEmpathy: 3.19,
+      stabilisingEmotions: 3.24,
+      toleratingCriticism: 1.92,
+      managingConflict: 2.75,
+      promotingIdeas: 3.72,
+      gainingAgreement: 3.28,
+      navigatingPolitics: 2.78,
+      buildingRelationships: 3.82,
+      developingNetworks: 2.93,
+      relatingAcrossLevels: 2.32,
+      understandingOthers: 3.18,
+      listeningToOthers: 2.19,
+      consultingOthers: 1.98,
+      supportingOthers: 2.41,
+      caringForOthers: 2.11,
+    },
+    accountability: {
+      learningQuickly: 2.99,
+      acceptingNewIdeas: 2.91,
+      thinkingQuickly: 2.14,
+      supportingOrganisationalLearning: 1.84,
+      evaluatingInformation: 3.38,
+      testingAssumptions: 3.14,
+      producingSolutions: 2.99,
+      formingJudgements: 2.88,
+      demonstratingSystemsThinking: 2.52,
+      adaptingToSituations: 2.56,
+      gatheringInformation: 2.49,
+      adaptingInterpersonalStyle: 2.17,
+      managingAmbiguity: 2.32,
+    },
+  },
+  countryGroups: {
+    primary: {
+      n: 260,
+      skillMatching: 39.6,
+    },
+    secondary: {
+      n: 30,
+      skillMatching: 44.8,
+    },
+    others: {
+      n: 55,
+      skillMatching: 41.8,
+    },
+  },
+  mobility: {
+    veryWilling: 7.3,
+    willing: 6.2,
+    openToConsidering: 53.7,
+    somewhatReluctant: 11.0,
+    notInterested: 21.8,
+  },
+  preferredAreas: {
+    sales: 60.7,
+    technicalSpecialist: 56.2,
+    marketing: 38.1,
+    operations: 5.1,
+    hr: 4.2,
+    finance: 0.6,
+  },
+  growth: {
+    crossFunctional: 32.2,
+    deepenExpertise: 34.2,
+    teamManagement: 28.0,
+    noPreference: 5.6,
+  },
+} as const;

--- a/data/demo/retail.ts
+++ b/data/demo/retail.ts
@@ -1,0 +1,405 @@
+// Retail store capability — aggregated assessment results.
+//
+// Aggregates only. The source dashboard runs on individual records —
+// one row per person and one per store, with names, store codes and per-store
+// revenue —
+// and none of them are here: every figure below is a group statistic computed
+// once, outside this repository, from data that never entered it.
+//
+// The rules the numbers obey, asserted by `npm run check:demo-anonymity`:
+//   - no strings. Every leaf is a number, so nothing here can read as copy or
+//     as a name. The labels these keys stand for live in `messages/`.
+//   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
+//   - a group carrying a score holds at least 25 people.
+//     Area managers become `area1`…`area5` in a stable order, and the mapping
+//     to the five real names is kept nowhere.
+//   - the per-area segment mix ships as a share, never as a cell count.
+
+export const retail = {
+  population: {
+    salesAdvisors: 570,
+    storeManagers: 110,
+    stores: 130,
+    outlets: 20,
+    topPerformers: 120,
+  },
+  overview: {
+    aboveThresholdPct: 20.5,
+    threshold: 40,
+    conversionRate: 10.71,
+    salesPerHour: 101,
+    potentialKEur: 7920,
+  },
+  skillDistribution: {
+    binWidth: 5,
+    distribution: [0.3, 0.1, 2.1, 7.9, 11.3, 17.8, 19.4, 15.3, 11.8, 8.1, 4.0, 1.0, 0.9, 0.0],
+  },
+  areas: {
+    area1: {
+      n: 85,
+      stores: 25,
+      aboveThresholdPct: 13.1,
+      conversionRate: 11.22,
+      segments: {
+        benchmark: 6.0,
+        resultWithoutMethod: 35.7,
+        skillWithoutResult: 6.0,
+        priorityDevelopment: 45.2,
+        toActivate: 7.1,
+      },
+    },
+    area2: {
+      n: 90,
+      stores: 20,
+      aboveThresholdPct: 12.4,
+      conversionRate: 9.09,
+      segments: {
+        benchmark: 7.9,
+        resultWithoutMethod: 52.8,
+        skillWithoutResult: 4.5,
+        priorityDevelopment: 32.6,
+        toActivate: 2.2,
+      },
+    },
+    area3: {
+      n: 135,
+      stores: 35,
+      aboveThresholdPct: 23.4,
+      conversionRate: 11.47,
+      segments: {
+        benchmark: 16.8,
+        resultWithoutMethod: 46.0,
+        skillWithoutResult: 6.6,
+        priorityDevelopment: 27.7,
+        toActivate: 2.9,
+      },
+    },
+    area4: {
+      n: 105,
+      stores: 25,
+      aboveThresholdPct: 25.2,
+      conversionRate: 14.08,
+      segments: {
+        benchmark: 14.6,
+        resultWithoutMethod: 35.0,
+        skillWithoutResult: 9.7,
+        priorityDevelopment: 34.0,
+        toActivate: 6.8,
+      },
+    },
+    area5: {
+      n: 140,
+      stores: 30,
+      aboveThresholdPct: 24.5,
+      conversionRate: 9.82,
+      segments: {
+        benchmark: 15.1,
+        resultWithoutMethod: 45.3,
+        skillWithoutResult: 9.4,
+        priorityDevelopment: 28.1,
+        toActivate: 2.2,
+      },
+    },
+  },
+  seniority: {
+    lt3m: {
+      n: 50,
+      skill: 28.5,
+      productKnowledge: 29.2,
+      aboveThresholdPct: 15.4,
+      relativeSph: 0.87,
+    },
+    m3to12: {
+      n: 40,
+      skill: 33.2,
+      productKnowledge: 31.9,
+      aboveThresholdPct: 21.4,
+      relativeSph: 0.97,
+    },
+    y1to2: {
+      n: 50,
+      skill: 32.8,
+      productKnowledge: 32.7,
+      aboveThresholdPct: 20.8,
+      relativeSph: 0.98,
+    },
+    y2to5: {
+      n: 140,
+      skill: 33.2,
+      productKnowledge: 33.7,
+      aboveThresholdPct: 26.1,
+      relativeSph: 1.02,
+    },
+    y5to10: {
+      n: 65,
+      skill: 32.2,
+      productKnowledge: 32.3,
+      aboveThresholdPct: 25.4,
+      relativeSph: 1.02,
+    },
+    y10to20: {
+      n: 140,
+      skill: 31.4,
+      productKnowledge: 32.6,
+      aboveThresholdPct: 18.0,
+      relativeSph: 1.06,
+    },
+    gt20: {
+      n: 60,
+      skill: 31.1,
+      productKnowledge: 31.3,
+      aboveThresholdPct: 11.9,
+      relativeSph: 1.06,
+    },
+  },
+  context: {
+    channel: {
+      fullPrice: {
+        n: 475,
+        skill: 32.3,
+        productKnowledge: 32.5,
+        aboveThresholdPct: 22.2,
+        relativeSph: 1.04,
+        areas: {
+          customerSalesExcellence: 37.2,
+          brandStorytelling: 31.7,
+          collaborationTeamContribution: 26.0,
+          agilityExecution: 33.9,
+          productKnowledge: 32.5,
+        },
+        stores: 110,
+        conversionRate: 11.21,
+        unitsPerTicket: 1.75,
+        averageTicket: 69.2,
+        salesPerHour: 96.9,
+        visitsPerDay: 188,
+        turnoverPct: 4.0,
+      },
+      outlet: {
+        n: 90,
+        skill: 30.1,
+        productKnowledge: 31.3,
+        aboveThresholdPct: 12.4,
+        relativeSph: 1.04,
+        areas: {
+          customerSalesExcellence: 33.0,
+          brandStorytelling: 28.6,
+          collaborationTeamContribution: 26.2,
+          agilityExecution: 31.4,
+          productKnowledge: 31.3,
+        },
+        stores: 20,
+        conversionRate: 9.09,
+        unitsPerTicket: 1.81,
+        averageTicket: 50.8,
+        salesPerHour: 122.4,
+        visitsPerDay: 429,
+        turnoverPct: 6.5,
+      },
+    },
+    location: {
+      mall: {
+        n: 445,
+        skill: 31.5,
+        productKnowledge: 32.1,
+        aboveThresholdPct: 19.3,
+        relativeSph: 1.03,
+        areas: {
+          customerSalesExcellence: 36.3,
+          brandStorytelling: 30.7,
+          collaborationTeamContribution: 25.3,
+          agilityExecution: 33.0,
+          productKnowledge: 32.1,
+        },
+        stores: 100,
+        conversionRate: 10.44,
+        unitsPerTicket: 1.78,
+        averageTicket: 67.9,
+        salesPerHour: 102.6,
+        visitsPerDay: 214,
+        turnoverPct: 9.5,
+      },
+      highStreet: {
+        n: 110,
+        skill: 33.8,
+        productKnowledge: 33.3,
+        aboveThresholdPct: 25.5,
+        relativeSph: 1.05,
+        areas: {
+          customerSalesExcellence: 38.2,
+          brandStorytelling: 33.1,
+          collaborationTeamContribution: 28.9,
+          agilityExecution: 35.4,
+          productKnowledge: 33.3,
+        },
+        stores: 30,
+        conversionRate: 11.43,
+        unitsPerTicket: 1.72,
+        averageTicket: 70.1,
+        salesPerHour: 90.8,
+        visitsPerDay: 175,
+        turnoverPct: 0.0,
+      },
+    },
+    tier: {
+      tier1: {
+        n: 220,
+        skill: 31.4,
+        productKnowledge: 31.3,
+        aboveThresholdPct: 19.5,
+        relativeSph: 1.04,
+        areas: {
+          customerSalesExcellence: 36.3,
+          brandStorytelling: 30.4,
+          collaborationTeamContribution: 26.0,
+          agilityExecution: 32.7,
+          productKnowledge: 31.3,
+        },
+        stores: 40,
+        conversionRate: 9.32,
+        unitsPerTicket: 1.79,
+        averageTicket: 70.7,
+        salesPerHour: 112.8,
+        visitsPerDay: 306,
+        turnoverPct: 13.0,
+      },
+      tier2: {
+        n: 220,
+        skill: 32.7,
+        productKnowledge: 33.1,
+        aboveThresholdPct: 24.9,
+        relativeSph: 1.03,
+        areas: {
+          customerSalesExcellence: 37.4,
+          brandStorytelling: 32.1,
+          collaborationTeamContribution: 26.8,
+          agilityExecution: 34.3,
+          productKnowledge: 33.1,
+        },
+        stores: 55,
+        conversionRate: 11.21,
+        unitsPerTicket: 1.75,
+        averageTicket: 67.8,
+        salesPerHour: 97.1,
+        visitsPerDay: 190,
+        turnoverPct: 0.0,
+      },
+      tier3: {
+        n: 115,
+        skill: 31.6,
+        productKnowledge: 33.0,
+        aboveThresholdPct: 14.0,
+        relativeSph: 1.04,
+        areas: {
+          customerSalesExcellence: 35.7,
+          brandStorytelling: 31.5,
+          collaborationTeamContribution: 24.8,
+          agilityExecution: 33.2,
+          productKnowledge: 33.0,
+        },
+        stores: 35,
+        conversionRate: 12.85,
+        unitsPerTicket: 1.72,
+        averageTicket: 64.9,
+        salesPerHour: 87.7,
+        visitsPerDay: 123,
+        turnoverPct: 0.0,
+      },
+    },
+  },
+  topVsRest: {
+    n: 120,
+    skill: {
+      top: 32.8,
+      rest: 31.9,
+    },
+    aboveThresholdPct: {
+      top: 23.8,
+      rest: 20.1,
+    },
+    salesPerHour: {
+      top: 119.4,
+      rest: 100.3,
+    },
+    relativeSph: {
+      top: 1.21,
+      rest: 1.0,
+    },
+    unitsPerTicket: {
+      top: 1.71,
+      rest: 1.65,
+    },
+    averageTicket: {
+      top: 65.7,
+      rest: 63.4,
+    },
+    areas: {
+      customerSalesExcellence: {
+        top: 38.2,
+        rest: 36.6,
+      },
+      brandStorytelling: {
+        top: 33.1,
+        rest: 31.2,
+      },
+      collaborationTeamContribution: {
+        top: 26.8,
+        rest: 25.9,
+      },
+      agilityExecution: {
+        top: 33.5,
+        rest: 33.7,
+      },
+      productKnowledge: {
+        top: 32.6,
+        rest: 32.4,
+      },
+    },
+    seniority: {
+      lt3m: {
+        top: 0.0,
+        rest: 9.7,
+      },
+      m3to12: {
+        top: 7.4,
+        rest: 7.8,
+      },
+      y1to2: {
+        top: 9.0,
+        rest: 8.7,
+      },
+      y2to5: {
+        top: 24.6,
+        rest: 26.2,
+      },
+      y5to10: {
+        top: 10.7,
+        rest: 12.9,
+      },
+      y10to20: {
+        top: 32.0,
+        rest: 23.1,
+      },
+      gt20: {
+        top: 14.8,
+        rest: 9.0,
+      },
+    },
+    skillPValue: 0.442,
+  },
+  segments: {
+    benchmark: 12.5,
+    resultWithoutMethod: 42.3,
+    skillWithoutResult: 7.2,
+    priorityDevelopment: 31.8,
+    toActivate: 6.3,
+  },
+  correlations: {
+    seniorityToKpi: 0.18,
+    seniorityToSkill: -0.01,
+    storeSkillToConversion: 0.08,
+    nStores: 125,
+    individualSkillToSales: 0.06,
+    nIndividuals: 455,
+  },
+} as const;

--- a/data/demo/retail.ts
+++ b/data/demo/retail.ts
@@ -11,8 +11,9 @@
 //     as a name. The labels these keys stand for live in `messages/`.
 //   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
 //   - a group carrying a score holds at least 25 people.
-//     Area managers become `area1`…`area5` in a stable order, and the mapping
-//     to the five real names is kept nowhere.
+//     Area managers become `area1`…`area5`, ordered by descending headcount
+//     rather than by name: the mapping is kept nowhere, and an alphabetical
+//     order would have let anyone holding the five names rebuild it.
 //   - the per-area segment mix ships as a share, never as a cell count.
 
 export const retail = {
@@ -36,32 +37,19 @@ export const retail = {
   },
   areas: {
     area1: {
-      n: 85,
-      stores: 25,
-      aboveThresholdPct: 13.1,
-      conversionRate: 11.22,
+      n: 140,
+      stores: 30,
+      aboveThresholdPct: 24.5,
+      conversionRate: 9.82,
       segments: {
-        benchmark: 6.0,
-        resultWithoutMethod: 35.7,
-        skillWithoutResult: 6.0,
-        priorityDevelopment: 45.2,
-        toActivate: 7.1,
-      },
-    },
-    area2: {
-      n: 90,
-      stores: 20,
-      aboveThresholdPct: 12.4,
-      conversionRate: 9.09,
-      segments: {
-        benchmark: 7.9,
-        resultWithoutMethod: 52.8,
-        skillWithoutResult: 4.5,
-        priorityDevelopment: 32.6,
+        benchmark: 15.1,
+        resultWithoutMethod: 45.3,
+        skillWithoutResult: 9.4,
+        priorityDevelopment: 28.1,
         toActivate: 2.2,
       },
     },
-    area3: {
+    area2: {
       n: 135,
       stores: 35,
       aboveThresholdPct: 23.4,
@@ -74,7 +62,7 @@ export const retail = {
         toActivate: 2.9,
       },
     },
-    area4: {
+    area3: {
       n: 105,
       stores: 25,
       aboveThresholdPct: 25.2,
@@ -87,17 +75,30 @@ export const retail = {
         toActivate: 6.8,
       },
     },
-    area5: {
-      n: 140,
-      stores: 30,
-      aboveThresholdPct: 24.5,
-      conversionRate: 9.82,
+    area4: {
+      n: 90,
+      stores: 20,
+      aboveThresholdPct: 12.4,
+      conversionRate: 9.09,
       segments: {
-        benchmark: 15.1,
-        resultWithoutMethod: 45.3,
-        skillWithoutResult: 9.4,
-        priorityDevelopment: 28.1,
+        benchmark: 7.9,
+        resultWithoutMethod: 52.8,
+        skillWithoutResult: 4.5,
+        priorityDevelopment: 32.6,
         toActivate: 2.2,
+      },
+    },
+    area5: {
+      n: 85,
+      stores: 25,
+      aboveThresholdPct: 13.1,
+      conversionRate: 11.22,
+      segments: {
+        benchmark: 6.0,
+        resultWithoutMethod: 35.7,
+        skillWithoutResult: 6.0,
+        priorityDevelopment: 45.2,
+        toActivate: 7.1,
       },
     },
   },

--- a/data/demo/sales-network.ts
+++ b/data/demo/sales-network.ts
@@ -1,0 +1,212 @@
+// Sales network readiness — aggregated assessment results.
+//
+// Aggregates only. The source dashboard runs on individual records —
+// one row per assessed person, with a first name and a surname on it —
+// and none of them are here: every figure below is a group statistic computed
+// once, outside this repository, from data that never entered it.
+//
+// The rules the numbers obey, asserted by `npm run check:demo-anonymity`:
+//   - no strings. Every leaf is a number, so nothing here can read as copy or
+//     as a name. The labels these keys stand for live in `messages/`.
+//   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
+//   - a group carrying a score holds at least 25 people.
+//     One job family holds fewer than that and is not broken out, so the
+//     family headcounts do not sum to the assessed total.
+//   - knowledge-area keys are renamed away from the sector the source names.
+
+export const salesNetwork = {
+  funnel: {
+    candidates: 190,
+    interviews: 180,
+    assessed: 185,
+    notAssessed: 5,
+    conversionPct: 96,
+  },
+  overview: {
+    skillMatchingMean: 54.6,
+    skillMatchingMedian: 55.0,
+    softMean: 2.9,
+    hardMean: 60.3,
+    aboveBothPct: 50.8,
+    softThreshold: 3,
+    hardThreshold: 40,
+  },
+  bands: {
+    belowThreshold: 6.6,
+    base: 43.2,
+    good: 40.4,
+    high: 9.8,
+  },
+  quadrants: {
+    softHighHardHigh: 50.8,
+    softHighHardLow: 2.7,
+    softLowHardHigh: 43.2,
+    softLowHardLow: 3.3,
+  },
+  families: {
+    salesManager: {
+      n: 85,
+      skillMatching: 55.8,
+      soft: 2.8,
+      hard: 64.8,
+    },
+    salesAccount: {
+      n: 90,
+      skillMatching: 54.0,
+      soft: 3.1,
+      hard: 56.9,
+    },
+  },
+  soft: {
+    strategicThinking: {
+      salesManager: 2.5,
+    },
+    teamManagement: {
+      salesManager: 3.0,
+    },
+    engageInspire: {
+      salesManager: 2.3,
+    },
+    decisionMaking: {
+      salesManager: 3.5,
+      salesAccount: 3.3,
+    },
+    influence: {
+      salesAccount: 3.0,
+    },
+    resilience: {
+      salesAccount: 3.1,
+    },
+    drive: {
+      salesAccount: 3.0,
+    },
+  },
+  hard: {
+    referenceMarket: {
+      salesManager: 62.1,
+    },
+    partnerManagement: {
+      salesManager: 68.7,
+    },
+    offeringPositioning: {
+      salesManager: 56.2,
+      salesAccount: 45.8,
+    },
+    networkProfitability: {
+      salesManager: 69.3,
+    },
+    technicalDomainKnowledge: {
+      salesManager: 67.9,
+      salesAccount: 65.3,
+    },
+    complexNegotiation: {
+      salesAccount: 60.5,
+    },
+    marketSegmentation: {
+      salesAccount: 50.3,
+    },
+    complexSellingTechniques: {
+      salesAccount: 62.6,
+    },
+  },
+  drivers: {
+    drive: {
+      workWithEnthusiasm: {
+        salesAccount: 3.6,
+      },
+      pursuePersonalDevelopment: {
+        salesAccount: 2.3,
+      },
+      showAmbition: {
+        salesAccount: 3.5,
+      },
+    },
+    strategicThinking: {
+      anticipateDevelopments: {
+        salesManager: 3.3,
+      },
+      alignStrategies: {
+        salesManager: 3.2,
+      },
+      defineTheVision: {
+        salesManager: 2.1,
+      },
+      validateStrategies: {
+        salesManager: 2.3,
+      },
+    },
+    teamManagement: {
+      coordinateAction: {
+        salesManager: 3.9,
+      },
+      delegate: {
+        salesManager: 2.9,
+      },
+      takeDecisions: {
+        salesManager: 3.2,
+      },
+      takeResponsibility: {
+        salesManager: 3.0,
+      },
+      crossFunctionalAwareness: {
+        salesManager: 2.8,
+      },
+    },
+    engageInspire: {
+      superviseBehaviour: {
+        salesManager: 2.5,
+      },
+      coaching: {
+        salesManager: 2.9,
+      },
+      valuePeople: {
+        salesManager: 2.5,
+      },
+      motivatePeople: {
+        salesManager: 2.9,
+      },
+      developPeople: {
+        salesManager: 2.6,
+      },
+      spotTalent: {
+        salesManager: 1.5,
+      },
+    },
+    decisionMaking: {
+      executePlans: {
+        salesManager: 3.8,
+        salesAccount: 3.6,
+      },
+      actWithConfidence: {
+        salesManager: 3.5,
+        salesAccount: 3.3,
+      },
+      actOnOwnInitiative: {
+        salesManager: 3.6,
+        salesAccount: 3.3,
+      },
+    },
+    influence: {
+      haveImpact: {
+        salesAccount: 3.5,
+      },
+      frameConversations: {
+        salesAccount: 3.7,
+      },
+      appealToEmotions: {
+        salesAccount: 2.4,
+      },
+    },
+    resilience: {
+      handlePressure: {
+        salesAccount: 3.9,
+      },
+      balanceWorkAndLife: {
+        salesAccount: 2.3,
+      },
+      stayPositive: {
+        salesAccount: 3.5,
+      },
+    },
+  },
+} as const;

--- a/messages/en.json
+++ b/messages/en.json
@@ -4586,7 +4586,7 @@
       "heading": "Three programmes, three questions",
       "retail": {
         "sector": "Retail",
-        "title": "Store manager capability",
+        "title": "Store network capability",
         "body": "A store network assessed on one frame end to end: how capability distributes across channel, location and store tier, and where the gap sits."
       },
       "salesNetwork": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -4587,17 +4587,17 @@
       "retail": {
         "sector": "Retail",
         "title": "Store manager capability",
-        "body": "A store network assessed on one frame end to end: how capability distributes across the estate, and which stores carry the gap."
+        "body": "A store network assessed on one frame end to end: how capability distributes across channel, location and store tier, and where the gap sits."
       },
       "salesNetwork": {
-        "sector": "Insurance",
+        "sector": "Telco",
         "title": "Sales network readiness",
-        "body": "An agent network measured before a commercial push: who is ready to sell the new range, and who goes through the training first."
+        "body": "A sales network measured on soft skills and technical knowledge together: who is ready to sell, and who goes through the training first."
       },
       "crossCountry": {
-        "sector": "Manufacturing",
+        "sector": "Pharma",
         "title": "Cross-country talent map",
-        "body": "One competency frame applied in six countries, so a group HR team can compare populations that were never comparable before."
+        "body": "One competency frame applied across every country in scope, so a group HR team can compare populations that were never comparable before."
       }
     },
     "status": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4586,7 +4586,7 @@
       "heading": "Tre programmi, tre domande",
       "retail": {
         "sector": "Retail",
-        "title": "Capability degli store manager",
+        "title": "Capability della rete retail",
         "body": "Una rete di punti vendita valutata con lo stesso schema dall’inizio alla fine: come si distribuisce la capability fra canale, location e tier, e dove sta il divario."
       },
       "salesNetwork": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4587,17 +4587,17 @@
       "retail": {
         "sector": "Retail",
         "title": "Capability degli store manager",
-        "body": "Una rete di punti vendita valutata con lo stesso schema dall’inizio alla fine: come si distribuisce la capability sul territorio e quali negozi si portano dietro il divario."
+        "body": "Una rete di punti vendita valutata con lo stesso schema dall’inizio alla fine: come si distribuisce la capability fra canale, location e tier, e dove sta il divario."
       },
       "salesNetwork": {
-        "sector": "Assicurazioni",
+        "sector": "Telco",
         "title": "Prontezza della rete vendita",
-        "body": "Una rete di agenti misurata prima di una spinta commerciale: chi è pronto a vendere la nuova gamma e chi passa prima dalla formazione."
+        "body": "Una rete vendita misurata insieme su soft skill e conoscenze tecniche: chi è pronto a vendere e chi passa prima dalla formazione."
       },
       "crossCountry": {
-        "sector": "Manifatturiero",
+        "sector": "Pharma",
         "title": "Mappa dei talenti cross-country",
-        "body": "Un solo schema di competenze applicato in sei paesi, perché l’HR di gruppo possa confrontare popolazioni che prima non erano confrontabili."
+        "body": "Un solo schema di competenze applicato a tutti i paesi coinvolti, perché l’HR di gruppo possa confrontare popolazioni che prima non erano confrontabili."
       }
     },
     "status": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check:build": "node scripts/build-clean.mjs",
     "check:assets": "node scripts/check-assets.mjs",
     "check:demo-event": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-event.mjs",
+    "check:demo-anonymity": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-anonymity.mjs",
     "test:smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {

--- a/scripts/check-demo-anonymity.mjs
+++ b/scripts/check-demo-anonymity.mjs
@@ -1,0 +1,181 @@
+// check-demo-anonymity — the demo dashboards carry no personal data.
+//
+// The three files in data/demo/ were derived from real assessment programmes:
+// hundreds of named participants, an agent network with a surname column, and a
+// retail estate with store codes and per-store revenue. None of that is in the
+// repository, and this is what makes that a fact rather than a claim.
+//
+// It reads the files two ways, because the two failures look different. As
+// text, because a name can arrive in a comment or a key and never be a value.
+// As a module, because "we removed the individual records" is a statement about
+// the shape of the data, not about any one string in it.
+//
+// Every rule below carries its own dirty input at the bottom of the file and is
+// asserted to fail on it. A rule that has only ever been run against clean data
+// is a rule nobody has tested.
+//
+// Run: npm run check:demo-anonymity
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIR = join(ROOT, 'data/demo');
+
+/** A group smaller than this is not an anonymous population, so its scores do not ship. */
+const MIN_GROUP = 25;
+
+/** Headcounts round to this, so no count in these files is a fingerprint. */
+const ROUND_TO = 5;
+
+/**
+ * The keys that hold a headcount. Explicit, because there is no way to tell a
+ * count from a measurement by looking at the number: `threshold: 40` and
+ * `visitsPerDay: 306` are neither counts nor rounded, and a heuristic that
+ * guessed would have to be loosened until it stopped saying anything.
+ */
+const COUNT_KEYS = new Set([
+  'n', 'stores', 'nStores', 'nIndividuals', 'invited', 'evaluated',
+  'candidates', 'interviews', 'assessed', 'notAssessed',
+  'salesAdvisors', 'storeManagers', 'outlets', 'topPerformers',
+]);
+
+// ---------------------------------------------------------------- text rules
+
+const PATTERNS = [
+  // A first name and a surname. Every source dashboard indexes people this way,
+  // and the retail one indexes an aggregate by them too (`seg_dm`).
+  ['a name', /\b[A-Z][a-zà-ù]+ [A-Z][a-zà-ù]+\b/u, { comments: true }],
+  // The customers themselves. De-branding is the other half of the removal:
+  // the numbers stay honest, the source of them does not ship.
+  ['a customer name', /Fidia|Wind ?Tre|Motivi|Glow ?Up|\bOVS\b/i, { comments: true }],
+  // Store codes are bare five-digit integers in the source. Nothing here needs
+  // one — the largest legitimate figure is a four-digit total in thousands —
+  // so the shape is refused outright rather than matched against a range.
+  ['a store code', /\b\d{5}\b/, { comments: true }],
+  // Copy lives in messages/. A string literal here is either a label that
+  // should have been a key, or a value that was never anonymised at all.
+  // Comments are dropped for this one alone: they are where the files explain
+  // what was removed, and they quote key names in backticks to do it.
+  ['a string literal', /(['"`])(?:(?!\1)[^\\])*\p{L}(?:(?!\1)[^\\])*\1/u, { comments: false }],
+];
+
+const stripComments = (text) => text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+/** @returns {string[]} one message per rule the text breaks. */
+function scanText(text) {
+  const code = stripComments(text);
+  return PATTERNS.flatMap(([what, re, where]) => {
+    const hit = (where.comments ? text : code).match(re);
+    return hit ? [`${what}: ${JSON.stringify(hit[0])}`] : [];
+  });
+}
+
+// -------------------------------------------------------------- shape rules
+
+/**
+ * Walks a parsed module.
+ *
+ * The load-bearing rule is the first one: every leaf is a number. It is what
+ * makes a row of people impossible to express here at all — a person is a name,
+ * and a name is a string — and it is why the labels these keys stand for have
+ * to live in the catalogue.
+ */
+function scanValue(node, path = '', out = []) {
+  if (node === null || typeof node === 'number') return out;
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => scanValue(v, `${path}[${i}]`, out));
+    return out;
+  }
+  if (typeof node !== 'object') {
+    out.push(`${path} is a ${typeof node}, and every leaf here must be a number`);
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const at = path ? `${path}.${key}` : key;
+    if (!/^[a-z][A-Za-z0-9]*$/.test(key)) out.push(`${at} is not an identifier key`);
+    if (COUNT_KEYS.has(key)) {
+      if (typeof value !== 'number' || value % ROUND_TO !== 0) {
+        out.push(`${at} is ${value}, and a headcount rounds to ${ROUND_TO}`);
+      }
+      if (key === 'n' && typeof value === 'number' && value < MIN_GROUP) {
+        out.push(`${at} is ${value}, under the ${MIN_GROUP}-person floor for a group that carries scores`);
+      }
+    }
+    scanValue(value, at, out);
+  }
+  return out;
+}
+
+/** How many numbers a file holds. A dump of individual records is thousands. */
+const LEAF_CAP = 600;
+function countLeaves(node) {
+  if (typeof node === 'number' || node === null) return 1;
+  if (typeof node !== 'object') return 1;
+  return Object.values(node).reduce((sum, v) => sum + countLeaves(v), 0);
+}
+
+// ------------------------------------------------------------------ the files
+
+const files = readdirSync(DIR).filter((f) => f.endsWith('.ts')).sort();
+assert.deepEqual(files, ['cross-country.ts', 'retail.ts', 'sales-network.ts'],
+  'data/demo must hold exactly the three dashboards');
+
+for (const file of files) {
+  const text = readFileSync(join(DIR, file), 'utf8');
+  assert.deepEqual(scanText(text), [], `data/demo/${file}`);
+
+  const mod = await import(pathToFileURL(join(DIR, file)).href);
+  const exported = Object.values(mod);
+  assert.equal(exported.length, 1, `data/demo/${file} must export exactly one dataset`);
+
+  const [data] = exported;
+  assert.deepEqual(scanValue(data), [], `data/demo/${file}`);
+
+  const leaves = countLeaves(data);
+  assert.ok(leaves < LEAF_CAP,
+    `data/demo/${file} holds ${leaves} numbers, over the ${LEAF_CAP} that says a record array crept back in`);
+
+  // Not vacuous: the file must actually declare headcounts for the rules above
+  // to have had anything to check.
+  assert.ok(/\bn: \d+/.test(text), `data/demo/${file} declares no group size`);
+}
+
+// ------------------------------------------------------- the rules, run red
+//
+// Each of these is a line that has really been in one of the sources.
+
+const DIRTY = [
+  ['  dm: Alessandro Bosica,', 'a name'],
+  ['// the Motivi store network', 'a customer name'],
+  ['// Fidia Farmaceutici, cross-country', 'a customer name'],
+  ['  cod: 36895,', 'a store code'],
+  ['  name: "Parma · C.C. Eurotorri",', 'a string literal'],
+];
+for (const [line, expected] of DIRTY) {
+  const found = scanText(line);
+  assert.ok(found.some((f) => f.startsWith(expected)),
+    `scanText missed ${expected} in ${JSON.stringify(line)} — it found ${JSON.stringify(found)}`);
+}
+
+const DIRTY_SHAPES = [
+  [{ people: [{ n: 1, name: 'Sara' }] }, /is a string/],
+  [{ people: [{ n: 1, name: 'Sara' }] }, /under the 25-person floor/],
+  [{ population: { stores: 129 } }, /a headcount rounds to 5/],
+  [{ 'Alessandro Bosica': { a: 5 } }, /is not an identifier key/],
+  [{ segment: { n: 20, skill: 3 } }, /under the 25-person floor/],
+];
+for (const [shape, expected] of DIRTY_SHAPES) {
+  const found = scanValue(shape);
+  assert.ok(found.some((f) => expected.test(f)),
+    `scanValue missed ${expected} in ${JSON.stringify(shape)} — it found ${JSON.stringify(found)}`);
+}
+
+// And clean input stays clean, so the rules above are not simply always red.
+assert.deepEqual(scanText('  aboveThresholdPct: 20.5,'), []);
+assert.deepEqual(scanValue({ area1: { n: 85, skill: 32.1 } }), []);
+assert.ok(countLeaves(Array.from({ length: LEAF_CAP }, () => ({ skill: 1, pk: 2 }))) > LEAF_CAP);
+
+console.log(`[OK] demo-anonymity — ${files.length} datasets, aggregates only`);


### PR DESCRIPTION
Due Issue, entrambe sui dati che le tre dashboard demo mostreranno.

## #168 — i dataset

I tre dashboard sorgente contengono dati personali: nomi e cognomi dei
partecipanti, nomi degli area manager, nomi e codici dei punti vendita col
fatturato di ciascuno. In due sorgenti su tre **non esistono aggregati
precalcolati**: esistono solo i record individuali, e ogni grafico è derivato
da quelli client-side.

Quindi il lavoro non è stato togliere i nomi dalle righe: è stato calcolare gli
aggregati e spedire solo quelli. Nessun array di persone entra nel repo, e gli
HTML sorgente non ci entrano in nessuna forma.

Quel che resta sono 20 KB per tutte e tre le dashboard — il solo blob del
retail ne pesava 401, di cui 326 di anagrafica persone e 71 di negozi.

Due trasformazioni oltre al taglio dei record, entrambe per lo stesso motivo:

- **Gli otto paesi del cross-country diventano tre gruppi.** La coda aveva
  paesi da 5, 8 e 10 persone: un aggregato su cinque persone in un'azienda
  identificabile per settore non è anonimo — chi conosce l'organizzazione
  risale alla persona — e una media su n=5 è comunque rumore, non un dato.
- **`seg_dm` perde i nomi dei cinque area manager**, e la mappatura non si
  conserva da nessuna parte.

`check:demo-anonymity` è il gate che lo dimostra: senza, "abbiamo tolto i nomi"
è un'affermazione, non un fatto.

## #173 — le schede dicevano un settore che non era il loro

Difetto introdotto dalla PR precedente e già arrivato in produzione. Due schede
su tre nominavano un settore inventato: la rete vendita **telco** era
etichettata Assicurazioni, il programma **pharma** Manifatturiero.

De-brandizzare significa togliere il nome del cliente, non sostituirlo con un
altro settore. Una scheda che dice a un prospect assicurativo che abbiamo
valutato una rete assicurativa, quando era un operatore telefonico, è
un'affermazione che crolla alla prima domanda di follow-up e si porta dietro la
credibilità di chi l'ha mandata. I due `body` erano scritti per reggere la
finzione — «rete di agenti», «la nuova gamma» — quindi cadono con essa.

Altri due nella stessa scheda: il cross-country contava i paesi, e li contava
sbagliati (otto nei dati, sei sulla scheda). Un conteggio preciso è esattamente
il metadato di ri-riconoscimento per cui #168 spedisce tre gruppi, quindi il
numero è stato tolto, non corretto. E il retail prometteva «quali negozi si
portano dietro il divario», che è la vista per singolo punto vendita che
abbiamo tagliato: i dati reggono canale, location e tier.

## Verifica

`./harness/init.sh` completo verde — 15 gate più `check:build`. I numeri
prodotti sono stati ricalcolati a campione contro i sorgenti, e il gate di
anonimato è stato rotto apposta e visto rosso prima di essere ripristinato.

Closes #168
Closes #173