### PR TITLE
Dashboard demo rete retail, e la scheda cross-country smette di dichiarare il settore

### DIFF
--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -5,20 +5,23 @@
 // will be — the chart wrapper is loaded with ssr: false, which is only legal
 // inside the client graph.
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Globe, Store, Users } from 'lucide-react';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/landing/Navbar';
 import { Reveal } from '@/components/ui/reveal';
 import DemoView from '@/components/demo/DemoView';
 import Chart from '@/components/demo/charts/Chart';
+import { href } from '@/i18n/routes';
 
-// Structure the catalogue cannot hold: which icon belongs to which card. The
-// copy is keyed by the same id under `demo.dashboards`.
+// Structure the catalogue cannot hold: which icon belongs to which card, and
+// which route it opens. The copy is keyed by the same id under
+// `demo.dashboards`; a `route` of undefined is a dashboard not built yet, and
+// its card stays a badge rather than becoming a link to nowhere.
 const DASHBOARDS = [
-  { id: 'retail', Icon: Store },
-  { id: 'salesNetwork', Icon: Users },
-  { id: 'crossCountry', Icon: Globe },
+  { id: 'retail', Icon: Store, route: 'demo/retail' },
+  { id: 'salesNetwork', Icon: Users, route: undefined },
+  { id: 'crossCountry', Icon: Globe, route: undefined },
 ];
 
 // The preview chart's numbers. Illustrative, and said to be illustrative in
@@ -27,6 +30,7 @@ const DASHBOARDS = [
 const PREVIEW_SCORES = [82, 74, 69, 61, 54];
 
 export default function DemoHub() {
+  const lang = useLocale();
   const t = useTranslations('demo');
 
   return (
@@ -90,7 +94,7 @@ export default function DemoHub() {
             </Reveal>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
-              {DASHBOARDS.map(({ id, Icon }, i) => (
+              {DASHBOARDS.map(({ id, Icon, route }, i) => (
                 <Reveal
                   key={id}
                   as="article"
@@ -109,13 +113,23 @@ export default function DemoHub() {
                   <p className="text-[14px] text-white/[0.55] leading-[1.7] mb-6">
                     {t(`dashboards.${id}.body`)}
                   </p>
-                  {/* Not a link: these three pages do not exist yet,
-                      and a card that navigates nowhere reads as a broken site
-                      rather than as a roadmap. */}
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/50">
-                    <span className="h-1.5 w-1.5 rounded-full bg-[#FFAF64]" />
-                    {t('status.comingSoon')}
-                  </span>
+                  {/* A card without a route is a dashboard not built yet, and
+                      it stays a badge: a card that navigates nowhere reads as a
+                      broken site rather than as a roadmap. */}
+                  {route ? (
+                    <a
+                      href={href(route, lang)}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
+                    >
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#5DDBA4]" />
+                      {t('status.open')}
+                    </a>
+                  ) : (
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/50">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#FFAF64]" />
+                      {t('status.comingSoon')}
+                    </span>
+                  )}
                 </Reveal>
               ))}
             </div>

--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -104,9 +104,19 @@ export default function DemoHub() {
                   className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-8"
                 >
                   <Icon className="h-6 w-6 text-white/30 mb-6" />
-                  <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 block mb-3">
-                    {t(`dashboards.${id}.sector`)}
-                  </span>
+                  {/* A card names its sector only if the catalogue gives it one.
+                      crossCountry has none: its real sector is Pharma, and
+                      customers/fidia-farmaceutici is the only pharmaceutical
+                      story on the site — so the label walks a reader from an
+                      anonymised dashboard to the customer whose aggregates it
+                      shows (issue 176). Reading the key rather than a flag means the
+                      fourth card gets this for free: write a sector, it shows;
+                      leave it out, it doesn't. */}
+                  {t.has(`dashboards.${id}.sector`) ? (
+                    <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 block mb-3">
+                      {t(`dashboards.${id}.sector`)}
+                    </span>
+                  ) : null}
                   <h3 className="text-[19px] md:text-[21px] font-semibold text-white/90 mb-3 leading-tight">
                     {t(`dashboards.${id}.title`)}
                   </h3>

--- a/app/[locale]/demo/retail-network/body.tsx
+++ b/app/[locale]/demo/retail-network/body.tsx
@@ -1,0 +1,730 @@
+'use client';
+
+// The retail demo dashboard.
+//
+// A client component for two reasons: the cut selector is state, and the chart
+// wrapper is loaded with `ssr: false`, which is only legal inside the client
+// graph. Every number comes from data/demo/retail.ts — aggregates computed once
+// outside this repository — and every word comes from messages/{en,it}.json.
+// Nothing on this page is a store, a person or a record.
+//
+// What it deliberately does NOT say: that competency explains revenue. On this
+// network it does not (r = 0.08 across the stores, 0.06 across the people), and
+// the `map` section puts both coefficients on screen rather than leaving them
+// out. A prospect who can read a scatter would find them in ten seconds anyway.
+
+import { useMemo, useState, type ReactNode } from 'react';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
+import Footer from '@/components/Footer';
+import Navbar from '@/components/landing/Navbar';
+import { Reveal } from '@/components/ui/reveal';
+import DemoView from '@/components/demo/DemoView';
+import Chart from '@/components/demo/charts/Chart';
+import { retail } from '@/data/demo/retail';
+import { href } from '@/i18n/routes';
+
+/** One row of a cut, flattened out of the three shapes the data holds it in. */
+type Group = {
+  id: string;
+  n: number;
+  stores: number;
+  aboveThresholdPct: number;
+  conversionRate: number;
+  /** Context cuts only: the areas are published as headcount and result. */
+  skill?: number;
+  areas?: Record<string, number>;
+  unitsPerTicket?: number;
+  averageTicket?: number;
+  salesPerHour?: number;
+  visitsPerDay?: number;
+  turnoverPct?: number;
+};
+
+const asGroups = (source: Record<string, any>): Group[] =>
+  Object.entries(source).map(([id, g]) => ({ id, ...g }));
+
+// The four cuts, each an ordered list of groups. `area` is the odd one: it
+// carries no competency breakdown, so the radar below is skipped for it rather
+// than drawn from nothing.
+const CUTS: Record<string, Group[]> = {
+  channel: asGroups(retail.context.channel),
+  location: asGroups(retail.context.location),
+  tier: asGroups(retail.context.tier),
+  area: asGroups(retail.areas),
+};
+const CUT_IDS = ['channel', 'location', 'tier', 'area'];
+
+// Structure the catalogue cannot hold: the order the keys are drawn in. The
+// labels for all of them live under `demo.retail` in messages/.
+const SKILLS = [
+  'customerSalesExcellence',
+  'brandStorytelling',
+  'collaborationTeamContribution',
+  'agilityExecution',
+  'productKnowledge',
+];
+const SEGMENTS = [
+  'benchmark',
+  'resultWithoutMethod',
+  'skillWithoutResult',
+  'priorityDevelopment',
+  'toActivate',
+];
+const SENIORITY = ['lt3m', 'm3to12', 'y1to2', 'y2to5', 'y5to10', 'y10to20', 'gt20'];
+
+// Which KPIs a group card shows, and where each one is read from. A group that
+// does not carry one simply does not render the row — the area cut has four of
+// these, the context cuts have all ten.
+// `digits` is fixed rather than maximum: a conversion rate of 11.21 rounded to
+// one place is a different number from the 11.2 next to it, and a relative
+// index printed as `1` instead of `1.00` reads as a rounding artefact.
+const KPIS: Array<{
+  id: string;
+  read: (g: Group) => number | undefined;
+  digits: number;
+  unit?: 'pct' | 'eur';
+}> = [
+  { id: 'people', read: (g) => g.n, digits: 0 },
+  { id: 'stores', read: (g) => g.stores, digits: 0 },
+  { id: 'skill', read: (g) => g.skill, digits: 1 },
+  { id: 'aboveThreshold', read: (g) => g.aboveThresholdPct, digits: 1, unit: 'pct' },
+  { id: 'conversionRate', read: (g) => g.conversionRate, digits: 2, unit: 'pct' },
+  { id: 'unitsPerTicket', read: (g) => g.unitsPerTicket, digits: 2 },
+  { id: 'averageTicket', read: (g) => g.averageTicket, digits: 2, unit: 'eur' },
+  { id: 'salesPerHour', read: (g) => g.salesPerHour, digits: 1 },
+  { id: 'visitsPerDay', read: (g) => g.visitsPerDay, digits: 0 },
+  { id: 'turnover', read: (g) => g.turnoverPct, digits: 1, unit: 'pct' },
+];
+
+// Every hex here is already in the ALLOWED list of scripts/check-colors.mjs:
+// the dashboards reuse the brand palette rather than opening a second one.
+const SERIES = ['#4B4DF7', '#FFAF64', '#5DDBA4', '#8A8CFF', '#FF5656'];
+const FILLS = [
+  'rgba(75,77,247,0.16)',
+  'rgba(255,175,100,0.16)',
+  'rgba(93,219,164,0.16)',
+];
+
+const GRID = 'rgba(255,255,255,0.06)';
+const TICK = 'rgba(255,255,255,0.45)';
+const AXIS = { grid: { color: GRID }, ticks: { color: TICK } };
+const LEGEND = {
+  labels: { color: 'rgba(255,255,255,0.6)', usePointStyle: true, boxWidth: 8, padding: 16 },
+};
+const axisTitle = (text: string) => ({ display: true, text, color: TICK });
+
+/** The recurring card. Local, because nothing outside this page has a second use for it. */
+function Panel({
+  title,
+  body,
+  note,
+  children,
+}: {
+  title: string;
+  body?: string;
+  note?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Reveal
+      as="section"
+      y={20}
+      duration={0.6}
+      className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-10"
+    >
+      <h2 className="text-[24px] md:text-[32px] font-semibold text-white/90 mb-3">{title}</h2>
+      {body ? (
+        <p className="text-[15px] text-white/[0.55] leading-[1.7] max-w-3xl mb-8">{body}</p>
+      ) : null}
+      {children}
+      {note ? (
+        <p className="text-[13px] text-white/40 leading-[1.7] max-w-3xl mt-6">{note}</p>
+      ) : null}
+    </Reveal>
+  );
+}
+
+export default function RetailDemo() {
+  const lang = useLocale();
+  const t = useTranslations('demo.retail');
+  const format = useFormatter();
+  const [cut, setCut] = useState('channel');
+
+  // Every number on the page goes through here, including the ones handed to a
+  // message as an ICU argument: next-intl interpolates a numeric argument
+  // as-is, so `{above}` would print "20.5" on the Italian page next to the
+  // "20,5%" of the stat card right above it. Formatting first and passing the
+  // string is what keeps the two agreeing.
+  const n = (value: number, digits = 1) =>
+    format.number(value, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+  const eur = (value: number) =>
+    format.number(value, { style: 'currency', currency: 'EUR' });
+
+  const groups = CUTS[cut];
+  const groupName = (id: string) => t(`cuts.groups.${cut}.${id}`);
+  const hasSkillProfile = groups.every((g) => g.areas !== undefined);
+
+  // ChartCanvas compares its config by identity, so a config rebuilt on every
+  // render rebuilds the chart on every render. These five do not depend on the
+  // selected cut; the three below do.
+  const fixed = useMemo(() => {
+    const { binWidth, distribution } = retail.skillDistribution;
+    const { topVsRest, correlations } = retail;
+
+    return {
+      distribution: {
+        data: {
+          labels: distribution.map((_, i) => `${i * binWidth}–${(i + 1) * binWidth}`),
+          datasets: [
+            {
+              label: t('distribution.series'),
+              data: [...distribution],
+              backgroundColor: SERIES[0],
+              hoverBackgroundColor: '#7B7DF9',
+              borderRadius: 4,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, grid: { display: false }, title: axisTitle(t('distribution.axisScore')) },
+            y: { ...AXIS, beginAtZero: true, title: axisTitle(t('distribution.axisShare')) },
+          },
+        },
+      },
+
+      map: {
+        data: {
+          datasets: CUT_IDS.map((id, i) => ({
+            label: t(`cuts.options.${id}`),
+            data: CUTS[id].map((g) => ({ x: g.aboveThresholdPct, y: g.conversionRate })),
+            backgroundColor: SERIES[i],
+            pointRadius: 7,
+            pointHoverRadius: 9,
+          })),
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          scales: {
+            x: { ...AXIS, title: axisTitle(t('map.axisX')) },
+            y: { ...AXIS, title: axisTitle(t('map.axisY')) },
+          },
+        },
+      },
+
+      segments: {
+        data: {
+          labels: CUTS.area.map((g) => t(`cuts.groups.area.${g.id}`)),
+          datasets: SEGMENTS.map((s, i) => ({
+            label: t(`segments.items.${s}.name`),
+            data: CUTS.area.map((g) => (g as any).segments[s]),
+            backgroundColor: SERIES[i],
+            borderRadius: 2,
+          })),
+        },
+        options: {
+          locale: lang,
+          indexAxis: 'y' as const,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          scales: {
+            x: { ...AXIS, stacked: true, min: 0, max: 100, title: axisTitle(t('segments.chart.axis')) },
+            y: { ...AXIS, stacked: true, grid: { display: false } },
+          },
+        },
+      },
+
+      top: {
+        data: {
+          labels: SKILLS.map((s) => t(`skills.${s}`)),
+          datasets: (['top', 'rest'] as const).map((band, i) => ({
+            label: t(`top.series.${band}`),
+            data: SKILLS.map((s) => topVsRest.areas[s][band]),
+            backgroundColor: SERIES[i],
+            borderRadius: 4,
+          })),
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          // Zero-based on purpose. The whole point of this chart is that the
+          // competency gap is small; a truncated axis would draw it as large.
+          scales: {
+            x: { ...AXIS, grid: { display: false } },
+            y: { ...AXIS, beginAtZero: true, max: 50 },
+          },
+        },
+      },
+
+      // Two charts rather than one with two y axes. On a shared plot the two
+      // series land on top of each other — 28-33 on a 0-40 axis and 0.87-1.06
+      // on a 0-1.2 axis are the same three-quarters of the height — and the
+      // reader cannot tell which line is which, let alone that one of them is
+      // flat. Side by side, on the same seven bands, the shapes are the
+      // comparison.
+      seniority: (['skill', 'relativeSph'] as const).map((series, i) => ({
+        series,
+        data: {
+          labels: SENIORITY.map((b) => t(`seniority.buckets.${b}`)),
+          datasets: [
+            {
+              label: t(`seniority.series.${series}`),
+              data: SENIORITY.map((b) => retail.seniority[b][series]),
+              borderColor: SERIES[i],
+              backgroundColor: SERIES[i],
+              tension: 0.3,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, grid: { display: false } },
+            // Zero-based, both of them. A truncated axis would draw the flat
+            // series as a slope, which is the claim this section refuses.
+            y: {
+              ...AXIS,
+              min: 0,
+              max: series === 'skill' ? 40 : 1.2,
+              title: axisTitle(t(series === 'skill' ? 'seniority.axisSkill' : 'seniority.axisSph')),
+            },
+          },
+        },
+      })),
+
+      correlations,
+      topVsRest,
+    };
+  }, [t, lang]);
+
+  const perCut = useMemo(
+    () => ({
+      skills: {
+        data: {
+          labels: SKILLS.map((s) => t(`skills.${s}`)),
+          datasets: groups.map((g, i) => ({
+            label: groupName(g.id),
+            data: SKILLS.map((s) => g.areas?.[s] ?? null),
+            borderColor: SERIES[i],
+            backgroundColor: FILLS[i % FILLS.length],
+            pointBackgroundColor: SERIES[i],
+            borderWidth: 2,
+          })),
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          scales: {
+            r: {
+              min: 0,
+              max: 50,
+              grid: { color: GRID },
+              angleLines: { color: GRID },
+              ticks: { color: TICK, backdropColor: 'transparent', stepSize: 10 },
+              pointLabels: { color: 'rgba(255,255,255,0.7)', font: { size: 11 } },
+            },
+          },
+        },
+      },
+
+      results: {
+        data: {
+          labels: groups.map((g) => groupName(g.id)),
+          datasets: [
+            {
+              label: t('cuts.labels.aboveThreshold'),
+              data: groups.map((g) => g.aboveThresholdPct),
+              backgroundColor: SERIES[0],
+              borderRadius: 4,
+              maxBarThickness: 56,
+            },
+            {
+              label: t('cuts.labels.conversionRate'),
+              data: groups.map((g) => g.conversionRate),
+              backgroundColor: SERIES[1],
+              borderRadius: 4,
+              maxBarThickness: 56,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          scales: {
+            x: { ...AXIS, grid: { display: false } },
+            y: { ...AXIS, beginAtZero: true, title: axisTitle(t('cuts.results.axis')) },
+          },
+        },
+      },
+    }),
+    // `cut` is what `groups` and `groupName` are derived from, so it is the
+    // dependency; listing the derivations as well would say the same thing twice.
+    [t, lang, cut],
+  );
+
+  const headline: Array<{ id: string; value: string; args: Record<string, string> }> = [
+    {
+      id: 'advisors',
+      value: n(retail.population.salesAdvisors, 0),
+      args: { managers: n(retail.population.storeManagers, 0) },
+    },
+    {
+      id: 'stores',
+      value: n(retail.population.stores, 0),
+      args: { outlets: n(retail.population.outlets, 0) },
+    },
+    {
+      id: 'aboveThreshold',
+      value: `${n(retail.overview.aboveThresholdPct)}%`,
+      args: { threshold: n(retail.overview.threshold, 0) },
+    },
+    { id: 'conversion', value: `${n(retail.overview.conversionRate, 2)}%`, args: {} },
+  ];
+
+  return (
+    <>
+      <DemoView slug="retail" />
+      <Navbar />
+      <main>
+        <section className="relative pt-[80px]">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-24">
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              className="text-[13px] font-semibold tracking-[0.18em] uppercase text-white/40 mb-6"
+            >
+              {t('hero.eyebrow')}
+            </Reveal>
+            <Reveal
+              as="h1"
+              y={40}
+              duration={0.8}
+              delay={0.1}
+              className="text-[40px] md:text-[56px] font-semibold tracking-[-0.02em] text-white/95 mb-8 max-w-4xl"
+              style={{ lineHeight: 1.15 }}
+            >
+              {t.rich('hero.heading', {
+                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+              })}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.8}
+              delay={0.2}
+              className="text-[18px] text-white/[0.65] leading-[1.75] max-w-3xl mb-8"
+              style={{ fontWeight: 300 }}
+            >
+              {t('hero.body')}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              delay={0.3}
+              className="text-[14px] text-white/40 leading-[1.7] max-w-2xl"
+            >
+              {t('hero.note')}
+            </Reveal>
+          </div>
+        </section>
+
+        <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 pb-24 lg:pb-32 flex flex-col gap-4 md:gap-6">
+          <Panel title={t('population.heading')}>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+              {headline.map((s) => (
+                <div key={s.id}>
+                  <span
+                    className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {s.value}
+                  </span>
+                  <span className="block text-[14px] font-semibold text-white/80 mb-2">
+                    {t(`population.${s.id}.label`)}
+                  </span>
+                  <span className="block text-[13px] text-white/40 leading-[1.7]">
+                    {t(`population.${s.id}.note`, s.args)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel
+            title={t('distribution.heading')}
+            body={t('distribution.body')}
+            note={t('distribution.caption', {
+              above: n(retail.overview.aboveThresholdPct),
+              threshold: n(retail.overview.threshold, 0),
+            })}
+          >
+            <Chart
+              className="h-[280px] md:h-[360px]"
+              type="bar"
+              ariaLabel={t('distribution.ariaLabel')}
+              data={fixed.distribution.data}
+              options={fixed.distribution.options}
+            />
+          </Panel>
+
+          <Panel title={t('cuts.heading')} body={t('cuts.body')}>
+            <div className="flex flex-wrap items-center gap-2 mb-8">
+              <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 mr-2">
+                {t('cuts.label')}
+              </span>
+              {CUT_IDS.map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  aria-pressed={cut === id}
+                  onClick={() => setCut(id)}
+                  className={`px-4 py-2 md:px-5 md:py-2.5 rounded-full text-[13px] font-medium transition-all duration-300 ${
+                    cut === id
+                      ? 'bg-white/[0.1] text-white border border-white/[0.15]'
+                      : 'text-white/40 border border-transparent hover:text-white/70'
+                  }`}
+                >
+                  {t(`cuts.options.${id}`)}
+                </button>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
+              <div>
+                <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+                  {t('cuts.skills.heading')}
+                </h3>
+                {hasSkillProfile ? (
+                  <Chart
+                    className="h-[300px] md:h-[380px]"
+                    type="radar"
+                    ariaLabel={t('cuts.skills.ariaLabel')}
+                    data={perCut.skills.data}
+                    options={perCut.skills.options}
+                  />
+                ) : (
+                  <p className="text-[14px] text-white/45 leading-[1.7] h-[300px] md:h-[380px] flex items-center">
+                    {t('cuts.skills.unavailable')}
+                  </p>
+                )}
+                <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+                  {t('cuts.skills.caption')}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+                  {t('cuts.results.heading')}
+                </h3>
+                <Chart
+                  className="h-[300px] md:h-[380px]"
+                  type="bar"
+                  ariaLabel={t('cuts.results.ariaLabel')}
+                  data={perCut.results.data}
+                  options={perCut.results.options}
+                />
+                <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+                  {t('cuts.results.caption')}
+                </p>
+              </div>
+            </div>
+
+            <h3 className="text-[17px] font-semibold text-white/85 mt-10 mb-4">
+              {t('cuts.kpis.heading')}
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {groups.map((g) => (
+                <div key={g.id} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+                  <span className="block text-[14px] font-semibold text-white/85 mb-4">
+                    {groupName(g.id)}
+                  </span>
+                  <dl className="flex flex-col gap-2">
+                    {KPIS.filter((k) => k.read(g) !== undefined).map((k) => {
+                      const value = k.read(g) as number;
+                      return (
+                        <div key={k.id} className="flex items-baseline justify-between gap-4">
+                          <dt className="text-[13px] text-white/45">{t(`cuts.labels.${k.id}`)}</dt>
+                          <dd className="text-[14px] font-semibold text-white/85 tabular-nums">
+                            {k.unit === 'eur'
+                              ? eur(value)
+                              : k.unit === 'pct'
+                                ? `${n(value, k.digits)}%`
+                                : n(value, k.digits)}
+                          </dd>
+                        </div>
+                      );
+                    })}
+                  </dl>
+                </div>
+              ))}
+            </div>
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-6">
+              {t('cuts.kpis.caption')} {cut === 'area' ? t('cuts.areaNote') : null}
+            </p>
+          </Panel>
+
+          <Panel title={t('map.heading')} body={t('map.body')} note={t('map.caption')}>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-10">
+              <div className="lg:col-span-2">
+                <Chart
+                  className="h-[300px] md:h-[400px]"
+                  type="scatter"
+                  ariaLabel={t('map.ariaLabel')}
+                  data={fixed.map.data}
+                  options={fixed.map.options}
+                />
+              </div>
+              <div className="flex flex-col justify-center gap-8">
+                {[
+                  { id: 'stores', r: fixed.correlations.storeSkillToConversion, count: fixed.correlations.nStores },
+                  { id: 'people', r: fixed.correlations.individualSkillToSales, count: fixed.correlations.nIndividuals },
+                ].map((c) => (
+                  <div key={c.id}>
+                    <span
+                      className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                      style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                    >
+                      {n(c.r, 2)}
+                    </span>
+                    <span className="block text-[14px] font-semibold text-white/80 mb-2">
+                      {t(`map.${c.id}.label`)}
+                    </span>
+                    <span className="block text-[13px] text-white/40 leading-[1.7]">
+                      {t(`map.${c.id}.note`, { n: n(c.count, 0) })}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Panel>
+
+          <Panel title={t('segments.heading')} body={t('segments.body')}>
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 mb-10">
+              {SEGMENTS.map((s, i) => (
+                <div key={s} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+                  <span
+                    className="block h-1 w-8 rounded-full mb-4"
+                    style={{ backgroundColor: SERIES[i] }}
+                  />
+                  <span className="block text-[15px] font-semibold text-white/90 mb-1">
+                    {t(`segments.items.${s}.name`)}
+                  </span>
+                  <span className="block text-[13px] text-white/45 mb-4">
+                    {n(retail.segments[s])}% {t('segments.share')}
+                  </span>
+                  <p className="text-[13px] text-white/[0.55] leading-[1.7] mb-3">
+                    {t(`segments.items.${s}.description`)}
+                  </p>
+                  <p className="text-[13px] text-white/[0.75] leading-[1.7]">
+                    {t(`segments.items.${s}.action`)}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+              {t('segments.chart.heading')}
+            </h3>
+            <Chart
+              className="h-[300px] md:h-[360px]"
+              type="bar"
+              ariaLabel={t('segments.chart.ariaLabel')}
+              data={fixed.segments.data}
+              options={fixed.segments.options}
+            />
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-6">
+              {t('segments.chart.caption')} {t('cuts.areaNote')}
+            </p>
+          </Panel>
+
+          <Panel
+            title={t('top.heading')}
+            body={t('top.body', { n: n(fixed.topVsRest.n, 0) })}
+            note={t('top.caveat', {
+              top: n(fixed.topVsRest.skill.top),
+              rest: n(fixed.topVsRest.skill.rest),
+              p: n(fixed.topVsRest.skillPValue, 3),
+            })}
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 md:gap-8 mb-10">
+              {[
+                { id: 'salesPerHour', band: fixed.topVsRest.salesPerHour, digits: 1 },
+                { id: 'aboveThreshold', band: fixed.topVsRest.aboveThresholdPct, digits: 1 },
+                { id: 'relativeSph', band: fixed.topVsRest.relativeSph, digits: 2 },
+              ].map((s) => (
+                <div key={s.id}>
+                  <span
+                    className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {n(s.band.top, s.digits)}
+                  </span>
+                  <span className="block text-[14px] font-semibold text-white/80 mb-2">
+                    {t(`top.stats.${s.id}`)}
+                  </span>
+                  <span className="block text-[13px] text-white/40">
+                    {t('top.series.rest')} · {n(s.band.rest, s.digits)}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <Chart
+              className="h-[300px] md:h-[380px]"
+              type="bar"
+              ariaLabel={t('top.ariaLabel')}
+              data={fixed.top.data}
+              options={fixed.top.options}
+            />
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-6">{t('top.caption')}</p>
+          </Panel>
+
+          <Panel
+            title={t('seniority.heading')}
+            body={t('seniority.body')}
+            note={t('seniority.caption', {
+              skill: n(fixed.correlations.seniorityToSkill, 2),
+              kpi: n(fixed.correlations.seniorityToKpi, 2),
+            })}
+          >
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
+              {fixed.seniority.map((chart) => (
+                <div key={chart.series}>
+                  <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+                    {t(`seniority.series.${chart.series}`)}
+                  </h3>
+                  <Chart
+                    className="h-[280px] md:h-[340px]"
+                    type="line"
+                    ariaLabel={t(
+                      chart.series === 'skill'
+                        ? 'seniority.skillChart.ariaLabel'
+                        : 'seniority.sphChart.ariaLabel',
+                    )}
+                    data={chart.data}
+                    options={chart.options}
+                  />
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel title={t('closing.heading')} body={t('closing.body')}>
+            <a
+              href={href('demo', lang)}
+              className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-4 py-2 text-[13px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
+            >
+              {t('closing.back')}
+            </a>
+          </Panel>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/[locale]/demo/retail-network/opengraph-image.tsx
+++ b/app/[locale]/demo/retail-network/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogFor } from '@/i18n/og-card';
+
+export { size, contentType } from '@/i18n/og-card';
+
+export function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'it' }];
+}
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return ogFor('demo/retail', locale);
+}

--- a/app/[locale]/demo/retail-network/page.tsx
+++ b/app/[locale]/demo/retail-network/page.tsx
@@ -1,0 +1,34 @@
+// The server half of this route. The page itself is body.tsx.
+//
+// Same shape as every other route. The one thing worth knowing about it is not
+// in this file: `"noindex": true` on `demo/retail` in i18n/routes.json, which
+// buildMetadata turns into robots noindex/nofollow and which keeps the route
+// out of the sitemap. These pages travel by link, one prospect at a time.
+import { NextIntlClientProvider } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+import { buildMetadata } from '@/i18n/metadata';
+import { messagesForRoute } from '@/i18n/messages';
+import JsonLd from '@/i18n/json-ld';
+import Body from './body';
+
+const ROUTE = 'demo/retail';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return buildMetadata(ROUTE, locale);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={await messagesForRoute(ROUTE, locale)}>
+      <JsonLd routeId={ROUTE} locale={locale} />
+      <Body />
+    </NextIntlClientProvider>
+  );
+}

--- a/i18n/routes.json
+++ b/i18n/routes.json
@@ -245,6 +245,14 @@
     "noindex": true
   },
   {
+    "id": "demo/retail",
+    "paths": {
+      "en": "/demo/retail-network",
+      "it": "/demo/rete-retail"
+    },
+    "noindex": true
+  },
+  {
     "id": "index",
     "paths": {
       "en": "/",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4595,7 +4595,6 @@
         "body": "A sales network measured on soft skills and technical knowledge together: who is ready to sell, and who goes through the training first."
       },
       "crossCountry": {
-        "sector": "Pharma",
         "title": "Cross-country talent map",
         "body": "One competency frame applied across every country in scope, so a group HR team can compare populations that were never comparable before."
       }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4699,7 +4699,7 @@
           "heading": "Skill and result, side by side",
           "ariaLabel": "Grouped bar chart comparing the share above threshold and the conversion rate of each group in the selected cut",
           "axis": "Percent",
-          "caption": "Both bars are percentages, so they sit on one axis. Read them as two facts about the same group, not as cause and effect — the group with the highest share above threshold is rarely the one converting best."
+          "caption": "Both bars are percentages, so they sit on one axis. On channel, location and area the same group leads both of them: between groups, competency and result do move together. Store tier is the one cut where they part — the tier with the most people above threshold is not the tier converting best. What does not survive is the step down from the group to the single store and the single person, where the link is gone."
         },
         "kpis": {
           "heading": "What the stores report",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4601,7 +4601,8 @@
       }
     },
     "status": {
-      "comingSoon": "Coming soon"
+      "comingSoon": "Coming soon",
+      "open": "Open the dashboard"
     },
     "preview": {
       "heading": "How a result reads",
@@ -4616,6 +4617,216 @@
         "Commercial drive"
       ],
       "caption": "Illustrative figures. The three dashboards run on aggregated data, with every individual record removed."
+    },
+    "retail": {
+      "meta": {
+        "title": "Store network capability — demo dashboard | Skillvue",
+        "description": "A retail network assessed on one competency frame end to end, read by channel, location, store tier and tenure. Aggregates only: every individual record removed."
+      },
+      "hero": {
+        "eyebrow": "Interactive demo · Retail",
+        "heading": "A store network, read on one frame <span>from end to end</span>",
+        "body": "Every sales advisor in the network was assessed on the same five competency areas, and the result was put next to the numbers the stores already report: conversion, units per ticket, average ticket, sales per hour. What follows is what that comparison says — including where it says nothing.",
+        "note": "Aggregates only. No store, no person and no individual record is on this page: every figure is a group statistic, computed once outside this website."
+      },
+      "population": {
+        "heading": "What was measured",
+        "advisors": {
+          "label": "Sales advisors assessed",
+          "note": "The population every cut on this page is computed on. The {managers} store managers were assessed on a frame of their own and are not in these figures."
+        },
+        "stores": {
+          "label": "Stores in scope",
+          "note": "Of which {outlets} are outlets."
+        },
+        "aboveThreshold": {
+          "label": "Above the mastery threshold",
+          "note": "The share of advisors scoring above {threshold} on the overall competency score."
+        },
+        "conversion": {
+          "label": "Network conversion rate",
+          "note": "Averaged across the stores in scope."
+        }
+      },
+      "distribution": {
+        "heading": "Where the network sits",
+        "body": "One bar per five-point band of the overall competency score, and the share of advisors who landed in it. The shape is the first thing a programme is sized against: a wide middle, and a thin tail past the threshold.",
+        "series": "Share of advisors",
+        "axisScore": "Competency score",
+        "axisShare": "% of advisors",
+        "ariaLabel": "Bar chart of the share of sales advisors in each five-point band of the competency score",
+        "caption": "{above}% of advisors score above {threshold}. That is a share, not a ranking — and it is the number a development budget is built on."
+      },
+      "cuts": {
+        "heading": "The same network, cut four ways",
+        "body": "Channel, location, store tier and area are four questions asked of one population. Pick one and the panels below redraw.",
+        "label": "Cut by",
+        "options": {
+          "channel": "Channel",
+          "location": "Location",
+          "tier": "Store tier",
+          "area": "Area"
+        },
+        "groups": {
+          "channel": {
+            "fullPrice": "Full price",
+            "outlet": "Outlet"
+          },
+          "location": {
+            "mall": "Shopping centre",
+            "highStreet": "High street"
+          },
+          "tier": {
+            "tier1": "Tier 1",
+            "tier2": "Tier 2",
+            "tier3": "Tier 3"
+          },
+          "area": {
+            "area1": "Area 1",
+            "area2": "Area 2",
+            "area3": "Area 3",
+            "area4": "Area 4",
+            "area5": "Area 5"
+          }
+        },
+        "areaNote": "Areas are numbered by headcount, largest first. The number says nothing about who they are and nothing about how they rank.",
+        "skills": {
+          "heading": "Competency profile",
+          "ariaLabel": "Radar chart of the five competency areas, one line per group in the selected cut",
+          "caption": "The five areas on one scale. The profiles differ in level more than in shape: the same competencies lead everywhere, and the distance between groups is a matter of a few points.",
+          "unavailable": "The area cut is published as headcount and result only. A competency profile per area is not part of this extract."
+        },
+        "results": {
+          "heading": "Skill and result, side by side",
+          "ariaLabel": "Grouped bar chart comparing the share above threshold and the conversion rate of each group in the selected cut",
+          "axis": "Percent",
+          "caption": "Both bars are percentages, so they sit on one axis. Read them as two facts about the same group, not as cause and effect — the group with the highest share above threshold is rarely the one converting best."
+        },
+        "kpis": {
+          "heading": "What the stores report",
+          "caption": "Store KPIs for the same groups, over the assessment perimeter."
+        },
+        "labels": {
+          "people": "Advisors",
+          "stores": "Stores",
+          "skill": "Competency score",
+          "aboveThreshold": "Above threshold",
+          "conversionRate": "Conversion rate",
+          "unitsPerTicket": "Units per ticket",
+          "averageTicket": "Average ticket",
+          "salesPerHour": "Sales per hour",
+          "visitsPerDay": "Visits per day",
+          "turnover": "Turnover"
+        }
+      },
+      "skills": {
+        "customerSalesExcellence": "Customer & sales excellence",
+        "brandStorytelling": "Brand storytelling",
+        "collaborationTeamContribution": "Collaboration & team contribution",
+        "agilityExecution": "Agility & execution",
+        "productKnowledge": "Product knowledge"
+      },
+      "map": {
+        "heading": "Skill and revenue, on the same axes",
+        "body": "Every point is one of the groups above — a channel, a location, a tier, an area — with its share above threshold on one axis and its conversion rate on the other. If competency drove conversion the points would line up. They do not.",
+        "ariaLabel": "Scatter chart of the aggregated groups, share above threshold against conversion rate",
+        "axisX": "% above threshold",
+        "axisY": "Conversion rate %",
+        "stores": {
+          "label": "Competency and conversion, store by store",
+          "note": "Across {n} stores."
+        },
+        "people": {
+          "label": "Competency and sales, advisor by advisor",
+          "note": "Across {n} advisors."
+        },
+        "caption": "Two coefficients close to zero, and they belong on the page rather than in a drawer: on this network competency does not predict the till on its own, and a dashboard claiming otherwise would be wrong in a way a prospect can check in ten seconds. What the data does carry is everything below — who is already ahead, where the profile differs, and which group needs which intervention."
+      },
+      "segments": {
+        "heading": "Five segments, five different conversations",
+        "body": "Crossing competency against commercial result splits the network into five groups. The split earns its keep in the second line of each card: what to do about a group is not the same thing five times.",
+        "share": "of the network",
+        "items": {
+          "benchmark": {
+            "name": "Benchmark",
+            "description": "Above the line on the assessment and on the commercial numbers.",
+            "action": "Make the method explicit and turn it into the training content everyone else gets."
+          },
+          "resultWithoutMethod": {
+            "name": "Result without method",
+            "description": "Delivering the numbers with a competency profile that does not explain them.",
+            "action": "Find out what they actually do on the floor before the next intake is asked to copy it."
+          },
+          "skillWithoutResult": {
+            "name": "Skill without result",
+            "description": "The assessment says they can; the till says they are not.",
+            "action": "The obstacle is rarely competency here. Look at shift, footfall and floor allocation before booking a course."
+          },
+          "priorityDevelopment": {
+            "name": "Priority development",
+            "description": "Below the line on both, with enough of a base to move.",
+            "action": "Structured development, aimed at the two areas their own profile is weakest on."
+          },
+          "toActivate": {
+            "name": "To activate",
+            "description": "Bottom of both scales.",
+            "action": "A conversation before a programme: this is the group where a change of role is on the table."
+          }
+        },
+        "chart": {
+          "heading": "The mix moves by area",
+          "ariaLabel": "Stacked bar chart of the five segments as a share of each area",
+          "axis": "% of the advisors in the area",
+          "caption": "The same five segments, area by area. One area is more than half result-without-method; another carries the largest priority-development share of all five. Those two need different budgets, not more of the same."
+        }
+      },
+      "top": {
+        "heading": "The top performers, and the gap that is not there",
+        "body": "{n} advisors sit in the top commercial band. On sales per hour and on the share above threshold they are clearly ahead. On the competency areas themselves the distance is small — and on one of the five it runs the other way.",
+        "series": {
+          "top": "Top performers",
+          "rest": "Everyone else"
+        },
+        "ariaLabel": "Grouped bar chart of the five competency areas, top performers against everyone else",
+        "stats": {
+          "salesPerHour": "Sales per hour",
+          "aboveThreshold": "% above threshold",
+          "relativeSph": "Sales per hour vs network average"
+        },
+        "caption": "The commercial gap is real and large. The competency gap is neither.",
+        "caveat": "On the overall competency score the difference — {top} against {rest} — does not clear statistical significance (p = {p}). It is on the page because leaving it out would be choosing the flattering half."
+      },
+      "seniority": {
+        "heading": "Tenure buys results, not competency",
+        "body": "Seven tenure bands, two lines. Sales per hour relative to the network average climbs steadily the longer someone has been there. The competency score does not follow it.",
+        "buckets": {
+          "lt3m": "Under 3 months",
+          "m3to12": "3–12 months",
+          "y1to2": "1–2 years",
+          "y2to5": "2–5 years",
+          "y5to10": "5–10 years",
+          "y10to20": "10–20 years",
+          "gt20": "Over 20 years"
+        },
+        "series": {
+          "skill": "Competency score",
+          "relativeSph": "Sales per hour vs network average"
+        },
+        "skillChart": {
+          "ariaLabel": "Line chart of the competency score across seven tenure bands"
+        },
+        "sphChart": {
+          "ariaLabel": "Line chart of sales per hour relative to the network average, across seven tenure bands"
+        },
+        "axisSkill": "Competency score",
+        "axisSph": "Relative sales per hour",
+        "caption": "Correlation between tenure and competency: {skill}. Between tenure and the commercial KPIs: {kpi}. The first is the useful one — it means the people who have been here longest are not automatically the ones to learn from, which is the whole reason an assessment is run instead of an org chart being read."
+      },
+      "closing": {
+        "heading": "How this page was made",
+        "body": "Every number here is a group statistic, computed once outside this website from data that never entered it. Headcounts are rounded to the nearest five, no group carrying a score holds fewer than 25 people, and the areas are numbered rather than named. There is no store table, no ranking and no individual record — not hidden, absent.",
+        "back": "Back to the demo dashboards"
+      }
     }
   },
   "home": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4601,7 +4601,8 @@
       }
     },
     "status": {
-      "comingSoon": "In arrivo"
+      "comingSoon": "In arrivo",
+      "open": "Apri la dashboard"
     },
     "preview": {
       "heading": "Come si legge un risultato",
@@ -4616,6 +4617,216 @@
         "Spinta commerciale"
       ],
       "caption": "Valori illustrativi. Le tre dashboard girano su dati aggregati, senza alcun record individuale."
+    },
+    "retail": {
+      "meta": {
+        "title": "Capability della rete retail — dashboard demo | Skillvue",
+        "description": "Una rete di punti vendita valutata con un solo schema di competenze, letta per canale, location, tier e anzianità. Solo aggregati: nessun dato individuale."
+      },
+      "hero": {
+        "eyebrow": "Demo interattiva · Retail",
+        "heading": "Una rete di negozi, letta con un solo schema <span>dall’inizio alla fine</span>",
+        "body": "Ogni sales advisor della rete è stato valutato sulle stesse cinque aree di competenza, e il risultato è stato messo accanto ai numeri che i negozi già producono: conversione, pezzi per scontrino, scontrino medio, vendite per ora. Quello che segue è ciò che quel confronto dice — compreso dove non dice nulla.",
+        "note": "Solo aggregati. Su questa pagina non c’è nessun negozio, nessuna persona e nessun record individuale: ogni cifra è una statistica di gruppo, calcolata una volta fuori da questo sito."
+      },
+      "population": {
+        "heading": "Che cosa è stato misurato",
+        "advisors": {
+          "label": "Sales advisor valutati",
+          "note": "La popolazione su cui è calcolato ogni taglio di questa pagina. I {managers} store manager sono stati valutati su uno schema diverso e non entrano in queste cifre."
+        },
+        "stores": {
+          "label": "Punti vendita nel perimetro",
+          "note": "Di cui {outlets} outlet."
+        },
+        "aboveThreshold": {
+          "label": "Sopra la soglia di padronanza",
+          "note": "La quota di advisor che supera {threshold} sul punteggio complessivo di competenze."
+        },
+        "conversion": {
+          "label": "Tasso di conversione della rete",
+          "note": "Media sui punti vendita nel perimetro."
+        }
+      },
+      "distribution": {
+        "heading": "Dove sta la rete",
+        "body": "Una barra ogni cinque punti di punteggio complessivo, e la quota di advisor finita in quella fascia. La forma è la prima cosa su cui si dimensiona un programma: un centro molto largo e una coda sottile oltre la soglia.",
+        "series": "Quota di advisor",
+        "axisScore": "Punteggio di competenze",
+        "axisShare": "% di advisor",
+        "ariaLabel": "Grafico a barre della quota di sales advisor in ciascuna fascia di cinque punti del punteggio di competenze",
+        "caption": "Il {above}% degli advisor supera {threshold}. È una quota, non una classifica — ed è il numero su cui si costruisce un budget di sviluppo."
+      },
+      "cuts": {
+        "heading": "La stessa rete, tagliata in quattro modi",
+        "body": "Canale, location, tier del punto vendita e area sono quattro domande poste alla stessa popolazione. Scegline una e i pannelli qui sotto si ridisegnano.",
+        "label": "Taglia per",
+        "options": {
+          "channel": "Canale",
+          "location": "Location",
+          "tier": "Tier del negozio",
+          "area": "Area"
+        },
+        "groups": {
+          "channel": {
+            "fullPrice": "Full price",
+            "outlet": "Outlet"
+          },
+          "location": {
+            "mall": "Centro commerciale",
+            "highStreet": "Strada"
+          },
+          "tier": {
+            "tier1": "Tier 1",
+            "tier2": "Tier 2",
+            "tier3": "Tier 3"
+          },
+          "area": {
+            "area1": "Area 1",
+            "area2": "Area 2",
+            "area3": "Area 3",
+            "area4": "Area 4",
+            "area5": "Area 5"
+          }
+        },
+        "areaNote": "Le aree sono numerate per headcount, dalla più grande alla più piccola. Il numero non dice nulla su chi siano e nulla su come si posizionino.",
+        "skills": {
+          "heading": "Profilo di competenze",
+          "ariaLabel": "Grafico radar delle cinque aree di competenza, una linea per ciascun gruppo del taglio selezionato",
+          "caption": "Le cinque aree sulla stessa scala. I profili differiscono più nel livello che nella forma: le competenze che guidano sono le stesse ovunque, e la distanza fra i gruppi è di pochi punti.",
+          "unavailable": "Il taglio per area è pubblicato solo come headcount e risultato. Un profilo di competenze per area non fa parte di questo estratto."
+        },
+        "results": {
+          "heading": "Competenze e risultato, affiancati",
+          "ariaLabel": "Grafico a barre raggruppate che confronta la quota sopra soglia e il tasso di conversione di ogni gruppo del taglio selezionato",
+          "axis": "Percentuale",
+          "caption": "Sono entrambe percentuali, quindi stanno sullo stesso asse. Vanno letti come due fatti sullo stesso gruppo, non come causa ed effetto: il gruppo con più persone sopra soglia raramente è quello che converte meglio."
+        },
+        "kpis": {
+          "heading": "Che cosa dicono i numeri dei negozi",
+          "caption": "I KPI di negozio per gli stessi gruppi, sul perimetro dell’assessment."
+        },
+        "labels": {
+          "people": "Advisor",
+          "stores": "Negozi",
+          "skill": "Punteggio competenze",
+          "aboveThreshold": "Sopra soglia",
+          "conversionRate": "Tasso di conversione",
+          "unitsPerTicket": "Pezzi per scontrino",
+          "averageTicket": "Scontrino medio",
+          "salesPerHour": "Vendite per ora",
+          "visitsPerDay": "Visite al giorno",
+          "turnover": "Turnover"
+        }
+      },
+      "skills": {
+        "customerSalesExcellence": "Eccellenza cliente e vendita",
+        "brandStorytelling": "Racconto del brand",
+        "collaborationTeamContribution": "Collaborazione e contributo al team",
+        "agilityExecution": "Agilità ed esecuzione",
+        "productKnowledge": "Conoscenza di prodotto"
+      },
+      "map": {
+        "heading": "Competenze e fatturato, sugli stessi assi",
+        "body": "Ogni punto è uno dei gruppi qui sopra — un canale, una location, un tier, un’area — con la quota sopra soglia su un asse e il tasso di conversione sull’altro. Se le competenze guidassero la conversione, i punti si allineerebbero. Non lo fanno.",
+        "ariaLabel": "Grafico a dispersione dei gruppi aggregati, quota sopra soglia contro tasso di conversione",
+        "axisX": "% sopra soglia",
+        "axisY": "Tasso di conversione %",
+        "stores": {
+          "label": "Competenze e conversione, negozio per negozio",
+          "note": "Su {n} punti vendita."
+        },
+        "people": {
+          "label": "Competenze e vendite, persona per persona",
+          "note": "Su {n} advisor."
+        },
+        "caption": "Due coefficienti vicini allo zero, e il loro posto è sulla pagina e non in un cassetto: su questa rete le competenze da sole non predicono la cassa, e una dashboard che sostenesse il contrario si smonterebbe in dieci secondi in mano a chi la riceve. Quello che i dati reggono davvero è tutto ciò che segue: chi è già avanti, dove il profilo cambia, e quale gruppo ha bisogno di quale intervento."
+      },
+      "segments": {
+        "heading": "Cinque segmenti, cinque conversazioni diverse",
+        "body": "Incrociando competenze e risultato commerciale la rete si divide in cinque gruppi. La divisione si paga nella seconda riga di ogni scheda: che cosa fare di un gruppo non è la stessa cosa cinque volte.",
+        "share": "della rete",
+        "items": {
+          "benchmark": {
+            "name": "Benchmark",
+            "description": "Sopra la linea sia nell’assessment sia nei numeri commerciali.",
+            "action": "Rendere esplicito il metodo e trasformarlo nel contenuto formativo che ricevono tutti gli altri."
+          },
+          "resultWithoutMethod": {
+            "name": "Risultato senza metodo",
+            "description": "Portano i numeri con un profilo di competenze che non li spiega.",
+            "action": "Capire che cosa fanno davvero in negozio, prima di chiedere alla prossima leva di copiarlo."
+          },
+          "skillWithoutResult": {
+            "name": "Competenze senza risultato",
+            "description": "L’assessment dice che sanno farlo, la cassa dice che non sta succedendo.",
+            "action": "Qui l’ostacolo raramente è la competenza. Guardare turni, affluenza e assegnazione al reparto prima di comprare un corso."
+          },
+          "priorityDevelopment": {
+            "name": "Sviluppo prioritario",
+            "description": "Sotto la linea su entrambi i fronti, ma con una base sufficiente per muoversi.",
+            "action": "Sviluppo strutturato, puntato sulle due aree in cui il loro profilo è più debole."
+          },
+          "toActivate": {
+            "name": "Da attivare",
+            "description": "In fondo a entrambe le scale.",
+            "action": "Una conversazione prima di un programma: è il gruppo in cui un cambio di ruolo è sul tavolo."
+          }
+        },
+        "chart": {
+          "heading": "Il mix cambia da area ad area",
+          "ariaLabel": "Grafico a barre impilate dei cinque segmenti come quota di ciascuna area",
+          "axis": "% degli advisor dell’area",
+          "caption": "Gli stessi cinque segmenti, area per area. Un’area è per più della metà «risultato senza metodo»; un’altra ha la quota di sviluppo prioritario più alta di tutte e cinque. Sono due budget diversi, non più dose dello stesso."
+        }
+      },
+      "top": {
+        "heading": "I top performer, e il divario che non c’è",
+        "body": "{n} advisor stanno nella fascia commerciale alta. Su vendite per ora e su quota sopra soglia sono nettamente avanti. Sulle aree di competenza in sé la distanza è piccola — e su una delle cinque va nella direzione opposta.",
+        "series": {
+          "top": "Top performer",
+          "rest": "Il resto della rete"
+        },
+        "ariaLabel": "Grafico a barre raggruppate delle cinque aree di competenza, top performer contro il resto della rete",
+        "stats": {
+          "salesPerHour": "Vendite per ora",
+          "aboveThreshold": "% sopra soglia",
+          "relativeSph": "Vendite per ora sulla media di rete"
+        },
+        "caption": "Il divario commerciale è reale e largo. Quello di competenze non lo è.",
+        "caveat": "Sul punteggio complessivo di competenze la differenza — {top} contro {rest} — non raggiunge la significatività statistica (p = {p}). Sta sulla pagina perché toglierla vorrebbe dire scegliere la metà che conviene."
+      },
+      "seniority": {
+        "heading": "L’anzianità porta risultati, non competenze",
+        "body": "Sette fasce di anzianità, due linee. Le vendite per ora rispetto alla media di rete salgono man mano che l’anzianità cresce. Il punteggio di competenze non le segue.",
+        "buckets": {
+          "lt3m": "Meno di 3 mesi",
+          "m3to12": "3–12 mesi",
+          "y1to2": "1–2 anni",
+          "y2to5": "2–5 anni",
+          "y5to10": "5–10 anni",
+          "y10to20": "10–20 anni",
+          "gt20": "Oltre 20 anni"
+        },
+        "series": {
+          "skill": "Punteggio competenze",
+          "relativeSph": "Vendite per ora sulla media di rete"
+        },
+        "skillChart": {
+          "ariaLabel": "Grafico a linee del punteggio di competenze su sette fasce di anzianità"
+        },
+        "sphChart": {
+          "ariaLabel": "Grafico a linee delle vendite per ora rispetto alla media di rete, su sette fasce di anzianità"
+        },
+        "axisSkill": "Punteggio competenze",
+        "axisSph": "Vendite per ora relative",
+        "caption": "Correlazione fra anzianità e competenze: {skill}. Fra anzianità e KPI commerciali: {kpi}. La prima è quella che serve — significa che chi è in azienda da più tempo non è automaticamente la persona da cui imparare, ed è esattamente il motivo per cui si fa un assessment invece di leggere un organigramma."
+      },
+      "closing": {
+        "heading": "Come è fatta questa pagina",
+        "body": "Ogni numero qui è una statistica di gruppo, calcolata una volta fuori da questo sito su dati che in questo sito non sono mai entrati. Gli headcount sono arrotondati al multiplo di cinque, nessun gruppo che porta un punteggio contiene meno di 25 persone, e le aree sono numerate invece che nominate. Non c’è nessuna tabella dei negozi, nessuna classifica e nessun record individuale — non nascosti, assenti.",
+        "back": "Torna alle dashboard demo"
+      }
     }
   },
   "home": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4699,7 +4699,7 @@
           "heading": "Competenze e risultato, affiancati",
           "ariaLabel": "Grafico a barre raggruppate che confronta la quota sopra soglia e il tasso di conversione di ogni gruppo del taglio selezionato",
           "axis": "Percentuale",
-          "caption": "Sono entrambe percentuali, quindi stanno sullo stesso asse. Vanno letti come due fatti sullo stesso gruppo, non come causa ed effetto: il gruppo con più persone sopra soglia raramente è quello che converte meglio."
+          "caption": "Sono entrambe percentuali, quindi stanno sullo stesso asse. Su canale, location e area lo stesso gruppo guida tutte e due: fra gruppi, competenze e risultato si muovono insieme. Il tier è l’unico taglio in cui si separano — quello con più persone sopra soglia non è quello che converte meglio. Quello che non regge è il passaggio dal gruppo al singolo negozio e alla singola persona, dove il legame sparisce."
         },
         "kpis": {
           "heading": "Che cosa dicono i numeri dei negozi",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4595,7 +4595,6 @@
         "body": "Una rete vendita misurata insieme su soft skill e conoscenze tecniche: chi è pronto a vendere e chi passa prima dalla formazione."
       },
       "crossCountry": {
-        "sector": "Pharma",
         "title": "Mappa dei talenti cross-country",
         "body": "Un solo schema di competenze applicato a tutti i paesi coinvolti, perché l’HR di gruppo possa confrontare popolazioni che prima non erano confrontabili."
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:assets": "node scripts/check-assets.mjs",
     "check:demo-event": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-event.mjs",
     "check:demo-anonymity": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-anonymity.mjs",
+    "check:demo-retail": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-retail.mjs",
     "test:smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {

--- a/scripts/check-demo-retail.mjs
+++ b/scripts/check-demo-retail.mjs
@@ -1,0 +1,233 @@
+// check-demo-retail — the retail dashboard's labels exist, and its copy still
+// describes the data underneath it.
+//
+// Two gaps meet on this page and neither is covered elsewhere.
+//
+// The first: every label on it is fetched with a composed key —
+// t(`cuts.groups.${cut}.${id}`), t(`skills.${s}`), t(`segments.items.${s}.name`).
+// check:i18n only reads string literals, so none of those keys is checked by
+// anything. A group renamed in data/demo/retail.ts would render the key path
+// itself as the pill's label, in both languages, with every gate green. So the
+// group ids are read from the data and matched against the catalogue in both
+// directions: no group without a label, no label without a group.
+//
+// The second, and the reason this file is longer than that: the page is an
+// argument about the data. It says the competency gap between top performers
+// and everyone else is small, that tenure buys results and not competency, and
+// that competency does not predict conversion — with the two coefficients on
+// screen rather than left out. If the extract is ever refreshed and the numbers
+// move, that copy becomes a claim the page's own charts contradict, and nothing
+// would say so. Each of those sentences is asserted against the figure it
+// describes.
+//
+// Run: npm run check:demo-retail
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { retail } = await import(pathToFileURL(join(ROOT, 'data/demo/retail.ts')).href);
+
+const catalogues = Object.fromEntries(
+  ['en', 'it'].map((l) => [
+    l,
+    JSON.parse(readFileSync(join(ROOT, `messages/${l}.json`), 'utf8')).demo.retail,
+  ]),
+);
+
+const at = (catalogue, path) =>
+  path.split('.').reduce((node, seg) => (node == null ? undefined : node[seg]), catalogue);
+
+const missing = [];
+const label = (path) => {
+  for (const locale of ['en', 'it']) {
+    if (typeof at(catalogues[locale], path) !== 'string') {
+      missing.push(`  ${locale}: demo.retail.${path}`);
+    }
+  }
+};
+
+// ── Every composed key the page builds ─────────────────────────────────────
+// The ids come from the data, exactly as the page derives them at runtime.
+const CUTS = {
+  channel: Object.keys(retail.context.channel),
+  location: Object.keys(retail.context.location),
+  tier: Object.keys(retail.context.tier),
+  area: Object.keys(retail.areas),
+};
+
+for (const [cut, ids] of Object.entries(CUTS)) {
+  label(`cuts.options.${cut}`);
+  for (const id of ids) label(`cuts.groups.${cut}.${id}`);
+}
+
+// The five competency areas, named once per context group and once in
+// topVsRest. All four lists must be the same five, or the radar draws a group
+// against axes it has no point for.
+const SKILLS = Object.keys(retail.topVsRest.areas);
+for (const skill of SKILLS) label(`skills.${skill}`);
+
+for (const segment of Object.keys(retail.segments)) {
+  for (const part of ['name', 'description', 'action']) label(`segments.items.${segment}.${part}`);
+}
+for (const bucket of Object.keys(retail.seniority)) label(`seniority.buckets.${bucket}`);
+// The two tenure charts pick their aria label and their axis title with a
+// ternary inside t(), which check:i18n cannot read either.
+for (const key of [
+  'seniority.series.skill', 'seniority.series.relativeSph',
+  'seniority.skillChart.ariaLabel', 'seniority.sphChart.ariaLabel',
+  'seniority.axisSkill', 'seniority.axisSph',
+]) label(key);
+for (const band of ['top', 'rest']) label(`top.series.${band}`);
+for (const stat of ['salesPerHour', 'aboveThreshold', 'relativeSph']) label(`top.stats.${stat}`);
+for (const kpi of [
+  'people', 'stores', 'skill', 'aboveThreshold', 'conversionRate',
+  'unitsPerTicket', 'averageTicket', 'salesPerHour', 'visitsPerDay', 'turnover',
+]) label(`cuts.labels.${kpi}`);
+for (const card of ['advisors', 'stores', 'aboveThreshold', 'conversion']) {
+  label(`population.${card}.label`);
+  label(`population.${card}.note`);
+}
+for (const side of ['stores', 'people']) {
+  label(`map.${side}.label`);
+  label(`map.${side}.note`);
+}
+
+assert.deepEqual(
+  missing,
+  [],
+  `${missing.length} label(s) the page composes have no message:\n${missing.join('\n')}\n` +
+    'next-intl renders the key path when a key is missing, so this ships as literal ' +
+    '"cuts.groups.channel.outlet" where the pill\'s name should be.',
+);
+
+// The other direction: copy for a group the data no longer holds is copy that
+// renders nowhere and still asks to be translated.
+const stale = [];
+for (const [cut, ids] of Object.entries(CUTS)) {
+  const declared = Object.keys(at(catalogues.en, `cuts.groups.${cut}`) ?? {});
+  for (const id of declared) if (!ids.includes(id)) stale.push(`  cuts.groups.${cut}.${id}`);
+}
+for (const id of Object.keys(catalogues.en.skills)) {
+  if (!SKILLS.includes(id)) stale.push(`  skills.${id}`);
+}
+assert.deepEqual(stale, [], `Labels with no group behind them:\n${stale.join('\n')}`);
+
+// ── The shape the page's one conditional is built on ───────────────────────
+// The radar is skipped for the area cut and `cuts.skills.unavailable` shown
+// instead, because the areas ship as headcount and result only. If an extract
+// ever carried a competency profile per area the fallback would be hiding a
+// chart the data can draw.
+for (const cut of ['channel', 'location', 'tier']) {
+  for (const [id, group] of Object.entries(retail.context[cut])) {
+    assert.deepEqual(
+      Object.keys(group.areas).sort(),
+      [...SKILLS].sort(),
+      `context.${cut}.${id} does not carry the same five competency areas as topVsRest.`,
+    );
+  }
+}
+assert.ok(
+  Object.values(retail.areas).every((a) => a.areas === undefined),
+  'An area now carries a competency profile — the page skips the radar for the area cut ' +
+    'and says so in cuts.skills.unavailable. Draw the chart instead of the fallback.',
+);
+
+// ── Shares are shares ──────────────────────────────────────────────────────
+// Each is drawn on an axis fixed to 0-100 by the page, so one that no longer
+// sums to a hundred is a bar that silently stops reaching the end of it.
+const sums = (label, values) =>
+  assert.ok(
+    Math.abs(values.reduce((a, b) => a + b, 0) - 100) <= 0.5,
+    `${label} sums to ${values.reduce((a, b) => a + b, 0)}, not 100.`,
+  );
+
+sums('skillDistribution.distribution', [...retail.skillDistribution.distribution]);
+sums('segments', Object.values(retail.segments));
+for (const [id, area] of Object.entries(retail.areas)) {
+  sums(`areas.${id}.segments`, Object.values(area.segments));
+}
+
+// ── The headline figures the copy quotes ───────────────────────────────────
+// population.stores.note says "of which {outlets} are outlets", which is only
+// true while the estate is the two channels and nothing else.
+assert.equal(
+  retail.population.stores,
+  retail.context.channel.fullPrice.stores + retail.context.channel.outlet.stores,
+  'population.stores is no longer the two channels added up, but the copy still says it is.',
+);
+assert.equal(
+  retail.population.outlets,
+  retail.context.channel.outlet.stores,
+  'population.outlets disagrees with the outlet channel.',
+);
+
+// ── The sentences the page argues, against the numbers it argues them from ──
+
+// map.caption: "competency does not predict the till on its own".
+for (const [key, r] of [
+  ['storeSkillToConversion', retail.correlations.storeSkillToConversion],
+  ['individualSkillToSales', retail.correlations.individualSkillToSales],
+]) {
+  assert.ok(
+    Math.abs(r) < 0.2,
+    `correlations.${key} is ${r}. The page is written around this being ~0 — it prints both ` +
+      'coefficients and says they do not line up. Rewrite map.caption before shipping a ' +
+      'correlation that does.',
+  );
+}
+
+// seniority.heading: "tenure buys results, not competency".
+const bands = Object.values(retail.seniority);
+const sph = bands.map((b) => b.relativeSph);
+const skills = bands.map((b) => b.skill);
+assert.ok(
+  sph.at(-1) - sph[0] >= 0.1,
+  `Relative sales per hour rises by ${(sph.at(-1) - sph[0]).toFixed(2)} across the tenure bands. ` +
+    'seniority.heading claims tenure buys results.',
+);
+assert.ok(
+  Math.max(...skills) - Math.min(...skills) < 6 &&
+    Math.abs(retail.correlations.seniorityToSkill) < 0.1,
+  'The competency score now moves with tenure. seniority.heading says it does not.',
+);
+
+// top.body: "on one of the five it runs the other way", and top.caveat quotes
+// the p-value as the reason the overall gap is not called a finding.
+const reversed = Object.entries(retail.topVsRest.areas).filter(([, a]) => a.top < a.rest);
+assert.equal(
+  reversed.length,
+  1,
+  `${reversed.length} competency areas run against the top performers, not 1 ` +
+    `(${reversed.map(([k]) => k).join(', ')}). top.body says one.`,
+);
+assert.ok(
+  retail.topVsRest.skillPValue > 0.05,
+  `skillPValue is ${retail.topVsRest.skillPValue}. top.caveat says the overall competency gap ` +
+    'does not clear significance; at this value it does.',
+);
+assert.ok(
+  retail.topVsRest.salesPerHour.top > retail.topVsRest.salesPerHour.rest,
+  'top.caption says the commercial gap is real and large.',
+);
+
+// segments.chart.caption: one area is more than half result-without-method, and
+// one carries the largest priority-development share — of all five, uniquely.
+const areas = Object.values(retail.areas);
+assert.ok(
+  Math.max(...areas.map((a) => a.segments.resultWithoutMethod)) > 50,
+  'No area is more than half result-without-method any more; segments.chart.caption says one is.',
+);
+const priority = areas.map((a) => a.segments.priorityDevelopment);
+assert.equal(
+  priority.filter((p) => p === Math.max(...priority)).length,
+  1,
+  'Two areas tie on the largest priority-development share; segments.chart.caption names one.',
+);
+
+console.log(
+  `[OK] demo retail: ${Object.values(CUTS).flat().length} group labels across ` +
+    `${Object.keys(CUTS).length} cuts, and 9 copy claims still true of the data`,
+);

--- a/scripts/check-demo-retail.mjs
+++ b/scripts/check-demo-retail.mjs
@@ -51,12 +51,15 @@ const label = (path) => {
 
 // ── Every composed key the page builds ─────────────────────────────────────
 // The ids come from the data, exactly as the page derives them at runtime.
-const CUTS = {
-  channel: Object.keys(retail.context.channel),
-  location: Object.keys(retail.context.location),
-  tier: Object.keys(retail.context.tier),
-  area: Object.keys(retail.areas),
+const CUT_GROUPS = {
+  channel: retail.context.channel,
+  location: retail.context.location,
+  tier: retail.context.tier,
+  area: retail.areas,
 };
+const CUTS = Object.fromEntries(
+  Object.entries(CUT_GROUPS).map(([cut, groups]) => [cut, Object.keys(groups)]),
+);
 
 for (const [cut, ids] of Object.entries(CUTS)) {
   label(`cuts.options.${cut}`);
@@ -179,10 +182,39 @@ for (const [key, r] of [
   );
 }
 
+// cuts.results.caption names which cuts have one group leading both bars and
+// which does not. The first version of that caption said the two rankings
+// rarely agree, which was false on three of the four cuts and visibly false to
+// anyone clicking the pills — overselling the *absence* of a link, which on
+// this page costs as much as overselling the link. This is the assertion that
+// was missing when it shipped.
+const leaderOf = (groups, key) =>
+  Object.entries(groups).reduce((a, b) => (b[1][key] > a[1][key] ? b : a))[0];
+const diverging = Object.entries(CUT_GROUPS)
+  .filter(([, g]) => leaderOf(g, 'aboveThresholdPct') !== leaderOf(g, 'conversionRate'))
+  .map(([cut]) => cut);
+assert.deepEqual(
+  diverging,
+  ['tier'],
+  `cuts.results.caption names store tier as the one cut whose two rankings disagree. ` +
+    `The cuts that now disagree are: ${diverging.join(', ') || 'none'}.`,
+);
+
 // seniority.heading: "tenure buys results, not competency".
 const bands = Object.values(retail.seniority);
 const sph = bands.map((b) => b.relativeSph);
 const skills = bands.map((b) => b.skill);
+// "climbs steadily" is a claim about every step, not about the two ends: with
+// only the endpoints compared, any middle band could be moved anywhere and the
+// chart would still be captioned as a steady climb (reviewer's mutation test —
+// this was the one surviving mutation of nineteen).
+const dips = sph.flatMap((v, i) => (i > 0 && v < sph[i - 1] ? [`${i - 1}->${i}`] : []));
+assert.deepEqual(
+  dips,
+  [],
+  `Relative sales per hour falls between tenure bands (${dips.join(', ')}). ` +
+    'seniority.body says it climbs steadily.',
+);
 assert.ok(
   sph.at(-1) - sph[0] >= 0.1,
   `Relative sales per hour rises by ${(sph.at(-1) - sph[0]).toFixed(2)} across the tenure bands. ` +
@@ -229,5 +261,5 @@ assert.equal(
 
 console.log(
   `[OK] demo retail: ${Object.values(CUTS).flat().length} group labels across ` +
-    `${Object.keys(CUTS).length} cuts, and 9 copy claims still true of the data`,
+    `${Object.keys(CUTS).length} cuts, and every copy claim still true of the data`,
 );


### PR DESCRIPTION
La prima delle tre dashboard demo, più la decisione presa su #176.

## #169 — la dashboard retail

Otto sezioni sui dati anonimizzati di #168: popolazione, distribuzione dei
punteggi, taglio a quattro vie (canale / location / tier / area), competenze e
risultato commerciale sugli stessi assi, i cinque segmenti con l'intervento
associato, il profilo dei top performer, le curve di anzianità, la nota di
metodo.

**Come è impaginata, e perché.** Nei dati veri la correlazione fra competenze e
conversion rate è ~0: 0.08 fra negozi, 0.06 fra persone. La pagina non sostiene
quindi che le competenze spieghino il fatturato — la sezione che ammette la
correlazione nulla è la quarta di otto, con i coefficienti in grande, non una
nota a piè di pagina.

Ma non sostiene nemmeno il contrario, ed è la correzione che questa PR si porta
dietro dalla review. Una didascalia affermava che il gruppo con più persone
sopra soglia raramente converte meglio: falso su tre dei quattro tagli
disegnati sopra di essa. Sovravendere l'assenza del legame è lo stesso difetto
con il segno invertito, e su una pagina che si regge sull'onestà costa di più —
un prospect che clicca tre pill e vede la didascalia smentita tre volte non
conclude che siamo prudenti.

Ciò che i dati dicono davvero è più interessante di entrambe le versioni: **fra
gruppi le due classifiche si muovono insieme** — canale, location e area hanno
lo stesso gruppo in testa a entrambe le barre — **e il legame sparisce nel
passaggio al singolo negozio e alla singola persona.** Il tier è l'unico taglio
in cui anche fra gruppi le classifiche divergono. La didascalia ora dice questo,
e `check:demo-retail` lo asserisce ricavandolo dai dati: se un domani i numeri
cambiano, il gate se ne accorge invece di lasciare la frase a mentire.

**Cosa la pagina non mostra.** Nessuna vista per singolo negozio o persona,
nessun ranking nominativo: quelle sono state tagliate in #168 e la copy non
promette letture che i dati non consentono. La popolazione sono i 570 sales
advisor, e gli store manager sono nominati una volta sola, per escluderli.

`overview.potentialKEur` (7.9 M€) è l'unico campo del dataset deliberatamente
lasciato fuori: una cifra di uplift si spedisce solo insieme alla metodologia
che la produce, e mai su una pagina che dichiara una correlazione bassa quattro
sezioni sotto. La regola è scritta sulla Issue e cross-postata su #170 e #171,
perché sarebbe rientrata per simmetria.

## #176 — la scheda cross-country non dichiara più il settore

#173 aveva sostituito i settori inventati con quelli veri, ed era giusto. Ma il
vero della terza scheda è `Pharma`, e su questo sito
`customers/fidia-farmaceutici` è una customer story pubblica, l'unica con
`industry: 'pharmaceutical'`. L'etichetta portava dalla dashboard anonimizzata
al cliente di cui mostra gli aggregati in un passaggio, annullando le due
soppressioni che i dati applicano per quel motivo.

La scheda legge la chiave invece di un flag, quindi una quarta scheda eredita il
comportamento senza che nessuno debba ricordarsi una regola: scrivi un settore e
appare, non lo scrivi e non appare. `Retail` e `Telco` restano — nessuna story
li rende univoci.

## Verifica

`./harness/init.sh` completo verde. Il gate nuovo è stato mutation-testato in
review — 19 mutazioni, 18 rosse — e l'unica sopravvissuta (la regola
sull'anzianità confrontava solo le fasce estreme) è stata chiusa: ora legge ogni
coppia consecutiva, verificata rossa su una fascia centrale. L'assertion sul
tier l'ho verificata rossa a mano rendendo il tier non divergente.

Smoke bilingue su `/demo/retail-network`, `/it/demo/rete-retail` e l'hub in
entrambe le lingue, con le quattro pill cliccate e la didascalia riletta ogni
volta.

Closes #169
Closes #176