### PR TITLE
Dashboard demo rete vendita

### DIFF
--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -20,7 +20,7 @@ import { href } from '@/i18n/routes';
 // its card stays a badge rather than becoming a link to nowhere.
 const DASHBOARDS = [
   { id: 'retail', Icon: Store, route: 'demo/retail' },
-  { id: 'salesNetwork', Icon: Users, route: undefined },
+  { id: 'salesNetwork', Icon: Users, route: 'demo/sales-network' },
   { id: 'crossCountry', Icon: Globe, route: undefined },
 ];
 

--- a/app/[locale]/demo/sales-network/body.tsx
+++ b/app/[locale]/demo/sales-network/body.tsx
@@ -192,7 +192,7 @@ export default function SalesNetworkDemo() {
     // the derivations as well would say the same thing twice.
   }, [t, lang, family, skill]);
 
-  const { funnel, overview } = salesNetwork;
+  const { funnel, overview, quadrants } = salesNetwork;
   const covered = FAMILIES.reduce((sum, f) => sum + salesNetwork.families[f].n, 0);
 
   const headline: Array<{ id: string; value: string; args: Record<string, string> }> = [
@@ -291,11 +291,13 @@ export default function SalesNetworkDemo() {
             />
           </Panel>
 
-          <Panel
-            title={t('families.heading')}
-            body={t('families.body')}
-            note={t('families.coverage', { covered: n(covered, 0), assessed: n(funnel.assessed, 0) })}
-          >
+          <Panel title={t('families.heading')} body={t('families.body')}>
+            {/* Above the cards, not under them: 85 and 90 are there to be added
+                up, and a reader who does that before being told they do not
+                reach 185 has found a hole instead of being shown one. */}
+            <p className="text-[13px] text-white/40 leading-[1.7] max-w-3xl mb-6">
+              {t('families.coverage', { covered: n(covered, 0), assessed: n(funnel.assessed, 0) })}
+            </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {FAMILIES.map((f, i) => (
                 <div key={f} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
@@ -421,7 +423,10 @@ export default function SalesNetworkDemo() {
 
           <Panel
             title={t('quadrants.heading')}
-            body={t('quadrants.body')}
+            body={t('quadrants.body', {
+              hardCleared: n(quadrants.softHighHardHigh + quadrants.softLowHardHigh),
+              softCleared: n(quadrants.softHighHardHigh + quadrants.softHighHardLow),
+            })}
             note={t('quadrants.caption', {
               soft: n(overview.softThreshold, 0),
               hard: n(overview.hardThreshold, 0),

--- a/app/[locale]/demo/sales-network/body.tsx
+++ b/app/[locale]/demo/sales-network/body.tsx
@@ -1,0 +1,480 @@
+'use client';
+
+// The sales network demo dashboard.
+//
+// Same construction as the retail one: numbers from data/demo/sales-network.ts,
+// words from messages/ under demo.salesNetwork, charts from the one wrapper.
+//
+// Two things this page deliberately does not draw, both because the data will
+// not carry them honestly:
+//
+// 1. No funnel. The extract holds 190 candidates, 180 interviews and 185
+//    assessed — the assessed count is above the interview count, because the
+//    source was already one out and rounding every headcount to the nearest
+//    five (the rule that makes these counts non-identifying) turned a gap of 1
+//    into a gap of 5. Three bars that must descend and do not read as numbers
+//    that do not add up, and a reader who stops trusting those stops trusting
+//    the rest. So the page shows the 185 and the conversion, and says in
+//    `population.rounding` why the percentages do not divide back.
+//
+// 2. No soft-by-hard scatter. Crossing the two thresholds is the reading the
+//    section exists for, but the extract has four quadrant shares and two
+//    family means — two points is not a scatter, and drawing one implies a
+//    resolution that is not in the file. The 2x2 grid below carries the same
+//    four numbers without the implication.
+
+import { useMemo, useState, type ReactNode } from 'react';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
+import Footer from '@/components/Footer';
+import Navbar from '@/components/landing/Navbar';
+import { Reveal } from '@/components/ui/reveal';
+import DemoView from '@/components/demo/DemoView';
+import Chart from '@/components/demo/charts/Chart';
+import { salesNetwork } from '@/data/demo/sales-network';
+import { href } from '@/i18n/routes';
+
+const FAMILIES = Object.keys(salesNetwork.families);
+const BANDS = Object.keys(salesNetwork.bands);
+const QUADRANTS = Object.keys(salesNetwork.quadrants);
+
+/**
+ * The competencies and knowledge areas a family was assessed on.
+ *
+ * Neither list is the same for the two families — managers are measured on
+ * managing and accounts on selling — so the page reads them out of the data
+ * per family rather than holding one list and hoping every cell is filled.
+ */
+const keysFor = (source: Record<string, Record<string, number>>, family: string) =>
+  Object.keys(source).filter((k) => source[k][family] !== undefined);
+
+// Every hex here is already in the ALLOWED list of scripts/check-colors.mjs.
+const SERIES = ['#4B4DF7', '#FFAF64', '#5DDBA4', '#FF5656'];
+const GRID = 'rgba(255,255,255,0.06)';
+const TICK = 'rgba(255,255,255,0.45)';
+const AXIS = { grid: { color: GRID }, ticks: { color: TICK } };
+const axisTitle = (text: string) => ({ display: true, text, color: TICK });
+
+/** The recurring card. Local, because nothing outside this page has a second use for it. */
+function Panel({
+  title,
+  body,
+  note,
+  children,
+}: {
+  title: string;
+  body?: string;
+  note?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Reveal
+      as="section"
+      y={20}
+      duration={0.6}
+      className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-10"
+    >
+      <h2 className="text-[24px] md:text-[32px] font-semibold text-white/90 mb-3">{title}</h2>
+      {body ? (
+        <p className="text-[15px] text-white/[0.55] leading-[1.7] max-w-3xl mb-8">{body}</p>
+      ) : null}
+      {children}
+      {note ? (
+        <p className="text-[13px] text-white/40 leading-[1.7] max-w-3xl mt-6">{note}</p>
+      ) : null}
+    </Reveal>
+  );
+}
+
+export default function SalesNetworkDemo() {
+  const lang = useLocale();
+  // The namespace is the route id with '/' becoming '.', so it keeps the
+  // kebab: `demo/sales-network` is `demo.sales-network`.
+  const t = useTranslations('demo.sales-network');
+  const format = useFormatter();
+  const [family, setFamily] = useState(FAMILIES[0]);
+
+  // Formatting first, then interpolation: next-intl passes a numeric ICU
+  // argument through as-is, so `{covered}` would print "175" on the Italian
+  // page beside a "175" formatted for Italian by everything else.
+  const n = (value: number, digits = 1) =>
+    format.number(value, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+
+  const softKeys = keysFor(salesNetwork.soft, family);
+  const hardKeys = keysFor(salesNetwork.hard, family);
+  // The competency whose behaviours are open. Reset when it does not belong to
+  // the family just selected — every family has its own competencies, and one
+  // of them (decisionMaking) belongs to both.
+  const [openSkill, setOpenSkill] = useState(softKeys[0]);
+  const skill = softKeys.includes(openSkill) ? openSkill : softKeys[0];
+  const driverKeys = Object.keys(salesNetwork.drivers[skill] ?? {}).filter(
+    (d) => salesNetwork.drivers[skill][d][family] !== undefined,
+  );
+
+  const bands = useMemo(
+    () => ({
+      data: {
+        labels: BANDS.map((b) => t(`bands.items.${b}`)),
+        datasets: [
+          {
+            label: t('bands.series'),
+            data: BANDS.map((b) => salesNetwork.bands[b]),
+            backgroundColor: SERIES[0],
+            hoverBackgroundColor: '#7B7DF9',
+            borderRadius: 4,
+            maxBarThickness: 64,
+          },
+        ],
+      },
+      options: {
+        locale: lang,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { ...AXIS, grid: { display: false } },
+          y: { ...AXIS, beginAtZero: true, title: axisTitle(t('bands.axis')) },
+        },
+      },
+    }),
+    [t, lang],
+  );
+
+  // The three panels the family selector drives. Rebuilt together because they
+  // change together, and ChartCanvas compares its config by identity.
+  const profile = useMemo(() => {
+    const bar = (series: string, labels: string[], data: number[], colour: string) => ({
+      data: {
+        labels,
+        datasets: [
+          {
+            label: series,
+            data,
+            backgroundColor: colour,
+            borderRadius: 4,
+            maxBarThickness: 40,
+          },
+        ],
+      },
+      options: {
+        locale: lang,
+        indexAxis: 'y' as const,
+        plugins: { legend: { display: false } },
+        scales: {
+          // No maximum on either axis. The soft scores look like a five-point
+          // scale and the hard ones like a hundred-point one, but neither
+          // maximum is in the extract, and a fixed axis would be this page
+          // asserting a scale it cannot check.
+          x: { ...AXIS, beginAtZero: true },
+          y: { ...AXIS, grid: { display: false } },
+        },
+      },
+    });
+
+    return {
+      soft: bar(
+        t('profile.soft.series'),
+        softKeys.map((k) => t(`skills.${k}`)),
+        softKeys.map((k) => salesNetwork.soft[k][family]),
+        SERIES[0],
+      ),
+      hard: bar(
+        t('profile.hard.series'),
+        hardKeys.map((k) => t(`knowledge.${k}`)),
+        hardKeys.map((k) => salesNetwork.hard[k][family]),
+        SERIES[2],
+      ),
+      drivers: bar(
+        t('profile.drivers.series'),
+        driverKeys.map((d) => t(`drivers.${d}`)),
+        driverKeys.map((d) => salesNetwork.drivers[skill][d][family]),
+        SERIES[1],
+      ),
+    };
+    // `family` and `skill` are what the three lists are derived from; listing
+    // the derivations as well would say the same thing twice.
+  }, [t, lang, family, skill]);
+
+  const { funnel, overview } = salesNetwork;
+  const covered = FAMILIES.reduce((sum, f) => sum + salesNetwork.families[f].n, 0);
+
+  const headline: Array<{ id: string; value: string; args: Record<string, string> }> = [
+    {
+      id: 'assessed',
+      value: n(funnel.assessed, 0),
+      args: { candidates: n(funnel.candidates, 0), notAssessed: n(funnel.notAssessed, 0) },
+    },
+    { id: 'conversion', value: `${n(funnel.conversionPct, 0)}%`, args: {} },
+    { id: 'matchingMean', value: n(overview.skillMatchingMean), args: {} },
+    { id: 'matchingMedian', value: n(overview.skillMatchingMedian), args: {} },
+  ];
+
+  return (
+    <>
+      <DemoView slug="sales-network" />
+      <Navbar />
+      <main>
+        <section className="relative pt-[80px]">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-24">
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              className="text-[13px] font-semibold tracking-[0.18em] uppercase text-white/40 mb-6"
+            >
+              {t('hero.eyebrow')}
+            </Reveal>
+            <Reveal
+              as="h1"
+              y={40}
+              duration={0.8}
+              delay={0.1}
+              className="text-[40px] md:text-[56px] font-semibold tracking-[-0.02em] text-white/95 mb-8 max-w-4xl"
+              style={{ lineHeight: 1.15 }}
+            >
+              {t.rich('hero.heading', {
+                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+              })}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.8}
+              delay={0.2}
+              className="text-[18px] text-white/[0.65] leading-[1.75] max-w-3xl mb-8"
+              style={{ fontWeight: 300 }}
+            >
+              {t('hero.body')}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              delay={0.3}
+              className="text-[14px] text-white/40 leading-[1.7] max-w-2xl"
+            >
+              {t('hero.note')}
+            </Reveal>
+          </div>
+        </section>
+
+        <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 pb-24 lg:pb-32 flex flex-col gap-4 md:gap-6">
+          <Panel title={t('population.heading')} note={t('population.rounding')}>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+              {headline.map((s) => (
+                <div key={s.id}>
+                  <span
+                    className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {s.value}
+                  </span>
+                  <span className="block text-[14px] font-semibold text-white/80 mb-2">
+                    {t(`population.${s.id}.label`)}
+                  </span>
+                  <span className="block text-[13px] text-white/40 leading-[1.7]">
+                    {t(`population.${s.id}.note`, s.args)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel
+            title={t('bands.heading')}
+            body={t('bands.body')}
+            note={t('bands.caption')}
+          >
+            <Chart
+              className="h-[280px] md:h-[340px]"
+              type="bar"
+              ariaLabel={t('bands.ariaLabel')}
+              data={bands.data}
+              options={bands.options}
+            />
+          </Panel>
+
+          <Panel
+            title={t('families.heading')}
+            body={t('families.body')}
+            note={t('families.coverage', { covered: n(covered, 0), assessed: n(funnel.assessed, 0) })}
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {FAMILIES.map((f, i) => (
+                <div key={f} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+                  <span
+                    className="block h-1 w-8 rounded-full mb-4"
+                    style={{ backgroundColor: SERIES[i] }}
+                  />
+                  <span className="block text-[15px] font-semibold text-white/90 mb-4">
+                    {t(`families.names.${f}`)}
+                  </span>
+                  <dl className="flex flex-col gap-2">
+                    {[
+                      { id: 'people', value: n(salesNetwork.families[f].n, 0) },
+                      { id: 'skillMatching', value: n(salesNetwork.families[f].skillMatching) },
+                      { id: 'soft', value: n(salesNetwork.families[f].soft) },
+                      { id: 'hard', value: n(salesNetwork.families[f].hard) },
+                    ].map((row) => (
+                      <div key={row.id} className="flex items-baseline justify-between gap-4">
+                        <dt className="text-[13px] text-white/45">
+                          {t(`families.labels.${row.id}`)}
+                        </dt>
+                        <dd className="text-[14px] font-semibold text-white/85 tabular-nums">
+                          {row.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              ))}
+            </div>
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-6">{t('families.overlap')}</p>
+          </Panel>
+
+          <Panel title={t('profile.heading')} body={t('profile.body')}>
+            <div className="flex flex-wrap items-center gap-2 mb-8">
+              <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 mr-2">
+                {t('profile.label')}
+              </span>
+              {FAMILIES.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  aria-pressed={family === f}
+                  onClick={() => setFamily(f)}
+                  className={`px-4 py-2 md:px-5 md:py-2.5 rounded-full text-[13px] font-medium transition-all duration-300 ${
+                    family === f
+                      ? 'bg-white/[0.1] text-white border border-white/[0.15]'
+                      : 'text-white/40 border border-transparent hover:text-white/70'
+                  }`}
+                >
+                  {t(`families.names.${f}`)}
+                </button>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
+              <div>
+                <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+                  {t('profile.soft.heading')}
+                </h3>
+                <Chart
+                  className="h-[260px] md:h-[300px]"
+                  type="bar"
+                  ariaLabel={t('profile.soft.ariaLabel')}
+                  data={profile.soft.data}
+                  options={profile.soft.options}
+                />
+                <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+                  {t('profile.soft.caption')}
+                </p>
+              </div>
+              <div>
+                <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+                  {t('profile.hard.heading')}
+                </h3>
+                <Chart
+                  className="h-[260px] md:h-[300px]"
+                  type="bar"
+                  ariaLabel={t('profile.hard.ariaLabel')}
+                  data={profile.hard.data}
+                  options={profile.hard.options}
+                />
+                <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+                  {t('profile.hard.caption')}
+                </p>
+              </div>
+            </div>
+
+            <h3 className="text-[17px] font-semibold text-white/85 mt-10 mb-4">
+              {t('profile.drivers.heading')}
+            </h3>
+            <div className="flex flex-wrap items-center gap-2 mb-6">
+              <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 mr-2">
+                {t('profile.drivers.label')}
+              </span>
+              {softKeys.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  aria-pressed={skill === k}
+                  onClick={() => setOpenSkill(k)}
+                  className={`px-4 py-2 rounded-full text-[13px] font-medium transition-all duration-300 ${
+                    skill === k
+                      ? 'bg-white/[0.1] text-white border border-white/[0.15]'
+                      : 'text-white/40 border border-transparent hover:text-white/70'
+                  }`}
+                >
+                  {t(`skills.${k}`)}
+                </button>
+              ))}
+            </div>
+            <Chart
+              className="h-[280px] md:h-[340px]"
+              type="bar"
+              ariaLabel={t('profile.drivers.ariaLabel')}
+              data={profile.drivers.data}
+              options={profile.drivers.options}
+            />
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-6">
+              {t('profile.drivers.caption')}
+            </p>
+          </Panel>
+
+          <Panel
+            title={t('quadrants.heading')}
+            body={t('quadrants.body')}
+            note={t('quadrants.caption', {
+              soft: n(overview.softThreshold, 0),
+              hard: n(overview.hardThreshold, 0),
+            })}
+          >
+            {/* The 2x2 itself. Four numbers in the shape they mean, which is
+                what a scatter of two aggregate points could not have been. */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {QUADRANTS.map((q, i) => (
+                <div key={q} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+                  <span className="block text-[12px] text-white/35 mb-3">
+                    {t('quadrants.axisSoft')}{' '}
+                    {t(q.startsWith('softHigh') ? 'quadrants.high' : 'quadrants.low', {
+                      threshold: n(overview.softThreshold, 0),
+                    })}
+                    {' · '}
+                    {t('quadrants.axisHard')}{' '}
+                    {t(q.endsWith('HardHigh') ? 'quadrants.high' : 'quadrants.low', {
+                      threshold: n(overview.hardThreshold, 0),
+                    })}
+                  </span>
+                  <span
+                    className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {n(salesNetwork.quadrants[q])}%
+                  </span>
+                  <span
+                    className="block h-1 w-8 rounded-full mb-3"
+                    style={{ backgroundColor: SERIES[i] }}
+                  />
+                  <span className="block text-[15px] font-semibold text-white/90 mb-2">
+                    {t(`quadrants.items.${q}.name`)}
+                  </span>
+                  <p className="text-[13px] text-white/[0.55] leading-[1.7]">
+                    {t(`quadrants.items.${q}.description`)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel title={t('closing.heading')} body={t('closing.body')}>
+            <a
+              href={href('demo', lang)}
+              className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-4 py-2 text-[13px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
+            >
+              {t('closing.back')}
+            </a>
+          </Panel>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/[locale]/demo/sales-network/opengraph-image.tsx
+++ b/app/[locale]/demo/sales-network/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogFor } from '@/i18n/og-card';
+
+export { size, contentType } from '@/i18n/og-card';
+
+export function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'it' }];
+}
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return ogFor('demo/sales-network', locale);
+}

--- a/app/[locale]/demo/sales-network/page.tsx
+++ b/app/[locale]/demo/sales-network/page.tsx
@@ -1,0 +1,34 @@
+// The server half of this route. The page itself is body.tsx.
+//
+// Same shape as every other route, with `"noindex": true` on
+// `demo/sales-network` in i18n/routes.json doing the one thing that is
+// different: robots noindex/nofollow, and out of the sitemap. These pages
+// travel by link, one prospect at a time.
+import { NextIntlClientProvider } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+import { buildMetadata } from '@/i18n/metadata';
+import { messagesForRoute } from '@/i18n/messages';
+import JsonLd from '@/i18n/json-ld';
+import Body from './body';
+
+const ROUTE = 'demo/sales-network';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return buildMetadata(ROUTE, locale);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={await messagesForRoute(ROUTE, locale)}>
+      <JsonLd routeId={ROUTE} locale={locale} />
+      <Body />
+    </NextIntlClientProvider>
+  );
+}

--- a/data/demo/sales-network.ts
+++ b/data/demo/sales-network.ts
@@ -10,8 +10,9 @@
 //     as a name. The labels these keys stand for live in `messages/`.
 //   - every headcount is rounded to the nearest 5, so no count is a fingerprint.
 //   - a group carrying a score holds at least 25 people.
-//     One job family holds fewer than that and is not broken out, so the
-//     family headcounts do not sum to the assessed total.
+//     Two job families hold fewer than that and are not broken out — one
+//     merged, one suppressed — so the family headcounts do not sum to the
+//     assessed total. The page says so rather than leaving a reader to find it.
 //   - knowledge-area keys are renamed away from the sector the source names.
 
 export const salesNetwork = {

--- a/i18n/routes.json
+++ b/i18n/routes.json
@@ -253,6 +253,14 @@
     "noindex": true
   },
   {
+    "id": "demo/sales-network",
+    "paths": {
+      "en": "/demo/sales-network",
+      "it": "/demo/rete-vendita"
+    },
+    "noindex": true
+  },
+  {
     "id": "index",
     "paths": {
       "en": "/",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4870,7 +4870,7 @@
           "good": "Good",
           "high": "High"
         },
-        "caption": "The two middle bands hold most of the network. Nothing here says one band is a pass and another is a fail — the bands are the client's frame, and the shape is what a development budget is sized against."
+        "caption": "More than four in five sit in the two middle bands. Nothing here says one band is a pass and another a fail — the bands are the client's frame, and the shape is what a development budget is sized against."
       },
       "families": {
         "heading": "Two job families, two different jobs",
@@ -4962,7 +4962,7 @@
       },
       "quadrants": {
         "heading": "Behaviour and knowledge, crossed",
-        "body": "Each person clears the soft skill bar, the technical one, both or neither. Crossing the two is the reading the whole programme exists for: the same average score means four different interventions depending on which side of each line it sits.",
+        "body": "Each person clears the behavioural bar, the technical one, both or neither. The two bars turn out to do very different work: {hardCleared}% are over the technical one and {softCleared}% over the behavioural one, so almost the whole network has the technical ground and behaviour is what separates it.",
         "axisSoft": "Soft skills",
         "axisHard": "Technical knowledge",
         "high": "at or above {threshold}",
@@ -4970,22 +4970,22 @@
         "items": {
           "softHighHardHigh": {
             "name": "Ready on both",
-            "description": "Clears both bars. Half the network, and the group a programme should be learning from rather than teaching."
+            "description": "Over both bars. Because almost everyone is over the technical one, this is in practice the half of the network that is over the behavioural one — read it as a behavioural result, not as a double distinction."
           },
           "softHighHardLow": {
             "name": "Behaviour ahead of knowledge",
-            "description": "The behaviours are there and the technical ground is not. The smallest group, and the cheapest to close: knowledge is what training is actually good at."
+            "description": "The behaviours are there and the technical ground is not. The smallest group by a distance, which is the same fact as the technical bar being cleared by almost everyone."
           },
           "softLowHardHigh": {
             "name": "Knowledge ahead of behaviour",
-            "description": "Knows the material, does not yet show the behaviours in front of a customer. The large group, and the slow one — this is coaching and field work, not a course."
+            "description": "Knows the material, does not yet show the behaviours in front of a customer. The other large group, and the slow one — this is coaching and field work, not a course."
           },
           "softLowHardLow": {
             "name": "Below both",
             "description": "Under both bars. Small enough to handle one conversation at a time rather than with a programme."
           }
         },
-        "caption": "The two bars are the client's, not ours: soft skills at {soft} and technical knowledge at {hard}. Move either line and these four numbers move with it, which is the point of showing where the lines are instead of only what falls each side."
+        "caption": "The two bars are the client's, not ours: behaviour at {soft} and technical knowledge at {hard}. Where a bar sits decides what it can tell you — this technical one is cleared by almost everyone, so it sorts nobody, and the reading worth having is the behavioural one. Move either line and these four numbers move with it."
       },
       "closing": {
         "heading": "How this page was made",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4974,7 +4974,7 @@
           },
           "softHighHardLow": {
             "name": "Behaviour ahead of knowledge",
-            "description": "The behaviours are there and the technical ground is not. The smallest group by a distance, which is the same fact as the technical bar being cleared by almost everyone."
+            "description": "The behaviours are there and the technical ground is not. The smallest group, which is the same fact as the technical bar being cleared by almost everyone."
           },
           "softLowHardHigh": {
             "name": "Knowledge ahead of behaviour",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4826,6 +4826,172 @@
         "body": "Every number here is a group statistic, computed once outside this website from data that never entered it. Headcounts are rounded to the nearest five, no group carrying a score holds fewer than 25 people, and the areas are numbered rather than named. There is no store table, no ranking and no individual record — not hidden, absent.",
         "back": "Back to the demo dashboards"
       }
+    },
+    "sales-network": {
+      "meta": {
+        "title": "Sales network readiness — demo dashboard | Skillvue",
+        "description": "A sales network assessed on soft skills and technical knowledge at once, read by job family, competency and behavioural driver. Aggregates only: every individual record removed."
+      },
+      "hero": {
+        "eyebrow": "Interactive demo · Telco",
+        "heading": "Two questions asked at once: <span>can they, and do they</span>",
+        "body": "A sales network measured on behaviour and on technical knowledge in the same programme, so that the two answers can be read against each other instead of one at a time. What follows is where the network sits on both, and what the split looks like once you stop averaging it.",
+        "note": "Aggregates only. No person and no individual record is on this page: every figure is a group statistic, computed once outside this website."
+      },
+      "population": {
+        "heading": "What was measured",
+        "assessed": {
+          "label": "People assessed",
+          "note": "Out of {candidates} in scope. The remaining {notAssessed} did not complete the assessment."
+        },
+        "conversion": {
+          "label": "Assessment conversion",
+          "note": "As the programme reported it. It is not the ratio of the two headcounts beside it — see the note below."
+        },
+        "matchingMean": {
+          "label": "Mean skill matching",
+          "note": "How closely the population matches the competency profile its roles were mapped to."
+        },
+        "matchingMedian": {
+          "label": "Median skill matching",
+          "note": "Within half a point of the mean, so the distribution has no long tail dragging it."
+        },
+        "rounding": "Headcounts here are rounded to the nearest five, so that no count identifies anyone. The percentages are computed on the real population — divide them back into the figures beside them and they will not come out."
+      },
+      "bands": {
+        "heading": "Where the network sits",
+        "body": "Skill matching split into four bands. More than nine in ten sit at base or above, and the question a programme has to answer is which of the two middle bands it is buying movement in.",
+        "series": "Share of the population",
+        "axis": "% of the assessed",
+        "ariaLabel": "Bar chart of the share of the assessed population in each skill matching band",
+        "items": {
+          "belowThreshold": "Below threshold",
+          "base": "Base",
+          "good": "Good",
+          "high": "High"
+        },
+        "caption": "The two middle bands hold most of the network. Nothing here says one band is a pass and another is a fail — the bands are the client's frame, and the shape is what a development budget is sized against."
+      },
+      "families": {
+        "heading": "Two job families, two different jobs",
+        "body": "Managers and accounts were not assessed on the same competencies, and that is not a gap in the data — it is the frame. Almost nothing overlaps, so the two columns below are two profiles, not two scores on one scale.",
+        "names": {
+          "salesManager": "Sales manager",
+          "salesAccount": "Sales account"
+        },
+        "labels": {
+          "people": "People",
+          "skillMatching": "Skill matching",
+          "soft": "Soft skills",
+          "hard": "Technical knowledge"
+        },
+        "coverage": "These two families hold {covered} of the {assessed} people assessed. The rest sit in families too small to publish on their own — below the twenty-five-person floor every figure here obeys — so they are inside every total on this page and broken out in none of them.",
+        "overlap": "Exactly one soft skill was measured on both families, and two of the knowledge areas. That is why there is no single ranking of the two."
+      },
+      "profile": {
+        "heading": "The profile, family by family",
+        "body": "Pick a family and the three panels redraw: its soft skills, its technical knowledge areas, and the behaviours underneath whichever competency you open.",
+        "label": "Job family",
+        "soft": {
+          "heading": "Soft skills",
+          "series": "Average score",
+          "ariaLabel": "Bar chart of the average score on each soft skill for the selected job family",
+          "caption": "The average of these is the family's soft skill score in the table above."
+        },
+        "hard": {
+          "heading": "Technical knowledge",
+          "series": "Average score",
+          "ariaLabel": "Bar chart of the average score on each technical knowledge area for the selected job family",
+          "caption": "Knowledge areas are named for what they test, not for the sector the client works in."
+        },
+        "drivers": {
+          "heading": "What sits underneath",
+          "label": "Competency",
+          "series": "Average score",
+          "ariaLabel": "Bar chart of the average score on each behavioural driver of the selected competency",
+          "caption": "Each competency is scored from several observed behaviours, and they do not move together: inside a single competency the behaviours can sit more than a point apart, which that competency's own average hides. This is the level a development plan is actually written at."
+        }
+      },
+      "skills": {
+        "strategicThinking": "Strategic thinking",
+        "teamManagement": "Team management",
+        "engageInspire": "Engage and inspire",
+        "decisionMaking": "Decision making",
+        "influence": "Influence",
+        "resilience": "Resilience",
+        "drive": "Drive"
+      },
+      "knowledge": {
+        "referenceMarket": "Reference market",
+        "partnerManagement": "Partner management",
+        "offeringPositioning": "Offering and positioning",
+        "networkProfitability": "Network profitability",
+        "technicalDomainKnowledge": "Technical domain knowledge",
+        "complexNegotiation": "Complex negotiation",
+        "marketSegmentation": "Market segmentation",
+        "complexSellingTechniques": "Complex selling techniques"
+      },
+      "drivers": {
+        "workWithEnthusiasm": "Works with enthusiasm",
+        "pursuePersonalDevelopment": "Pursues personal development",
+        "showAmbition": "Shows ambition",
+        "anticipateDevelopments": "Anticipates developments",
+        "alignStrategies": "Aligns strategies",
+        "defineTheVision": "Defines the vision",
+        "validateStrategies": "Validates strategies",
+        "coordinateAction": "Coordinates action",
+        "delegate": "Delegates",
+        "takeDecisions": "Takes decisions",
+        "takeResponsibility": "Takes responsibility",
+        "crossFunctionalAwareness": "Works across functions",
+        "superviseBehaviour": "Supervises behaviour",
+        "coaching": "Coaches",
+        "valuePeople": "Values people",
+        "motivatePeople": "Motivates people",
+        "developPeople": "Develops people",
+        "spotTalent": "Spots talent",
+        "executePlans": "Executes plans",
+        "actWithConfidence": "Acts with confidence",
+        "actOnOwnInitiative": "Acts on own initiative",
+        "haveImpact": "Has impact",
+        "frameConversations": "Frames the conversation",
+        "appealToEmotions": "Appeals to emotions",
+        "handlePressure": "Handles pressure",
+        "balanceWorkAndLife": "Balances work and life",
+        "stayPositive": "Stays positive"
+      },
+      "quadrants": {
+        "heading": "Behaviour and knowledge, crossed",
+        "body": "Each person clears the soft skill bar, the technical one, both or neither. Crossing the two is the reading the whole programme exists for: the same average score means four different interventions depending on which side of each line it sits.",
+        "axisSoft": "Soft skills",
+        "axisHard": "Technical knowledge",
+        "high": "at or above {threshold}",
+        "low": "below {threshold}",
+        "items": {
+          "softHighHardHigh": {
+            "name": "Ready on both",
+            "description": "Clears both bars. Half the network, and the group a programme should be learning from rather than teaching."
+          },
+          "softHighHardLow": {
+            "name": "Behaviour ahead of knowledge",
+            "description": "The behaviours are there and the technical ground is not. The smallest group, and the cheapest to close: knowledge is what training is actually good at."
+          },
+          "softLowHardHigh": {
+            "name": "Knowledge ahead of behaviour",
+            "description": "Knows the material, does not yet show the behaviours in front of a customer. The large group, and the slow one — this is coaching and field work, not a course."
+          },
+          "softLowHardLow": {
+            "name": "Below both",
+            "description": "Under both bars. Small enough to handle one conversation at a time rather than with a programme."
+          }
+        },
+        "caption": "The two bars are the client's, not ours: soft skills at {soft} and technical knowledge at {hard}. Move either line and these four numbers move with it, which is the point of showing where the lines are instead of only what falls each side."
+      },
+      "closing": {
+        "heading": "How this page was made",
+        "body": "Every number here is a group statistic, computed once outside this website from data that never entered it. Headcounts are rounded to the nearest five, no group carrying a score holds fewer than twenty-five people, and the knowledge areas are named for what they test rather than for the client's sector. The source dashboard has a participant table with a first name and a surname in it; there is nothing of that kind here, in any form.",
+        "back": "Back to the demo dashboards"
+      }
     }
   },
   "home": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4974,7 +4974,7 @@
           },
           "softHighHardLow": {
             "name": "Comportamento avanti alla conoscenza",
-            "description": "I comportamenti ci sono, la base tecnica no. È di gran lunga il gruppo più piccolo, che è poi lo stesso fatto della soglia tecnica superata da quasi tutti."
+            "description": "I comportamenti ci sono, la base tecnica no. È il gruppo più piccolo, che è poi lo stesso fatto della soglia tecnica superata da quasi tutti."
           },
           "softLowHardHigh": {
             "name": "Conoscenza avanti al comportamento",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4826,6 +4826,172 @@
         "body": "Ogni numero qui è una statistica di gruppo, calcolata una volta fuori da questo sito su dati che in questo sito non sono mai entrati. Gli headcount sono arrotondati al multiplo di cinque, nessun gruppo che porta un punteggio contiene meno di 25 persone, e le aree sono numerate invece che nominate. Non c’è nessuna tabella dei negozi, nessuna classifica e nessun record individuale — non nascosti, assenti.",
         "back": "Torna alle dashboard demo"
       }
+    },
+    "sales-network": {
+      "meta": {
+        "title": "Prontezza della rete vendita — dashboard demo | Skillvue",
+        "description": "Una rete vendita valutata insieme su soft skill e conoscenze tecniche, letta per famiglia professionale, competenza e driver comportamentale. Solo aggregati: nessun dato individuale."
+      },
+      "hero": {
+        "eyebrow": "Demo interattiva · Telco",
+        "heading": "Due domande insieme: <span>sanno farlo, e lo fanno</span>",
+        "body": "Una rete vendita misurata sul comportamento e sulle conoscenze tecniche nello stesso programma, così che le due risposte si possano leggere una contro l’altra invece che una per volta. Quello che segue è dove sta la rete su entrambe, e che forma ha la divisione quando si smette di fare medie.",
+        "note": "Solo aggregati. Su questa pagina non c’è nessuna persona e nessun record individuale: ogni cifra è una statistica di gruppo, calcolata una volta fuori da questo sito."
+      },
+      "population": {
+        "heading": "Che cosa è stato misurato",
+        "assessed": {
+          "label": "Persone valutate",
+          "note": "Su {candidates} nel perimetro. Le altre {notAssessed} non hanno completato l’assessment."
+        },
+        "conversion": {
+          "label": "Conversione dell’assessment",
+          "note": "Come l’ha riportata il programma. Non è il rapporto fra i due headcount qui accanto — vedi la nota sotto."
+        },
+        "matchingMean": {
+          "label": "Skill matching medio",
+          "note": "Quanto la popolazione aderisce al profilo di competenze su cui i suoi ruoli sono stati mappati."
+        },
+        "matchingMedian": {
+          "label": "Skill matching mediano",
+          "note": "A meno di mezzo punto dalla media: la distribuzione non ha una coda lunga che la tira da una parte."
+        },
+        "rounding": "Gli headcount qui sono arrotondati al multiplo di cinque, perché nessun conteggio identifichi qualcuno. Le percentuali invece sono calcolate sulla popolazione reale: se le si divide per le cifre qui accanto non tornano."
+      },
+      "bands": {
+        "heading": "Dove sta la rete",
+        "body": "Lo skill matching diviso in quattro fasce. Più di nove su dieci stanno da «base» in su, e la domanda a cui un programma deve rispondere è in quale delle due fasce centrali sta comprando movimento.",
+        "series": "Quota della popolazione",
+        "axis": "% dei valutati",
+        "ariaLabel": "Grafico a barre della quota di popolazione valutata in ciascuna fascia di skill matching",
+        "items": {
+          "belowThreshold": "Sotto soglia",
+          "base": "Base",
+          "good": "Buono",
+          "high": "Alto"
+        },
+        "caption": "Le due fasce centrali tengono quasi tutta la rete. Niente qui dice che una fascia sia promossa e un’altra bocciata — le fasce sono lo schema del cliente, e la forma è ciò su cui si dimensiona un budget di sviluppo."
+      },
+      "families": {
+        "heading": "Due famiglie professionali, due mestieri diversi",
+        "body": "Manager e account non sono stati valutati sulle stesse competenze, e non è un buco nei dati: è lo schema. Quasi nulla si sovrappone, quindi le due colonne qui sotto sono due profili, non due punteggi sulla stessa scala.",
+        "names": {
+          "salesManager": "Sales manager",
+          "salesAccount": "Sales account"
+        },
+        "labels": {
+          "people": "Persone",
+          "skillMatching": "Skill matching",
+          "soft": "Soft skill",
+          "hard": "Conoscenze tecniche"
+        },
+        "coverage": "Queste due famiglie tengono {covered} delle {assessed} persone valutate. Le altre stanno in famiglie troppo piccole per essere pubblicate da sole — sotto la soglia di venticinque persone che ogni cifra qui rispetta — quindi sono dentro tutti i totali di questa pagina e spacchettate in nessuno.",
+        "overlap": "Una sola soft skill è stata misurata su entrambe le famiglie, e due delle aree di conoscenza. È per questo che non esiste una classifica unica delle due."
+      },
+      "profile": {
+        "heading": "Il profilo, famiglia per famiglia",
+        "body": "Scegli una famiglia e i tre pannelli si ridisegnano: le sue soft skill, le sue aree di conoscenza tecnica, e i comportamenti sotto la competenza che apri.",
+        "label": "Famiglia professionale",
+        "soft": {
+          "heading": "Soft skill",
+          "series": "Punteggio medio",
+          "ariaLabel": "Grafico a barre del punteggio medio di ciascuna soft skill per la famiglia professionale selezionata",
+          "caption": "La media di queste è il punteggio soft skill della famiglia nella tabella qui sopra."
+        },
+        "hard": {
+          "heading": "Conoscenze tecniche",
+          "series": "Punteggio medio",
+          "ariaLabel": "Grafico a barre del punteggio medio di ciascuna area di conoscenza tecnica per la famiglia professionale selezionata",
+          "caption": "Le aree di conoscenza sono nominate per quello che misurano, non per il settore in cui lavora il cliente."
+        },
+        "drivers": {
+          "heading": "Che cosa c’è sotto",
+          "label": "Competenza",
+          "series": "Punteggio medio",
+          "ariaLabel": "Grafico a barre del punteggio medio di ciascun driver comportamentale della competenza selezionata",
+          "caption": "Ogni competenza è misurata da più comportamenti osservati, e non si muovono insieme: dentro una stessa competenza i comportamenti possono stare a più di un punto di distanza, cosa che la media della competenza nasconde. È il livello a cui un piano di sviluppo si scrive davvero."
+        }
+      },
+      "skills": {
+        "strategicThinking": "Pensiero strategico",
+        "teamManagement": "Gestione del team",
+        "engageInspire": "Coinvolgere e ispirare",
+        "decisionMaking": "Capacità decisionale",
+        "influence": "Influenza",
+        "resilience": "Resilienza",
+        "drive": "Spinta personale"
+      },
+      "knowledge": {
+        "referenceMarket": "Mercato di riferimento",
+        "partnerManagement": "Gestione dei partner",
+        "offeringPositioning": "Offerta e posizionamento",
+        "networkProfitability": "Redditività della rete",
+        "technicalDomainKnowledge": "Conoscenza tecnica di dominio",
+        "complexNegotiation": "Negoziazione complessa",
+        "marketSegmentation": "Segmentazione del mercato",
+        "complexSellingTechniques": "Tecniche di vendita complessa"
+      },
+      "drivers": {
+        "workWithEnthusiasm": "Lavora con entusiasmo",
+        "pursuePersonalDevelopment": "Cerca la propria crescita",
+        "showAmbition": "Mostra ambizione",
+        "anticipateDevelopments": "Anticipa gli sviluppi",
+        "alignStrategies": "Allinea le strategie",
+        "defineTheVision": "Definisce la visione",
+        "validateStrategies": "Valida le strategie",
+        "coordinateAction": "Coordina l’azione",
+        "delegate": "Delega",
+        "takeDecisions": "Prende decisioni",
+        "takeResponsibility": "Si prende la responsabilità",
+        "crossFunctionalAwareness": "Lavora fra funzioni diverse",
+        "superviseBehaviour": "Vigila sui comportamenti",
+        "coaching": "Fa coaching",
+        "valuePeople": "Dà valore alle persone",
+        "motivatePeople": "Motiva le persone",
+        "developPeople": "Fa crescere le persone",
+        "spotTalent": "Riconosce il talento",
+        "executePlans": "Esegue i piani",
+        "actWithConfidence": "Agisce con sicurezza",
+        "actOnOwnInitiative": "Agisce di propria iniziativa",
+        "haveImpact": "Ha impatto",
+        "frameConversations": "Imposta la conversazione",
+        "appealToEmotions": "Fa leva sulle emozioni",
+        "handlePressure": "Regge la pressione",
+        "balanceWorkAndLife": "Tiene insieme lavoro e vita",
+        "stayPositive": "Resta positivo"
+      },
+      "quadrants": {
+        "heading": "Comportamento e conoscenza, incrociati",
+        "body": "Ogni persona supera la soglia soft, quella tecnica, tutte e due o nessuna. Incrociarle è la lettura per cui esiste tutto il programma: lo stesso punteggio medio vuol dire quattro interventi diversi a seconda da che parte di ciascuna linea cade.",
+        "axisSoft": "Soft skill",
+        "axisHard": "Conoscenze tecniche",
+        "high": "da {threshold} in su",
+        "low": "sotto {threshold}",
+        "items": {
+          "softHighHardHigh": {
+            "name": "Pronti su entrambi",
+            "description": "Superano tutte e due le soglie. Metà della rete, ed è il gruppo da cui un programma dovrebbe imparare invece che quello a cui insegnare."
+          },
+          "softHighHardLow": {
+            "name": "Comportamento avanti alla conoscenza",
+            "description": "I comportamenti ci sono, la base tecnica no. È il gruppo più piccolo, ed è il più economico da chiudere: la conoscenza è ciò in cui la formazione funziona davvero."
+          },
+          "softLowHardHigh": {
+            "name": "Conoscenza avanti al comportamento",
+            "description": "Sanno la materia, ma davanti al cliente i comportamenti non si vedono ancora. È il gruppo grande, ed è quello lento: qui servono coaching e affiancamento, non un corso."
+          },
+          "softLowHardLow": {
+            "name": "Sotto entrambe",
+            "description": "Sotto tutte e due le soglie. Abbastanza pochi da gestirli una conversazione alla volta invece che con un programma."
+          }
+        },
+        "caption": "Le due soglie sono del cliente, non nostre: soft skill a {soft} e conoscenze tecniche a {hard}. Sposta una delle due linee e questi quattro numeri si spostano con lei, che è il motivo per cui mostriamo dove sono le linee e non solo che cosa cade da ciascuna parte."
+      },
+      "closing": {
+        "heading": "Come è fatta questa pagina",
+        "body": "Ogni numero qui è una statistica di gruppo, calcolata una volta fuori da questo sito su dati che in questo sito non sono mai entrati. Gli headcount sono arrotondati al multiplo di cinque, nessun gruppo che porta un punteggio contiene meno di venticinque persone, e le aree di conoscenza sono nominate per quello che misurano invece che per il settore del cliente. La dashboard di origine ha una tabella partecipanti con nome e cognome dentro; qui non c’è nulla del genere, in nessuna forma.",
+        "back": "Torna alle dashboard demo"
+      }
     }
   },
   "home": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4870,7 +4870,7 @@
           "good": "Buono",
           "high": "Alto"
         },
-        "caption": "Le due fasce centrali tengono quasi tutta la rete. Niente qui dice che una fascia sia promossa e un’altra bocciata — le fasce sono lo schema del cliente, e la forma è ciò su cui si dimensiona un budget di sviluppo."
+        "caption": "Più di quattro su cinque stanno nelle due fasce centrali. Niente qui dice che una fascia sia promossa e un’altra bocciata — le fasce sono lo schema del cliente, e la forma è ciò su cui si dimensiona un budget di sviluppo."
       },
       "families": {
         "heading": "Due famiglie professionali, due mestieri diversi",
@@ -4962,7 +4962,7 @@
       },
       "quadrants": {
         "heading": "Comportamento e conoscenza, incrociati",
-        "body": "Ogni persona supera la soglia soft, quella tecnica, tutte e due o nessuna. Incrociarle è la lettura per cui esiste tutto il programma: lo stesso punteggio medio vuol dire quattro interventi diversi a seconda da che parte di ciascuna linea cade.",
+        "body": "Ogni persona supera la soglia comportamentale, quella tecnica, tutte e due o nessuna. Le due soglie fanno un lavoro molto diverso: il {hardCleared}% è sopra quella tecnica e il {softCleared}% sopra quella comportamentale, quindi la base tecnica ce l’ha quasi tutta la rete e ciò che la separa è il comportamento.",
         "axisSoft": "Soft skill",
         "axisHard": "Conoscenze tecniche",
         "high": "da {threshold} in su",
@@ -4970,22 +4970,22 @@
         "items": {
           "softHighHardHigh": {
             "name": "Pronti su entrambi",
-            "description": "Superano tutte e due le soglie. Metà della rete, ed è il gruppo da cui un programma dovrebbe imparare invece che quello a cui insegnare."
+            "description": "Sopra entrambe le soglie. Siccome quella tecnica la supera quasi chiunque, in pratica è la metà di rete che sta sopra quella comportamentale: va letto come un risultato di comportamento, non come una doppia eccellenza."
           },
           "softHighHardLow": {
             "name": "Comportamento avanti alla conoscenza",
-            "description": "I comportamenti ci sono, la base tecnica no. È il gruppo più piccolo, ed è il più economico da chiudere: la conoscenza è ciò in cui la formazione funziona davvero."
+            "description": "I comportamenti ci sono, la base tecnica no. È di gran lunga il gruppo più piccolo, che è poi lo stesso fatto della soglia tecnica superata da quasi tutti."
           },
           "softLowHardHigh": {
             "name": "Conoscenza avanti al comportamento",
-            "description": "Sanno la materia, ma davanti al cliente i comportamenti non si vedono ancora. È il gruppo grande, ed è quello lento: qui servono coaching e affiancamento, non un corso."
+            "description": "Sanno la materia, ma davanti al cliente i comportamenti non si vedono ancora. È l’altro gruppo grande, ed è quello lento: qui servono coaching e affiancamento, non un corso."
           },
           "softLowHardLow": {
             "name": "Sotto entrambe",
             "description": "Sotto tutte e due le soglie. Abbastanza pochi da gestirli una conversazione alla volta invece che con un programma."
           }
         },
-        "caption": "Le due soglie sono del cliente, non nostre: soft skill a {soft} e conoscenze tecniche a {hard}. Sposta una delle due linee e questi quattro numeri si spostano con lei, che è il motivo per cui mostriamo dove sono le linee e non solo che cosa cade da ciascuna parte."
+        "caption": "Le due soglie sono del cliente, non nostre: comportamento a {soft} e conoscenze tecniche a {hard}. Dove sta una soglia decide che cosa può dirti — questa tecnica la supera quasi chiunque, quindi non separa nessuno, e la lettura che serve è quella comportamentale. Sposta una delle due linee e questi quattro numeri si spostano con lei."
       },
       "closing": {
         "heading": "Come è fatta questa pagina",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:demo-event": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-event.mjs",
     "check:demo-anonymity": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-anonymity.mjs",
     "check:demo-retail": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-retail.mjs",
+    "check:demo-sales-network": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-sales-network.mjs",
     "test:smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {

--- a/scripts/check-demo-sales-network.mjs
+++ b/scripts/check-demo-sales-network.mjs
@@ -360,7 +360,14 @@ assert.ok(
     'network has the technical ground.',
 );
 
+// Two lines, because they are two mechanisms with two different powers and one
+// combined number would read as a quality measure it is not. The digest catches
+// every value and knows nothing about what any of them means; the rules below it
+// catch only what the copy claims, and are the half that can say which sentence
+// a refreshed extract broke. Reported together, "everything is covered" is what
+// a reader takes away — and the semantic half is far weaker than that.
+console.log(`[OK] demo sales network: extract pinned by digest (every value, no meaning)`);
 console.log(
   `[OK] demo sales network: ${SOFT.length + HARD.length + DRIVERS.length} composed labels across ` +
-    `${FAMILIES.length} families, and every copy claim still true of the data`,
+    `${FAMILIES.length} families, and every claim the copy makes still true of the data`,
 );

--- a/scripts/check-demo-sales-network.mjs
+++ b/scripts/check-demo-sales-network.mjs
@@ -1,0 +1,317 @@
+// check-demo-sales-network — the sales network dashboard's labels exist, and
+// its copy still describes the data underneath it.
+//
+// Same two gaps as check-demo-retail, and the same reason for closing them.
+//
+// Every label on that page is fetched with a composed key — t(`skills.${k}`),
+// t(`drivers.${d}`), t(`quadrants.items.${q}.name`) — and check:i18n only reads
+// string literals, so none of them is checked by anything else. The ids come
+// from the data and are matched against both catalogues in both directions.
+//
+// And the page argues about its own numbers: that more than nine in ten sit at
+// base or above, that one soft skill and two knowledge areas are shared between
+// the families, that a family's soft score is the average of its own
+// competencies, that the behaviours inside one competency spread more than a
+// point. Each of those is asserted against the figure it describes, derived
+// from the data rather than copied out of it, so a refreshed extract cannot
+// leave a sentence on the page mentioning a number that has moved.
+//
+// Run: npm run check:demo-sales-network
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { salesNetwork: sn } = await import(
+  pathToFileURL(join(ROOT, 'data/demo/sales-network.ts')).href
+);
+
+const catalogues = Object.fromEntries(
+  ['en', 'it'].map((l) => [
+    l,
+    JSON.parse(readFileSync(join(ROOT, `messages/${l}.json`), 'utf8')).demo['sales-network'],
+  ]),
+);
+
+const at = (catalogue, path) =>
+  path.split('.').reduce((node, seg) => (node == null ? undefined : node[seg]), catalogue);
+
+const missing = [];
+const label = (path) => {
+  for (const locale of ['en', 'it']) {
+    if (typeof at(catalogues[locale], path) !== 'string') {
+      missing.push(`  ${locale}: demo.sales-network.${path}`);
+    }
+  }
+};
+
+const FAMILIES = Object.keys(sn.families);
+const SOFT = Object.keys(sn.soft);
+const HARD = Object.keys(sn.hard);
+const DRIVERS = [...new Set(Object.values(sn.drivers).flatMap((d) => Object.keys(d)))];
+
+// ── Every composed key the page builds ─────────────────────────────────────
+for (const f of FAMILIES) label(`families.names.${f}`);
+for (const row of ['people', 'skillMatching', 'soft', 'hard']) label(`families.labels.${row}`);
+for (const b of Object.keys(sn.bands)) label(`bands.items.${b}`);
+for (const s of SOFT) label(`skills.${s}`);
+for (const h of HARD) label(`knowledge.${h}`);
+for (const d of DRIVERS) label(`drivers.${d}`);
+for (const q of Object.keys(sn.quadrants)) {
+  label(`quadrants.items.${q}.name`);
+  label(`quadrants.items.${q}.description`);
+}
+for (const card of ['assessed', 'conversion', 'matchingMean', 'matchingMedian']) {
+  label(`population.${card}.label`);
+  label(`population.${card}.note`);
+}
+// The quadrant cells pick their side of each threshold with a ternary inside
+// t(), which check:i18n cannot read either.
+for (const key of ['quadrants.high', 'quadrants.low', 'quadrants.axisSoft', 'quadrants.axisHard']) {
+  label(key);
+}
+for (const panel of ['soft', 'hard', 'drivers']) {
+  label(`profile.${panel}.series`);
+  label(`profile.${panel}.ariaLabel`);
+}
+
+assert.deepEqual(
+  missing,
+  [],
+  `${missing.length} label(s) the page composes have no message:\n${missing.join('\n')}\n` +
+    'next-intl renders the key path when a key is missing, so this ships as literal ' +
+    '"skills.strategicThinking" where the bar\'s name should be.',
+);
+
+// The other direction: a label for a competency, area or behaviour the extract
+// no longer holds is copy that renders nowhere and still asks to be translated.
+const stale = [
+  ...Object.keys(catalogues.en.skills).filter((k) => !SOFT.includes(k)).map((k) => `  skills.${k}`),
+  ...Object.keys(catalogues.en.knowledge).filter((k) => !HARD.includes(k)).map((k) => `  knowledge.${k}`),
+  ...Object.keys(catalogues.en.drivers).filter((k) => !DRIVERS.includes(k)).map((k) => `  drivers.${k}`),
+];
+assert.deepEqual(stale, [], `Labels with nothing behind them:\n${stale.join('\n')}`);
+
+// ── The shape the page's controls are built on ─────────────────────────────
+// The family selector redraws three panels from per-family lists. A family with
+// no competencies, or a competency with no behaviours under it, is an empty
+// chart rather than a missing one — nothing else would say so.
+const keysFor = (source, family) => Object.keys(source).filter((k) => source[k][family] !== undefined);
+for (const family of FAMILIES) {
+  const soft = keysFor(sn.soft, family);
+  const hard = keysFor(sn.hard, family);
+  assert.ok(soft.length > 0, `family ${family} has no soft skills — the panel would draw empty.`);
+  assert.ok(hard.length > 0, `family ${family} has no knowledge areas.`);
+  for (const skill of soft) {
+    const drivers = Object.keys(sn.drivers[skill] ?? {}).filter((d) => sn.drivers[skill][d][family] !== undefined);
+    assert.ok(
+      drivers.length > 0,
+      `${family}/${skill} is selectable in the competency pills but has no behaviours under it.`,
+    );
+  }
+}
+
+// ── Shares are shares ──────────────────────────────────────────────────────
+const sums = (name, values) => {
+  const total = values.reduce((a, b) => a + b, 0);
+  assert.ok(Math.abs(total - 100) <= 0.5, `${name} sums to ${total}, not 100.`);
+};
+sums('bands', Object.values(sn.bands));
+sums('quadrants', Object.values(sn.quadrants));
+
+// ── The scales hold ────────────────────────────────────────────────────────
+// Four structural rules, all of them things the page draws rather than says.
+// They exist because a mutation test over every number in the extract found
+// them uncovered: 37 of 76 single-number mutations left the gate green, and
+// most of them were a bar drawn three times the height of its neighbours.
+
+// A percentage is a percentage. `conversionPct` in particular is asserted
+// nowhere else, on purpose — it is not the ratio of the rounded headcounts
+// beside it — but it is still printed with a % sign after it.
+for (const [name, value] of [
+  ['funnel.conversionPct', sn.funnel.conversionPct],
+  ['overview.aboveBothPct', sn.overview.aboveBothPct],
+  ...Object.entries(sn.bands).map(([k, v]) => [`bands.${k}`, v]),
+  ...Object.entries(sn.quadrants).map(([k, v]) => [`quadrants.${k}`, v]),
+]) {
+  assert.ok(value >= 0 && value <= 100, `${name} is ${value}, which the page prints as a percent.`);
+}
+
+// Skill matching is a 0-100 score, printed bare rather than with a % sign, and
+// the network mean is bracketed by the families below — so raising one family
+// on its own only widens the bracket and slips through that check.
+for (const [name, value] of [
+  ['overview.skillMatchingMean', sn.overview.skillMatchingMean],
+  ['overview.skillMatchingMedian', sn.overview.skillMatchingMedian],
+  ...FAMILIES.map((f) => [`families.${f}.skillMatching`, sn.families[f].skillMatching]),
+]) {
+  assert.ok(value >= 0 && value <= 100, `${name} is ${value}, off the 0-100 skill matching scale.`);
+}
+
+// A competency's score is an aggregate of its own behaviours, so it tracks
+// their mean. Not equal to it — the aggregate is weighted, and across the eight
+// competencies here the score runs up to 0.23 under the plain mean — but a
+// behaviour that wanders off the scale drags the mean away from the score it
+// belongs to, and that is what keeps one bar from being drawn three times the
+// height of the chart it shares. Asserting the range instead would only catch
+// a behaviour moving inward, which is the half that does not distort anything.
+const DRIVER_TOLERANCE = 0.3;
+for (const [skill, behaviours] of Object.entries(sn.drivers)) {
+  for (const family of FAMILIES) {
+    const scores = Object.values(behaviours).map((b) => b[family]).filter((v) => v !== undefined);
+    if (scores.length === 0) continue;
+    const score = sn.soft[skill][family];
+    const driverMean = scores.reduce((a, b) => a + b, 0) / scores.length;
+    assert.ok(
+      Math.abs(score - driverMean) <= DRIVER_TOLERANCE,
+      `${family}/${skill} scores ${score} but its behaviours average ` +
+        `${driverMean.toFixed(2)}. One of the two is on a different scale from the other.`,
+    );
+  }
+}
+
+// A network mean sits between the family means it is made of.
+for (const [name, network, field] of [
+  ['softMean', sn.overview.softMean, 'soft'],
+  ['hardMean', sn.overview.hardMean, 'hard'],
+  ['skillMatchingMean', sn.overview.skillMatchingMean, 'skillMatching'],
+]) {
+  const perFamily = FAMILIES.map((f) => sn.families[f][field]);
+  assert.ok(
+    network >= Math.min(...perFamily) - 0.5 && network <= Math.max(...perFamily) + 0.5,
+    `overview.${name} is ${network}, outside the family range ` +
+      `(${Math.min(...perFamily)}-${Math.max(...perFamily)}).`,
+  );
+}
+
+// A threshold has to fall somewhere the scores actually are, or the quadrant
+// shares below it describe a population that cannot exist. The soft bar sits
+// inside the observed soft scores; the hard bar is under every family's mean,
+// which is what makes nine in ten of them clear it.
+const softScores = SOFT.flatMap((k) => FAMILIES.map((f) => sn.soft[k][f]).filter((v) => v !== undefined));
+assert.ok(
+  sn.overview.softThreshold > Math.min(...softScores) &&
+    sn.overview.softThreshold < Math.max(...softScores),
+  `softThreshold ${sn.overview.softThreshold} is outside the observed soft scores ` +
+    `(${Math.min(...softScores)}-${Math.max(...softScores)}), so no one would fall either side of it.`,
+);
+assert.ok(
+  FAMILIES.every((f) => sn.families[f].hard > sn.overview.hardThreshold),
+  `hardThreshold ${sn.overview.hardThreshold} is above a family mean, which contradicts the ` +
+    `${(sn.quadrants.softHighHardHigh + sn.quadrants.softLowHardHigh).toFixed(1)}% the quadrants ` +
+    'put above it.',
+);
+
+// ── The headline figures the copy quotes ───────────────────────────────────
+// population.assessed.note says "out of {candidates} in scope, the remaining
+// {notAssessed} did not complete".
+assert.equal(
+  sn.funnel.candidates,
+  sn.funnel.assessed + sn.funnel.notAssessed,
+  'candidates is no longer assessed + notAssessed, but population.assessed.note still says it is.',
+);
+
+// The page shows `interviews` nowhere, on purpose: it sits above `assessed`, so
+// any funnel drawn from these three widens in the middle. This is the assertion
+// that tells whoever refreshes the extract that the omission was a decision.
+assert.ok(
+  sn.funnel.interviews < sn.funnel.assessed,
+  'interviews is no longer below assessed. The funnel was left off the page because it was — ' +
+    'if the extract now descends, body.tsx can draw one and this assertion should go.',
+);
+
+// aboveBothPct and the top-right quadrant are the same population read twice.
+assert.equal(
+  sn.overview.aboveBothPct,
+  sn.quadrants.softHighHardHigh,
+  'overview.aboveBothPct and quadrants.softHighHardHigh disagree — the page presents them as ' +
+    'the same group.',
+);
+
+// population.matchingMedian.note: "within half a point of the mean".
+assert.ok(
+  Math.abs(sn.overview.skillMatchingMedian - sn.overview.skillMatchingMean) <= 0.5,
+  `The median is ${Math.abs(sn.overview.skillMatchingMedian - sn.overview.skillMatchingMean).toFixed(1)} ` +
+    'from the mean. population.matchingMedian.note says half a point.',
+);
+
+// ── The sentences the page argues, against the numbers it argues them from ──
+
+// bands.body: "more than nine in ten sit at base or above".
+const atBaseOrAbove = sn.bands.base + sn.bands.good + sn.bands.high;
+assert.ok(
+  atBaseOrAbove > 90,
+  `${atBaseOrAbove.toFixed(1)}% sit at base or above. bands.body says more than nine in ten.`,
+);
+// bands.caption: "the two middle bands hold most of the network".
+assert.ok(
+  sn.bands.base + sn.bands.good > 50,
+  'The two middle bands no longer hold most of the network; bands.caption says they do.',
+);
+
+// families.coverage: the two published families do not cover the assessed total.
+const covered = FAMILIES.reduce((sum, f) => sum + sn.families[f].n, 0);
+assert.ok(
+  covered < sn.funnel.assessed,
+  'The published families now cover the whole assessed population. families.coverage explains ' +
+    'a gap that would no longer exist.',
+);
+
+// families.overlap: "exactly one soft skill … and two of the knowledge areas".
+const sharedSoft = SOFT.filter((k) => FAMILIES.every((f) => sn.soft[k][f] !== undefined));
+const sharedHard = HARD.filter((k) => FAMILIES.every((f) => sn.hard[k][f] !== undefined));
+assert.equal(sharedSoft.length, 1, `${sharedSoft.length} soft skills are shared, not 1 (${sharedSoft}).`);
+assert.equal(sharedHard.length, 2, `${sharedHard.length} knowledge areas are shared, not 2 (${sharedHard}).`);
+
+// profile.soft.caption: "the average of these is the family's soft skill score
+// in the table above" — and the same for the knowledge areas.
+const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
+for (const family of FAMILIES) {
+  for (const [source, keys, field] of [
+    [sn.soft, keysFor(sn.soft, family), 'soft'],
+    [sn.hard, keysFor(sn.hard, family), 'hard'],
+  ]) {
+    const computed = mean(keys.map((k) => source[k][family]));
+    assert.ok(
+      Math.abs(computed - sn.families[family][field]) <= 0.05,
+      `${family}.${field} is ${sn.families[family][field]} but its own areas average ` +
+        `${computed.toFixed(2)}. profile.${field}.caption says the second is the first.`,
+    );
+  }
+}
+
+// profile.drivers.caption: "inside a single competency the behaviours can sit
+// more than a point apart". `can`, so at least one must.
+const spreads = Object.entries(sn.drivers).flatMap(([skill, behaviours]) =>
+  FAMILIES.map((family) => {
+    const scores = Object.values(behaviours).map((b) => b[family]).filter((v) => v !== undefined);
+    return scores.length > 1 ? [`${family}/${skill}`, Math.max(...scores) - Math.min(...scores)] : null;
+  }).filter(Boolean),
+);
+assert.ok(
+  spreads.some(([, spread]) => spread > 1),
+  'No competency has behaviours more than a point apart any more; profile.drivers.caption says ' +
+    'they can be. Widest is ' + Math.max(...spreads.map(([, s]) => s)).toFixed(1) + '.',
+);
+
+// The quadrant descriptions name their groups by size: "half the network" on
+// ready-on-both, "the smallest group" on behaviour-ahead, "the large group" on
+// knowledge-ahead.
+const bySize = Object.entries(sn.quadrants).sort((a, b) => b[1] - a[1]).map(([q]) => q);
+assert.deepEqual(
+  bySize,
+  ['softHighHardHigh', 'softLowHardHigh', 'softLowHardLow', 'softHighHardLow'],
+  'The quadrants have changed order by size, and quadrants.items.*.description names them by ' +
+    `size: ${bySize.join(' > ')}.`,
+);
+assert.ok(
+  sn.quadrants.softHighHardHigh >= 45 && sn.quadrants.softHighHardHigh <= 55,
+  `Ready-on-both is ${sn.quadrants.softHighHardHigh}%; its description calls it half the network.`,
+);
+
+console.log(
+  `[OK] demo sales network: ${SOFT.length + HARD.length + DRIVERS.length} composed labels across ` +
+    `${FAMILIES.length} families, and every copy claim still true of the data`,
+);

--- a/scripts/check-demo-sales-network.mjs
+++ b/scripts/check-demo-sales-network.mjs
@@ -19,6 +19,7 @@
 // Run: npm run check:demo-sales-network
 
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -120,6 +121,30 @@ const sums = (name, values) => {
 };
 sums('bands', Object.values(sn.bands));
 sums('quadrants', Object.values(sn.quadrants));
+
+// ── The extract is frozen ──────────────────────────────────────────────────
+// Every rule below reads the data and asserts something *about* it, which is
+// the right shape for catching a refreshed extract that contradicts the page's
+// copy — and the wrong shape for catching a single value moved on its own. A
+// behavioural driver has no sentence written about it: the page draws all 33 of
+// them and says nothing, so no derived rule can pin one. Asserting the mean of
+// a competency's behaviours came close and still absorbed a full point moved on
+// a three-behaviour competency, because a mean divides it by three.
+//
+// So the values are pinned outright. These extracts are one-off anonymised
+// artefacts, not a feed: changing a number is a decision, and this is what
+// makes it one. On a legitimate refresh, update the digest — and re-read the
+// copy, because the assertions below are what tell you which sentences the new
+// numbers have broken.
+const DIGEST = '6e06ad8faf0f60cb5ed5916c15acb2d9252f94a04a1767eb0f5c9aa4d34840dd';
+const digest = createHash('sha256').update(JSON.stringify(sn)).digest('hex');
+assert.equal(
+  digest,
+  DIGEST,
+  'data/demo/sales-network.ts has changed. If that was deliberate, put the new digest in this ' +
+    `file (${digest}) and check every claim below against the new numbers — several sentences on ` +
+    'the page name figures that are no longer what they were.',
+);
 
 // ── The scales hold ────────────────────────────────────────────────────────
 // Four structural rules, all of them things the page draws rather than says.
@@ -245,10 +270,14 @@ assert.ok(
   atBaseOrAbove > 90,
   `${atBaseOrAbove.toFixed(1)}% sit at base or above. bands.body says more than nine in ten.`,
 );
-// bands.caption: "the two middle bands hold most of the network".
+// bands.caption: "more than four in five sit in the two middle bands". The
+// bound is the sentence's, not a bound that any majority would satisfy — at
+// `> 50` this survived the share dropping to 55%, with the caption still
+// claiming four in five.
+const middle = sn.bands.base + sn.bands.good;
 assert.ok(
-  sn.bands.base + sn.bands.good > 50,
-  'The two middle bands no longer hold most of the network; bands.caption says they do.',
+  middle > 80,
+  `The two middle bands hold ${middle.toFixed(1)}%. bands.caption says more than four in five.`,
 );
 
 // families.coverage: the two published families do not cover the assessed total.
@@ -309,6 +338,26 @@ assert.deepEqual(
 assert.ok(
   sn.quadrants.softHighHardHigh >= 45 && sn.quadrants.softHighHardHigh <= 55,
   `Ready-on-both is ${sn.quadrants.softHighHardHigh}%; its description calls it half the network.`,
+);
+
+// quadrants.body and quadrants.caption: the two bars are cleared by very
+// different shares, and that gap is the section's whole argument — the
+// technical bar sorts nobody, the behavioural one halves the network. Read the
+// same figure as "half the network clears both" and it becomes a claim of
+// double excellence resting on a floor 94% are already over, which the bands
+// section contradicts two panels down (9.8% in the top band).
+const hardCleared = sn.quadrants.softHighHardHigh + sn.quadrants.softLowHardHigh;
+const softCleared = sn.quadrants.softHighHardHigh + sn.quadrants.softHighHardLow;
+assert.ok(
+  hardCleared - softCleared > 25,
+  `The technical bar is cleared by ${hardCleared.toFixed(1)}% and the behavioural one by ` +
+    `${softCleared.toFixed(1)}%. The section is written around those being far apart; at this ` +
+    'distance "over both" would have to be described as something other than a behavioural result.',
+);
+assert.ok(
+  hardCleared > 85,
+  `The technical bar is cleared by ${hardCleared.toFixed(1)}%. The copy says almost the whole ` +
+    'network has the technical ground.',
 );
 
 console.log(


### PR DESCRIPTION
La seconda delle tre dashboard demo, sui dati anonimizzati di #168.

## Due grafici che non ci sono, e perché

**Nessun funnel.** Nei dati ci sono 190 candidati, 180 colloqui e 185 valutati:
185 valutati su 180 colloqui. Viene da un disallineamento di anagrafica già nel
sorgente (183 contro 182) amplificato dall'arrotondamento a multipli di 5, che è
la regola che rende i conteggi non identificanti e non si tocca. Un imbuto che
si allarga a metà non fa pensare «arrotondamento», fa pensare che i numeri non
tornino — e da lì il lettore smette di fidarsi anche di quelli che tornano. La
pagina mostra i 185 valutati e il 96% di conversione; `interviews` non compare
nel testo renderizzato, in nessuna delle due lingue, e lo smoke test fallisce se
ricompare.

**Nessuno scatter soft × hard.** Il sorgente ne disegnava uno di 183
punti-persona, e quei punti sono stati tagliati in #168: nell'estratto restano
quattro quote di quadrante e due medie di famiglia. Due punti non sono uno
scatter, e disegnarne uno dichiara al lettore una risoluzione che il file non
ha. Una griglia 2×2 porta gli stessi quattro numeri senza fingere.

Entrambi erano nell'Acceptance perché li aveva la dashboard sorgente. Emendata:
ogni volta che l'originale usava i record individuali, l'Acceptance chiedeva
qualcosa che l'estratto non può reggere.

## La sezione che è stata riscritta in review

La pagina chiamava il 50.8% «sopra entrambe le soglie» il gruppo da cui un
programma dovrebbe imparare. Ma la barra tecnica (≥ 40) è superata dal **94.0%**
e quella comportamentale (≥ 3) dal 53.5%: «sopra entrambe» è in pratica la sola
barra comportamentale, e la tecnica non discrimina nessuno. Rivendicare
eccellenza da un pavimento che quasi tutti hanno già passato è sovravendita, e
le bande della pagina stessa la smentiscono due sezioni sotto, dove in «Alto»
c'è il 9.8%.

La sezione ora apre sulle due quote di superamento e dice ciò che i numeri
dicono: **la conoscenza tecnica non è ciò che separa questa rete, il
comportamento sì.** Il gate asserisce che il divario fra le due barre superi i
25 punti e che la tecnica stia sopra 85, ricavandoli dai dati — il divario *è*
l'argomento della sezione, quindi è la cosa da accorgersi quando cambia.

## Quattro affermazioni false, tutte trovate prima del merge

Tre le ha trovate l'implementer rileggendo la propria copy contro i dati:
«quattro su cinque a livello base o sopra» era 93.4%, la sovrapposizione fra
famiglie era una soft skill *e due aree di conoscenza*, e «la dispersione dentro
una competenza è di solito più ampia del divario fra due» era falsa (vera in 1
caso su 4).

Le altre due le ha trovate la review. Una esisteva **solo in italiano**: EN
diceva che le due fasce centrali tengono *most* della rete, IT diceva *quasi
tutta*, per 83.6%. L'altra è arrivata con la riscrittura stessa — «il gruppo più
piccolo **di gran lunga**» per 2.7% contro 3.3%, sei decimi di distanza: su una
pagina che due pannelli sopra dichiara di arrotondare ogni conteggio a multipli
di 5, quelle sono circa cinque persone e circa sei, e l'estratto non può
separarle.

## Il gate, e cosa può davvero dimostrare

`check:demo-sales-network` chiude su due risultati separati, non su un totale:

```
extract pinned by digest (every value, no meaning)
42 composed labels across 2 families, and every claim the copy makes still true of the data
```

Il digest sha256 dell'oggetto esportato fissa ogni valore, comprese le decine di
punteggi per driver comportamentale su cui la copy non dice nulla e che quindi
nessuna regola semantica può fissare. Ma rende qualunque totale di mutation test
banalmente completo, ed è il motivo per cui le due righe sono separate: il
numero onesto sulle regole semantiche è **38 su 76** contro uno spostamento di
un punto pieno, non il 76 su 76 che il digest garantisce.

Il digest non è propagato al gate della retail: lì ogni valore renderizzato ha
una frase che lo riguarda, quindi le regole semantiche lo coprono davvero.

## Verifica

`./harness/init.sh` completo verde. Le due mutazioni sopravvissute al primo giro
verificate rosse; le due regole nuove sui quadranti fatte scattare in
isolamento; il digest verificato calcolato sull'oggetto e non sul file, e le
regole semantiche verificate ancora vive dietro di esso.

Nessuna pagina esistente ha guadagnato peso: il diff non tocca nulla sotto
`components/`, e l'unico file di pagina esistente modificato è
`app/[locale]/demo/body.tsx`, dove cambia una riga — la scheda che passa da
badge a link. Il payload dei messaggi dell'hub è #179.

Closes #170