### PR TITLE
Standardize section-title and hero heading typography sitewide

### DIFF
--- a/app/[locale]/blog/accountability/body.tsx
+++ b/app/[locale]/blog/accountability/body.tsx
@@ -205,7 +205,7 @@ export default async function BlogArticle4() {
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">
                 {t('text5')}
               </span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading7', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/attitude-vs-competence/body.tsx
+++ b/app/[locale]/blog/attitude-vs-competence/body.tsx
@@ -265,7 +265,7 @@ export default async function BlogArticle1() {
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">
                 {t('text5')}
               </span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading10', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/body.tsx
+++ b/app/[locale]/blog/body.tsx
@@ -110,7 +110,7 @@ export default function BlogPage() {
         <section id="articles" className="section-breathe">
           <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-28">
             <Reveal y={20} duration={0.6} className="mb-8 md:mb-12">
-              <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
+              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
             </Reveal>
 
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/app/[locale]/blog/body.tsx
+++ b/app/[locale]/blog/body.tsx
@@ -110,7 +110,7 @@ export default function BlogPage() {
         <section id="articles" className="section-breathe">
           <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-28">
             <Reveal y={20} duration={0.6} className="mb-8 md:mb-12">
-              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
+              <h2 className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
             </Reveal>
 
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/app/[locale]/blog/corporate-onboarding/body.tsx
+++ b/app/[locale]/blog/corporate-onboarding/body.tsx
@@ -150,7 +150,7 @@ export default async function BlogArticle6() {
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">
                 {t('text3')}
               </span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading5', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/critical-thinking/body.tsx
+++ b/app/[locale]/blog/critical-thinking/body.tsx
@@ -177,7 +177,7 @@ export default async function BlogArticle5() {
               as="h2"
               y={20}
               duration={0.6}
-              className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]"
+              className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]"
             >
               {t('heading8')}
             </Reveal>

--- a/app/[locale]/blog/critical-thinking/body.tsx
+++ b/app/[locale]/blog/critical-thinking/body.tsx
@@ -177,7 +177,7 @@ export default async function BlogArticle5() {
               as="h2"
               y={20}
               duration={0.6}
-              className="text-[clamp(1.5rem,3vw,2rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]"
+              className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]"
             >
               {t('heading8')}
             </Reveal>
@@ -202,7 +202,7 @@ export default async function BlogArticle5() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text4')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading9', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/managerial-skills/body.tsx
+++ b/app/[locale]/blog/managerial-skills/body.tsx
@@ -173,7 +173,7 @@ export default async function BlogArticle7() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text3')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading6', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/negotiation-techniques/body.tsx
+++ b/app/[locale]/blog/negotiation-techniques/body.tsx
@@ -173,7 +173,7 @@ export default async function BlogArticle3() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text4')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading9', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/newsletter-august-2026/body.tsx
+++ b/app/[locale]/blog/newsletter-august-2026/body.tsx
@@ -165,7 +165,7 @@ export default async function AugustNewsletter() {
           <div className="max-w-[1400px] mx-auto px-6 md:px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('finalKicker')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t('finalTitle')} <span className="gradient-text">{t('finalTitleHighlight')}</span>
               </h2>
               <p className="text-[17px] text-white/[0.4] mb-12 max-w-xl mx-auto leading-[1.75]">{t('finalBody')}</p>

--- a/app/[locale]/blog/newsletter-july-2026/body.tsx
+++ b/app/[locale]/blog/newsletter-july-2026/body.tsx
@@ -126,7 +126,7 @@ export default async function JulyNewsletter() {
           <div className="max-w-[1400px] mx-auto px-6 md:px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('finalKicker')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t('finalTitle')} <span className="gradient-text">{t('finalTitleHighlight')}</span>
               </h2>
               <p className="text-[17px] text-white/[0.4] mb-12 max-w-xl mx-auto leading-[1.75]">{t('finalBody')}</p>

--- a/app/[locale]/blog/recruitment-biases/body.tsx
+++ b/app/[locale]/blog/recruitment-biases/body.tsx
@@ -160,7 +160,7 @@ export default async function BlogArticle2() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text4')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading5', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/social-skills/body.tsx
+++ b/app/[locale]/blog/social-skills/body.tsx
@@ -148,7 +148,7 @@ export default async function BlogArticle8() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text3')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading7', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/blog/talent-acquisition/body.tsx
+++ b/app/[locale]/blog/talent-acquisition/body.tsx
@@ -161,7 +161,7 @@ export default async function BlogArticle9() {
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
               <span className="text-[12px] font-bold text-[#4B4DF7]/50 tracking-[0.2em] uppercase mb-6 block">{t('text3')}</span>
-              <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.03em]">
+              <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold text-white/90 mb-5 leading-[1.1] max-w-3xl mx-auto tracking-[-0.02em]">
                 {t.rich('heading5', {
     s: (chunks) => <span className="gradient-text">{chunks}</span>,
   })}

--- a/app/[locale]/book-meeting/body.tsx
+++ b/app/[locale]/book-meeting/body.tsx
@@ -76,7 +76,7 @@ export default function BookMeetingPage() {
                 className="text-[48px] md:text-[64px] font-semibold tracking-[-0.02em] text-white/95 mb-4"
                 style={{ lineHeight: 1.1 }}
               >{t.rich('heading', {
-                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+                span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
               })}</h1>
 
               <p className="text-[16px] text-white/[0.55] leading-[1.65] max-w-md" style={{ fontWeight: 300 }}>

--- a/app/[locale]/careers/body.tsx
+++ b/app/[locale]/careers/body.tsx
@@ -115,7 +115,7 @@ export default function CareersPage() {
                   className="font-semibold text-white/95 mb-6 text-[48px] md:text-[64px]"
                   style={{ lineHeight: 1.05, letterSpacing: '-0.02em' }}
                 >{t.rich('heading', {
-                  span: (chunks) => <span className="italic font-bold gradient-text-warm">{chunks}</span>,
+                  span: (chunks) => <span className="italic font-semibold gradient-text-warm">{chunks}</span>,
                 })}</h1>
                 <p className="text-[15px] md:text-[17px] text-white/55 leading-[1.7] mb-8 max-w-lg font-light">{t('body')}</p>
                 <div className="flex flex-wrap gap-3">
@@ -184,7 +184,7 @@ export default function CareersPage() {
                 className="font-semibold text-[#121212] mb-6"
                 style={{ fontSize: 'clamp(1.8rem, 4vw, 3rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
               >{t.rich('heading2', {
-                span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+                span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
               })}</h2>
               <p className="text-[15px] md:text-[17px] text-[#7A7A7A] leading-[1.7] mb-8 max-w-2xl">{t('body2')}</p>
               <Button asChild variant="secondary" mode="light">
@@ -213,7 +213,7 @@ export default function CareersPage() {
                 className="font-semibold text-white/95 mb-4"
                 style={{ fontSize: 'clamp(1.8rem, 4vw, 3rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
               >{t.rich('heading3', {
-                span: (chunks) => <span className="italic font-bold gradient-text-warm">{chunks}</span>,
+                span: (chunks) => <span className="italic font-semibold gradient-text-warm">{chunks}</span>,
               })}</h2>
               <p className="text-[15px] md:text-[17px] text-white/50 leading-[1.7] font-light">{t('body3')}</p>
             </Reveal>

--- a/app/[locale]/careers/body.tsx
+++ b/app/[locale]/careers/body.tsx
@@ -182,7 +182,7 @@ export default function CareersPage() {
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-6 block">{t('text2')}</span>
               <h2
                 className="font-semibold text-[#121212] mb-6"
-                style={{ fontSize: 'clamp(1.8rem, 4vw, 3.2rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
+                style={{ fontSize: 'clamp(1.8rem, 4vw, 3rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
               >{t.rich('heading2', {
                 span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
               })}</h2>
@@ -263,7 +263,7 @@ export default function CareersPage() {
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">{t('text4')}</span>
               <h2
                 className="font-semibold text-[#121212] mb-2"
-                style={{ fontSize: 'clamp(1.6rem, 3.5vw, 2.8rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
+                style={{ fontSize: 'clamp(1.6rem, 3.5vw, 3rem)', lineHeight: 1.1, letterSpacing: '-0.02em' }}
               >{t('heading4')}</h2>
               <p className="text-[15px] md:text-[17px] text-[#7A7A7A] leading-[1.6]">{t('body4')}</p>
             </Reveal>

--- a/app/[locale]/customers/adr-2/body.tsx
+++ b/app/[locale]/customers/adr-2/body.tsx
@@ -128,7 +128,7 @@ export default function AdRStoryPage2() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -140,7 +140,7 @@ export default function AdRStoryPage2() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.3rem,2vw,1.8rem)] font-semibold text-[#121212] leading-[1.5] mb-14">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.3rem,2vw,3rem)] font-semibold text-[#121212] leading-[1.5] mb-14 tracking-[-0.02em]">{t('challenge.title')}</h2>
 
               <span className="text-[12px] font-bold text-[#121212]/30 tracking-[0.1em] uppercase mb-5 block">{t('challenge.factorsLabel')}</span>
               <div className="grid md:grid-cols-2 gap-5">
@@ -160,7 +160,7 @@ export default function AdRStoryPage2() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               {t.has('solution.streams') && (
@@ -197,7 +197,7 @@ export default function AdRStoryPage2() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -249,7 +249,7 @@ export default function AdRStoryPage2() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4 leading-[1.3]">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/adr-2/body.tsx
+++ b/app/[locale]/customers/adr-2/body.tsx
@@ -128,7 +128,7 @@ export default function AdRStoryPage2() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -140,7 +140,7 @@ export default function AdRStoryPage2() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.3rem,2vw,3rem)] font-semibold text-[#121212] leading-[1.5] mb-14 tracking-[-0.02em]">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.3rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.5] mb-14 tracking-[-0.02em]">{t('challenge.title')}</h2>
 
               <span className="text-[12px] font-bold text-[#121212]/30 tracking-[0.1em] uppercase mb-5 block">{t('challenge.factorsLabel')}</span>
               <div className="grid md:grid-cols-2 gap-5">
@@ -160,7 +160,7 @@ export default function AdRStoryPage2() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               {t.has('solution.streams') && (
@@ -197,7 +197,7 @@ export default function AdRStoryPage2() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -249,7 +249,7 @@ export default function AdRStoryPage2() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/adr/body.tsx
+++ b/app/[locale]/customers/adr/body.tsx
@@ -137,7 +137,7 @@ export default function ADRStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -147,7 +147,7 @@ export default function ADRStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -184,7 +184,7 @@ export default function ADRStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -205,7 +205,7 @@ export default function ADRStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               {t.has('solution.streams') && (
@@ -242,7 +242,7 @@ export default function ADRStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -294,7 +294,7 @@ export default function ADRStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/adr/body.tsx
+++ b/app/[locale]/customers/adr/body.tsx
@@ -137,7 +137,7 @@ export default function ADRStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -147,7 +147,7 @@ export default function ADRStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -184,7 +184,7 @@ export default function ADRStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -205,7 +205,7 @@ export default function ADRStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               {t.has('solution.streams') && (
@@ -242,7 +242,7 @@ export default function ADRStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -294,7 +294,7 @@ export default function ADRStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4 leading-[1.3]">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/carrefour/body.tsx
+++ b/app/[locale]/customers/carrefour/body.tsx
@@ -135,7 +135,7 @@ export default function CarrefourStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -145,7 +145,7 @@ export default function CarrefourStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -182,7 +182,7 @@ export default function CarrefourStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -203,7 +203,7 @@ export default function CarrefourStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -237,7 +237,7 @@ export default function CarrefourStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/carrefour/body.tsx
+++ b/app/[locale]/customers/carrefour/body.tsx
@@ -135,7 +135,7 @@ export default function CarrefourStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -145,7 +145,7 @@ export default function CarrefourStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -182,7 +182,7 @@ export default function CarrefourStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -203,7 +203,7 @@ export default function CarrefourStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -237,7 +237,7 @@ export default function CarrefourStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/credem/body.tsx
+++ b/app/[locale]/customers/credem/body.tsx
@@ -153,7 +153,7 @@ export default function CredemStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -163,7 +163,7 @@ export default function CredemStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -200,7 +200,7 @@ export default function CredemStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -221,7 +221,7 @@ export default function CredemStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -243,7 +243,7 @@ export default function CredemStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
                 {RESULTS_METRICS.map((m, i) => {

--- a/app/[locale]/customers/credem/body.tsx
+++ b/app/[locale]/customers/credem/body.tsx
@@ -153,7 +153,7 @@ export default function CredemStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -163,7 +163,7 @@ export default function CredemStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -200,7 +200,7 @@ export default function CredemStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -221,7 +221,7 @@ export default function CredemStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -243,7 +243,7 @@ export default function CredemStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
                 {RESULTS_METRICS.map((m, i) => {

--- a/app/[locale]/customers/douglas/body.tsx
+++ b/app/[locale]/customers/douglas/body.tsx
@@ -136,7 +136,7 @@ export default function DouglasStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function DouglasStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function DouglasStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function DouglasStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -226,7 +226,7 @@ export default function DouglasStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/douglas/body.tsx
+++ b/app/[locale]/customers/douglas/body.tsx
@@ -136,7 +136,7 @@ export default function DouglasStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function DouglasStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function DouglasStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function DouglasStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -226,7 +226,7 @@ export default function DouglasStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/eataly-2/body.tsx
+++ b/app/[locale]/customers/eataly-2/body.tsx
@@ -135,7 +135,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function EatalyStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-4">{t('solution.intro')}</p>
               {t.has('solution.intro2') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro2')}</p>}
               <div>
@@ -225,7 +225,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -262,7 +262,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t('vision.intro')}</p>
                 {t.has('vision.nextGen') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mt-4">{t('vision.nextGen')}</p>}
               </div>

--- a/app/[locale]/customers/eataly-2/body.tsx
+++ b/app/[locale]/customers/eataly-2/body.tsx
@@ -135,7 +135,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function EatalyStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-4">{t('solution.intro')}</p>
               {t.has('solution.intro2') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro2')}</p>}
               <div>
@@ -225,7 +225,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -262,7 +262,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t('vision.intro')}</p>
                 {t.has('vision.nextGen') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mt-4">{t('vision.nextGen')}</p>}
               </div>

--- a/app/[locale]/customers/eataly-3/body.tsx
+++ b/app/[locale]/customers/eataly-3/body.tsx
@@ -135,7 +135,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -182,7 +182,7 @@ export default function EatalyStoryPage() {
 
             {/* OBJECTIVES */}
             <Section className="mb-24">
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -203,7 +203,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-4">{t.rich('solution.intro', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>
@@ -228,7 +228,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -266,7 +266,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t.rich('vision.intro', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>

--- a/app/[locale]/customers/eataly-3/body.tsx
+++ b/app/[locale]/customers/eataly-3/body.tsx
@@ -135,7 +135,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -182,7 +182,7 @@ export default function EatalyStoryPage() {
 
             {/* OBJECTIVES */}
             <Section className="mb-24">
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -203,7 +203,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-4">{t.rich('solution.intro', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>
@@ -228,7 +228,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -266,7 +266,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t.rich('vision.intro', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>

--- a/app/[locale]/customers/eataly/body.tsx
+++ b/app/[locale]/customers/eataly/body.tsx
@@ -136,7 +136,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -147,7 +147,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -184,7 +184,7 @@ export default function EatalyStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -205,7 +205,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
               <div>
                 <span className="text-[12px] font-bold text-[#121212]/30 tracking-[0.1em] uppercase mb-5 block">{t('solution.skillsLabel')}</span>
@@ -225,7 +225,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -262,7 +262,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t('vision.intro')}</p>
               </div>
             </Section>

--- a/app/[locale]/customers/eataly/body.tsx
+++ b/app/[locale]/customers/eataly/body.tsx
@@ -136,7 +136,7 @@ export default function EatalyStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -147,7 +147,7 @@ export default function EatalyStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -184,7 +184,7 @@ export default function EatalyStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -205,7 +205,7 @@ export default function EatalyStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
               <div>
                 <span className="text-[12px] font-bold text-[#121212]/30 tracking-[0.1em] uppercase mb-5 block">{t('solution.skillsLabel')}</span>
@@ -225,7 +225,7 @@ export default function EatalyStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -262,7 +262,7 @@ export default function EatalyStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8]">{t('vision.intro')}</p>
               </div>
             </Section>

--- a/app/[locale]/customers/europ-assistance-2/body.tsx
+++ b/app/[locale]/customers/europ-assistance-2/body.tsx
@@ -133,7 +133,7 @@ export default function EuropAssistance2StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -143,7 +143,7 @@ export default function EuropAssistance2StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -180,7 +180,7 @@ export default function EuropAssistance2StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -201,7 +201,7 @@ export default function EuropAssistance2StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -236,7 +236,7 @@ export default function EuropAssistance2StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -274,7 +274,7 @@ export default function EuropAssistance2StoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/europ-assistance-2/body.tsx
+++ b/app/[locale]/customers/europ-assistance-2/body.tsx
@@ -133,7 +133,7 @@ export default function EuropAssistance2StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -143,7 +143,7 @@ export default function EuropAssistance2StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -180,7 +180,7 @@ export default function EuropAssistance2StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -201,7 +201,7 @@ export default function EuropAssistance2StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -236,7 +236,7 @@ export default function EuropAssistance2StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">
@@ -274,7 +274,7 @@ export default function EuropAssistance2StoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('vision.badge')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4 leading-[1.3]">{t('vision.title')}</h2>
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('vision.title')}</h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">{t('vision.intro')}</p>
                 <div className="rounded-xl border border-[#4b4df7]/[0.15] bg-[#4b4df7]/[0.05] p-6 mb-8 flex items-start gap-4">
                   <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(75,77,247,0.12)' }}>

--- a/app/[locale]/customers/europ-assistance/body.tsx
+++ b/app/[locale]/customers/europ-assistance/body.tsx
@@ -156,7 +156,7 @@ export default function EuropAssistanceStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -166,7 +166,7 @@ export default function EuropAssistanceStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -203,7 +203,7 @@ export default function EuropAssistanceStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -224,7 +224,7 @@ export default function EuropAssistanceStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -259,7 +259,7 @@ export default function EuropAssistanceStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
                 {RESULTS_PILLARS.map((p) => {

--- a/app/[locale]/customers/europ-assistance/body.tsx
+++ b/app/[locale]/customers/europ-assistance/body.tsx
@@ -156,7 +156,7 @@ export default function EuropAssistanceStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -166,7 +166,7 @@ export default function EuropAssistanceStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -203,7 +203,7 @@ export default function EuropAssistanceStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -224,7 +224,7 @@ export default function EuropAssistanceStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -259,7 +259,7 @@ export default function EuropAssistanceStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('results.title')}</h2>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
                 {RESULTS_PILLARS.map((p) => {

--- a/app/[locale]/customers/fidia-farmaceutici/body.tsx
+++ b/app/[locale]/customers/fidia-farmaceutici/body.tsx
@@ -149,7 +149,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -160,7 +160,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -196,7 +196,7 @@ export default function FidiaFarmaceuticiStoryPage() {
 
             {/* OBJECTIVES */}
             <Section className="mb-24">
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -216,7 +216,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-10">{t.rich('solution.intro', {
 
   })}</p>
@@ -270,7 +270,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               {t.raw('results.metrics').length > 0 && (

--- a/app/[locale]/customers/fidia-farmaceutici/body.tsx
+++ b/app/[locale]/customers/fidia-farmaceutici/body.tsx
@@ -149,7 +149,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -160,7 +160,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -196,7 +196,7 @@ export default function FidiaFarmaceuticiStoryPage() {
 
             {/* OBJECTIVES */}
             <Section className="mb-24">
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -216,7 +216,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-10">{t.rich('solution.intro', {
 
   })}</p>
@@ -270,7 +270,7 @@ export default function FidiaFarmaceuticiStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               {t.raw('results.metrics').length > 0 && (

--- a/app/[locale]/customers/ins-mercato/body.tsx
+++ b/app/[locale]/customers/ins-mercato/body.tsx
@@ -176,7 +176,7 @@ export default function InsMercatoStoryPage() {
             {/* Context */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text10')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('heading3')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading3')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-6">
                 {t.rich('body2', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
@@ -188,7 +188,7 @@ export default function InsMercatoStoryPage() {
             {/* Challenge */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('text11')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('heading4')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading4')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">
                 {t('body3')
                 }
@@ -226,7 +226,7 @@ export default function InsMercatoStoryPage() {
             {/* Objectives */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text12')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('heading5')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('heading5')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES.map((o) => {
                   const [title, ...rest] = t(`objectives.${o.id}.label`).split(':');
@@ -247,7 +247,7 @@ export default function InsMercatoStoryPage() {
             {/* Solution */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text13')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('heading6')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading6')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">
                 {t('body4')
                 }
@@ -282,7 +282,7 @@ export default function InsMercatoStoryPage() {
             {/* Results */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('text16')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
                 {t('heading7')}
               </h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">
@@ -445,7 +445,7 @@ export default function InsMercatoStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('text18')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
                   {t('heading8')}
                 </h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">

--- a/app/[locale]/customers/ins-mercato/body.tsx
+++ b/app/[locale]/customers/ins-mercato/body.tsx
@@ -176,7 +176,7 @@ export default function InsMercatoStoryPage() {
             {/* Context */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text10')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading3')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading3')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-6">
                 {t.rich('body2', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
@@ -188,7 +188,7 @@ export default function InsMercatoStoryPage() {
             {/* Challenge */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('text11')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading4')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading4')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">
                 {t('body3')
                 }
@@ -226,7 +226,7 @@ export default function InsMercatoStoryPage() {
             {/* Objectives */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text12')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('heading5')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('heading5')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES.map((o) => {
                   const [title, ...rest] = t(`objectives.${o.id}.label`).split(':');
@@ -247,7 +247,7 @@ export default function InsMercatoStoryPage() {
             {/* Solution */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('text13')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading6')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('heading6')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">
                 {t('body4')
                 }
@@ -282,7 +282,7 @@ export default function InsMercatoStoryPage() {
             {/* Results */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('text16')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
                 {t('heading7')}
               </h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">
@@ -445,7 +445,7 @@ export default function InsMercatoStoryPage() {
                 <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[11px] font-bold tracking-[0.12em] uppercase mb-6 block w-fit" style={{ background: 'rgba(75,77,247,0.1)', color: '#4b4df7', border: '1px solid rgba(75,77,247,0.2)' }}>
                   {t('text18')}
                 </span>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">
                   {t('heading8')}
                 </h2>
                 <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-8">

--- a/app/[locale]/customers/mediaset-1/body.tsx
+++ b/app/[locale]/customers/mediaset-1/body.tsx
@@ -152,7 +152,7 @@ export default function Mediaset1StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -162,7 +162,7 @@ export default function Mediaset1StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -199,7 +199,7 @@ export default function Mediaset1StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -219,7 +219,7 @@ export default function Mediaset1StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -241,7 +241,7 @@ export default function Mediaset1StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/mediaset-1/body.tsx
+++ b/app/[locale]/customers/mediaset-1/body.tsx
@@ -152,7 +152,7 @@ export default function Mediaset1StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -162,7 +162,7 @@ export default function Mediaset1StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -199,7 +199,7 @@ export default function Mediaset1StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -219,7 +219,7 @@ export default function Mediaset1StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -241,7 +241,7 @@ export default function Mediaset1StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/mediaset-2/body.tsx
+++ b/app/[locale]/customers/mediaset-2/body.tsx
@@ -153,7 +153,7 @@ export default function Mediaset2StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -163,7 +163,7 @@ export default function Mediaset2StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -200,7 +200,7 @@ export default function Mediaset2StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -220,7 +220,7 @@ export default function Mediaset2StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -242,7 +242,7 @@ export default function Mediaset2StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/mediaset-2/body.tsx
+++ b/app/[locale]/customers/mediaset-2/body.tsx
@@ -153,7 +153,7 @@ export default function Mediaset2StoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -163,7 +163,7 @@ export default function Mediaset2StoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -200,7 +200,7 @@ export default function Mediaset2StoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -220,7 +220,7 @@ export default function Mediaset2StoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -242,7 +242,7 @@ export default function Mediaset2StoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/subdued/body.tsx
+++ b/app/[locale]/customers/subdued/body.tsx
@@ -136,7 +136,7 @@ export default function SubduedStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function SubduedStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function SubduedStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function SubduedStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -238,7 +238,7 @@ export default function SubduedStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-5 mb-5">

--- a/app/[locale]/customers/subdued/body.tsx
+++ b/app/[locale]/customers/subdued/body.tsx
@@ -136,7 +136,7 @@ export default function SubduedStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -146,7 +146,7 @@ export default function SubduedStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -183,7 +183,7 @@ export default function SubduedStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -204,7 +204,7 @@ export default function SubduedStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -238,7 +238,7 @@ export default function SubduedStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('results.subtitle')}</p>}
 
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-5 mb-5">

--- a/app/[locale]/customers/unicomm/body.tsx
+++ b/app/[locale]/customers/unicomm/body.tsx
@@ -143,7 +143,7 @@ export default function UnicommStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>
@@ -152,7 +152,7 @@ export default function UnicommStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -189,7 +189,7 @@ export default function UnicommStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -210,7 +210,7 @@ export default function UnicommStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -245,7 +245,7 @@ export default function UnicommStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t.raw('results').subtitle}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/customers/unicomm/body.tsx
+++ b/app/[locale]/customers/unicomm/body.tsx
@@ -143,7 +143,7 @@ export default function UnicommStoryPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
   })}</p>
@@ -152,7 +152,7 @@ export default function UnicommStoryPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#ea580c' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -189,7 +189,7 @@ export default function UnicommStoryPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => {
                   const [title, ...rest] = t(`objectives.items.${o.id}.text`).split(':');
@@ -210,7 +210,7 @@ export default function UnicommStoryPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -245,7 +245,7 @@ export default function UnicommStoryPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#047857' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               {t.has('results.subtitle') && <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t.raw('results').subtitle}</p>}
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-5">

--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -57,7 +57,7 @@ export default function DemoHub() {
               style={{ lineHeight: 1.15 }}
             >
               {t.rich('hero.heading', {
-                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+                span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
               })}
             </Reveal>
             <Reveal

--- a/app/[locale]/demo/retail-network/body.tsx
+++ b/app/[locale]/demo/retail-network/body.tsx
@@ -408,7 +408,7 @@ export default function RetailDemo() {
               style={{ lineHeight: 1.15 }}
             >
               {t.rich('hero.heading', {
-                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+                span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
               })}
             </Reveal>
             <Reveal

--- a/app/[locale]/demo/sales-network/body.tsx
+++ b/app/[locale]/demo/sales-network/body.tsx
@@ -230,7 +230,7 @@ export default function SalesNetworkDemo() {
               style={{ lineHeight: 1.15 }}
             >
               {t.rich('hero.heading', {
-                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+                span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
               })}
             </Reveal>
             <Reveal

--- a/app/[locale]/lp/ai-act-banking/body.tsx
+++ b/app/[locale]/lp/ai-act-banking/body.tsx
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/ai-act-banking/body.tsx
+++ b/app/[locale]/lp/ai-act-banking/body.tsx
@@ -248,7 +248,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
       <section className="py-16 px-6 lg:px-10 bg-white">
         <div className="max-w-[1100px] mx-auto">
           <Reveal {...FADE} className="text-center mb-12">
-            <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+            <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
               {t('heading')}</h2>
             <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
               {t('body')}</p>
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/ai-competency-newsletter/body.tsx
+++ b/app/[locale]/lp/ai-competency-newsletter/body.tsx
@@ -236,7 +236,7 @@ export default function AiCompetencyNewsletterPage() {
             style={{ background: 'linear-gradient(120deg, #1a1a3f 0%, #201436 45%, #3a1730 100%)' }}>
             <div className="pointer-events-none absolute -top-24 right-[-80px] w-[420px] h-[420px] rounded-full" style={{ background: 'radial-gradient(circle, rgba(255,86,86,0.22) 0%, rgba(255,86,86,0) 65%)' }} />
             <div className="relative">
-              <h2 className="text-[26px] md:text-[38px] font-bold text-white tracking-[-0.02em] mb-3">{t('cta.title')}</h2>
+              <h2 className="text-[26px] md:text-[48px] font-semibold text-white tracking-[-0.02em] mb-3">{t('cta.title')}</h2>
               <p className="text-[15px] md:text-[16px] text-white/65 mb-8 max-w-xl mx-auto">{t('cta.body')}</p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
                 <a href={href('book-meeting', lang)} onClick={() => track('book_bottom')}

--- a/app/[locale]/lp/ai-competency/body.tsx
+++ b/app/[locale]/lp/ai-competency/body.tsx
@@ -141,7 +141,7 @@ export default function AiCompetencyPage() {
                 </span>
                 <h1 className="text-[23px] font-semibold md:text-[30px] md:font-bold tracking-[-0.02em] text-white/95 mb-2.5" style={{ lineHeight: 1.12 }}>
                   {t('titleLead')}
-                  <span className="font-bold gradient-text" style={{ display: 'inline', backgroundImage: 'linear-gradient(135deg, #FFAF64 0%, #FF5656 62%, #4B4DF7 128%)' }}>
+                  <span className="font-semibold md:font-bold gradient-text" style={{ display: 'inline', backgroundImage: 'linear-gradient(135deg, #FFAF64 0%, #FF5656 62%, #4B4DF7 128%)' }}>
                     {t('titleHighlight')}
                   </span>
                   {t('titleTail')}

--- a/app/[locale]/lp/arte-di-misurare-allineamento/body.tsx
+++ b/app/[locale]/lp/arte-di-misurare-allineamento/body.tsx
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/arte-di-misurare-allineamento/body.tsx
+++ b/app/[locale]/lp/arte-di-misurare-allineamento/body.tsx
@@ -248,7 +248,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
       <section className="py-16 px-6 lg:px-10 bg-white">
         <div className="max-w-[1100px] mx-auto">
           <Reveal {...FADE} className="text-center mb-12">
-            <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+            <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
               {t('heading')}</h2>
             <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
               {t('body')}</p>
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/career-aspiration-insurance/body.tsx
+++ b/app/[locale]/lp/career-aspiration-insurance/body.tsx
@@ -215,7 +215,7 @@ export default function CareerAspirationInsuranceVetrina() {
         <section className="py-16 px-6 lg:px-10 bg-white">
           <div className="max-w-[1100px] mx-auto">
             <Reveal {...FADE} className="text-center mb-12">
-              <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+              <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
                 {t('heading')}</h2>
               <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
                 {t('body')}</p>
@@ -249,7 +249,7 @@ export default function CareerAspirationInsuranceVetrina() {
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
               {/* Left */}
               <Reveal {...FADE}>
-                <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                   {t('heading2')}</h2>
                 <ul className="space-y-3 mb-8">
                   {[

--- a/app/[locale]/lp/career-aspiration-insurance/body.tsx
+++ b/app/[locale]/lp/career-aspiration-insurance/body.tsx
@@ -249,7 +249,7 @@ export default function CareerAspirationInsuranceVetrina() {
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
               {/* Left */}
               <Reveal {...FADE}>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                   {t('heading2')}</h2>
                 <ul className="space-y-3 mb-8">
                   {[

--- a/app/[locale]/lp/europ-assistance/body.tsx
+++ b/app/[locale]/lp/europ-assistance/body.tsx
@@ -160,7 +160,7 @@ export default function EuropAssistanceLandingPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -170,7 +170,7 @@ export default function EuropAssistanceLandingPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -207,7 +207,7 @@ export default function EuropAssistanceLandingPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="flex items-start gap-5 rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -225,7 +225,7 @@ export default function EuropAssistanceLandingPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -257,7 +257,7 @@ export default function EuropAssistanceLandingPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#16a34a' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,2.5rem)] font-semibold text-[#121212] leading-[1.4] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-10">{t('results.intro')}</p>
 
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">

--- a/app/[locale]/lp/europ-assistance/body.tsx
+++ b/app/[locale]/lp/europ-assistance/body.tsx
@@ -160,7 +160,7 @@ export default function EuropAssistanceLandingPage() {
             {/* CONTEXT */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('context.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-6">{t('context.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.85] mb-8">{t.rich('context.paragraph', {
     b: (chunks) => <strong className="text-[#121212]/80 font-semibold">{chunks}</strong>,
     br: () => <br />,
@@ -170,7 +170,7 @@ export default function EuropAssistanceLandingPage() {
             {/* CHALLENGE */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('challenge.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('challenge.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-14">{t('challenge.intro')}</p>
 
               <div className="mb-10">
@@ -207,7 +207,7 @@ export default function EuropAssistanceLandingPage() {
             {/* OBJECTIVES */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('objectives.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-10">{t('objectives.title')}</h2>
               <div className="grid md:grid-cols-2 gap-5">
                 {OBJECTIVES_ITEMS.map((o, i) => (
                   <div key={i} className="flex items-start gap-5 rounded-2xl border border-[#e2e8f0] bg-white p-7 shadow-sm">
@@ -225,7 +225,7 @@ export default function EuropAssistanceLandingPage() {
             {/* SOLUTION */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#4b4df7' }}>{t('solution.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('solution.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-12">{t('solution.intro')}</p>
 
               <div className="mb-12">
@@ -257,7 +257,7 @@ export default function EuropAssistanceLandingPage() {
             {/* RESULTS */}
             <Section className="mb-24">
               <span className="text-[11px] font-bold tracking-[0.15em] uppercase block mb-4" style={{ color: '#16a34a' }}>{t('results.badge')}</span>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold text-[#121212] leading-[1.4] tracking-[-0.02em] mb-4">{t('results.title')}</h2>
               <p className="text-[16px] text-[#121212]/[0.65] leading-[1.8] mb-10">{t('results.intro')}</p>
 
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">

--- a/app/[locale]/lp/food-retail/body.tsx
+++ b/app/[locale]/lp/food-retail/body.tsx
@@ -70,7 +70,7 @@ export default function FoodRetailPage() {
       {/* Inline so the highlight flows with the lead ("already" stays next to "is") and wraps naturally.
           Local gradient override pushes the purple further out so less of it shows. */}
       <span
-        className="font-bold gradient-text"
+        className="font-semibold md:font-bold gradient-text"
         style={{
           display: 'inline',
           backgroundImage: 'linear-gradient(135deg, #FFAF64 0%, #FF5656 62%, #4B4DF7 128%)',

--- a/app/[locale]/lp/hidden-cost-recruiting/body.tsx
+++ b/app/[locale]/lp/hidden-cost-recruiting/body.tsx
@@ -244,7 +244,7 @@ export default function HiddenCostRecruiting() {
             <p className="text-[11px] font-bold tracking-[0.3em] uppercase mb-4"
               style={{ background: 'linear-gradient(90deg, #4B4DF7, #FF5F24)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
               {t('body3')}</p>
-            <h2 className="text-[clamp(2rem,4vw,3.2rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15]">
+            <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15]">
               {t('heading')}</h2>
           </Reveal>
 
@@ -276,7 +276,7 @@ export default function HiddenCostRecruiting() {
             <p className="text-[11px] font-bold tracking-[0.3em] uppercase mb-4"
               style={{ background: 'linear-gradient(90deg, #4B4DF7, #FF5F24)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
               {t('body4')}</p>
-            <h2 className="text-[clamp(2rem,4vw,3.2rem)] font-semibold tracking-[-0.03em] text-white/95 leading-[1.15] max-w-[600px]">
+            <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-white/95 leading-[1.15] max-w-[600px]">
               {t.rich('heading2', {
           s: (chunks) => <span className="gradient-text">{chunks}</span>,
         })}</h2>
@@ -360,7 +360,7 @@ export default function HiddenCostRecruiting() {
                 <p className="text-[11px] font-bold tracking-[0.3em] uppercase mb-5"
                   style={{ background: 'linear-gradient(90deg, #4B4DF7, #FF5F24)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
                   {t('body7')}</p>
-                <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+                <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                   {t.rich('heading3', {
           s: (chunks) => <span className="italic" style={{ background: 'linear-gradient(90deg, #4B4DF7, #FF5F24)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>{chunks}</span>,
         })}</h2>
@@ -424,7 +424,7 @@ export default function HiddenCostRecruiting() {
               <p className="text-[11px] font-bold tracking-[0.3em] uppercase mb-5"
                 style={{ background: 'linear-gradient(90deg, #4B4DF7, #FF5F24)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
                 {t('body10')}</p>
-              <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-white/95 leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-white/95 leading-[1.15] mb-6">
                 {t.rich('heading5', {
           s: (chunks) => <span className="gradient-text">{chunks}</span>,
         })}</h2>

--- a/app/[locale]/lp/il-costo-invisibile/body.tsx
+++ b/app/[locale]/lp/il-costo-invisibile/body.tsx
@@ -215,7 +215,7 @@ export default function IlCostoInvisibileVetrina() {
         <section className="py-16 px-6 lg:px-10 bg-white">
           <div className="max-w-[1100px] mx-auto">
             <Reveal {...FADE} className="text-center mb-12">
-              <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+              <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
                 {t('heading')}</h2>
               <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
                 {t('body')}</p>
@@ -249,7 +249,7 @@ export default function IlCostoInvisibileVetrina() {
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
               {/* Left */}
               <Reveal {...FADE}>
-                <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                   {t('heading2')}</h2>
                 <ul className="space-y-3 mb-8">
                   {[

--- a/app/[locale]/lp/il-costo-invisibile/body.tsx
+++ b/app/[locale]/lp/il-costo-invisibile/body.tsx
@@ -249,7 +249,7 @@ export default function IlCostoInvisibileVetrina() {
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
               {/* Left */}
               <Reveal {...FADE}>
-                <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+                <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                   {t('heading2')}</h2>
                 <ul className="space-y-3 mb-8">
                   {[

--- a/app/[locale]/lp/il-turnover-nei-negozi-del-lusso/body.tsx
+++ b/app/[locale]/lp/il-turnover-nei-negozi-del-lusso/body.tsx
@@ -238,7 +238,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
         <div className="max-w-[1100px] mx-auto">
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/il-turnover-nei-negozi-del-lusso/body.tsx
+++ b/app/[locale]/lp/il-turnover-nei-negozi-del-lusso/body.tsx
@@ -212,7 +212,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
       <section className="py-16 px-6 lg:px-10 bg-white">
         <div className="max-w-[1100px] mx-auto">
           <Reveal {...FADE} className="text-center mb-12">
-            <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">{t('heading')}</h2>
+            <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">{t('heading')}</h2>
             <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
               {t('body')}</p>
           </Reveal>
@@ -238,7 +238,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
         <div className="max-w-[1100px] mx-auto">
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/la-crisi-delle-competenze/body.tsx
+++ b/app/[locale]/lp/la-crisi-delle-competenze/body.tsx
@@ -283,7 +283,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/la-crisi-delle-competenze/body.tsx
+++ b/app/[locale]/lp/la-crisi-delle-competenze/body.tsx
@@ -249,7 +249,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
       <section className="py-16 px-6 lg:px-10 bg-white">
         <div className="max-w-[1100px] mx-auto">
           <Reveal {...FADE} className="text-center mb-12">
-            <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+            <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
               {t('heading')}</h2>
             <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
               {t('body')}</p>
@@ -283,7 +283,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/scalare-l-eccellenza/body.tsx
+++ b/app/[locale]/lp/scalare-l-eccellenza/body.tsx
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,4vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/scalare-l-eccellenza/body.tsx
+++ b/app/[locale]/lp/scalare-l-eccellenza/body.tsx
@@ -248,7 +248,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
       <section className="py-16 px-6 lg:px-10 bg-white">
         <div className="max-w-[1100px] mx-auto">
           <Reveal {...FADE} className="text-center mb-12">
-            <h2 className="text-[clamp(1.8rem,3.5vw,2.8rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] mb-3">
+            <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] mb-3">
               {t('heading')}</h2>
             <p className="text-[16px] text-[#0D0D0D]/45 max-w-[580px] mx-auto leading-[1.65]" style={{ fontWeight: 300 }}>
               {t('body')}</p>
@@ -282,7 +282,7 @@ function VetrinaLayer({ onUnlock }: { onUnlock: () => void }) {
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left */}
             <Reveal {...FADE}>
-              <h2 className="text-[clamp(1.8rem,3vw,2.4rem)] font-semibold tracking-[-0.03em] text-[#0D0D0D] leading-[1.15] mb-6">
+              <h2 className="text-[clamp(1.8rem,3vw,3rem)] font-semibold tracking-[-0.02em] text-[#0D0D0D] leading-[1.15] mb-6">
                 {t('heading2')}</h2>
               <ul className="space-y-3 mb-8">
                 {[

--- a/app/[locale]/lp/supermarkets/body.tsx
+++ b/app/[locale]/lp/supermarkets/body.tsx
@@ -203,7 +203,7 @@ export default function SupermarketsPage() {
             style={{ background: 'linear-gradient(120deg, #1a1a3f 0%, #201436 45%, #3a1730 100%)' }}>
             <div className="pointer-events-none absolute -top-24 right-[-80px] w-[420px] h-[420px] rounded-full" style={{ background: 'radial-gradient(circle, rgba(255,86,86,0.22) 0%, rgba(255,86,86,0) 65%)' }} />
             <div className="relative">
-              <h2 className="text-[26px] md:text-[38px] font-bold text-white tracking-[-0.02em] mb-3">{t('cta.title')}</h2>
+              <h2 className="text-[26px] md:text-[48px] font-semibold text-white tracking-[-0.02em] mb-3">{t('cta.title')}</h2>
               <p className="text-[15px] md:text-[16px] text-white/65 mb-8 max-w-xl mx-auto">{t('cta.body')}</p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
                 <a href={href('book-meeting', lang)} onClick={() => track('book_bottom')}

--- a/app/[locale]/resources/press/body.tsx
+++ b/app/[locale]/resources/press/body.tsx
@@ -200,7 +200,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">{t('text2')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
+              <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
             </Reveal>
 
             {(() => {
@@ -255,7 +255,7 @@ export default function PressPage() {
                 <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">
                   {t('italianKicker')}
                 </span>
-                <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">
+                <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">
                   {t('italianHeading')}
                 </h2>
               </Reveal>
@@ -308,7 +308,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">{t('text3')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading3')}</h2>
+              <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading3')}</h2>
             </Reveal>
 
             <div className="flex flex-col md:grid md:grid-cols-2 gap-3 md:gap-5 md:max-w-3xl">
@@ -355,7 +355,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#9B9DFB] tracking-[0.2em] uppercase mb-4 block">{t('text4')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-white/90 tracking-[-0.02em]">{t('heading4')}</h2>
+              <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold text-white/90 tracking-[-0.02em]">{t('heading4')}</h2>
             </Reveal>
 
             <div className="flex flex-col gap-3 md:gap-4">

--- a/app/[locale]/resources/press/body.tsx
+++ b/app/[locale]/resources/press/body.tsx
@@ -200,7 +200,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">{t('text2')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,2.2rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
+              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading2')}</h2>
             </Reveal>
 
             {(() => {
@@ -255,7 +255,7 @@ export default function PressPage() {
                 <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">
                   {t('italianKicker')}
                 </span>
-                <h2 className="text-[clamp(1.6rem,3vw,2.2rem)] font-semibold text-[#121212] tracking-[-0.02em]">
+                <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">
                   {t('italianHeading')}
                 </h2>
               </Reveal>
@@ -308,7 +308,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#4B4DF7] tracking-[0.2em] uppercase mb-4 block">{t('text3')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,2.2rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading3')}</h2>
+              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-[#121212] tracking-[-0.02em]">{t('heading3')}</h2>
             </Reveal>
 
             <div className="flex flex-col md:grid md:grid-cols-2 gap-3 md:gap-5 md:max-w-3xl">
@@ -355,7 +355,7 @@ export default function PressPage() {
               className="mb-8 md:mb-12"
             >
               <span className="text-[11px] font-bold text-[#9B9DFB] tracking-[0.2em] uppercase mb-4 block">{t('text4')}</span>
-              <h2 className="text-[clamp(1.6rem,3vw,2.2rem)] font-semibold text-white/90 tracking-[-0.02em]">{t('heading4')}</h2>
+              <h2 className="text-[clamp(1.6rem,3vw,3rem)] font-semibold text-white/90 tracking-[-0.02em]">{t('heading4')}</h2>
             </Reveal>
 
             <div className="flex flex-col gap-3 md:gap-4">

--- a/app/[locale]/resources/whitepapers/[slug]/body.tsx
+++ b/app/[locale]/resources/whitepapers/[slug]/body.tsx
@@ -208,7 +208,7 @@ export default function WhitepaperDetailPage({ slug }: { slug: string }) {
               <div className="w-16 h-16 rounded-2xl bg-[#4B4DF7]/[0.12] border border-[#4B4DF7]/[0.15] flex items-center justify-center mx-auto mb-6">
                 <FileText className="h-7 w-7 text-[#4B4DF7]" />
               </div>
-              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-3 tracking-[-0.02em]">{t('detail.heading')}</h2>
+              <h2 className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-white/90 mb-3 tracking-[-0.02em]">{t('detail.heading')}</h2>
               <p className="text-[15px] text-white/40">{t('detail.body2')}</p>
             </Reveal>
             <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] backdrop-blur-sm p-8 lg:p-10">
@@ -221,7 +221,7 @@ export default function WhitepaperDetailPage({ slug }: { slug: string }) {
         {related.length > 0 && (
           <section className="relative pt-8 pb-2 lg:pt-10 lg:pb-2">
             <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
-              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]">{t('detail.heading2')}</h2>
+              <h2 className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]">{t('detail.heading2')}</h2>
               <div className="grid md:grid-cols-2 gap-6">
                 {related.map((rw, i) => {
                   return (

--- a/app/[locale]/resources/whitepapers/[slug]/body.tsx
+++ b/app/[locale]/resources/whitepapers/[slug]/body.tsx
@@ -171,7 +171,7 @@ export default function WhitepaperDetailPage({ slug }: { slug: string }) {
         <section className="section-breathe">
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 py-20 lg:py-28">
             <Reveal y={20} duration={0.6} className="mb-14">
-              <h2 className="text-[clamp(1.8rem,3.5vw,2.5rem)] font-semibold text-[#121212] mb-4 tracking-[-0.02em]">
+              <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold text-[#121212] mb-4 tracking-[-0.02em]">
                 {t.rich('detail.insideHeading', { span: (chunks) => <span className="gradient-text-on-light">{chunks}</span> })}
               </h2>
               <p className="text-[16px] text-[#121212]/[0.45] max-w-xl">{t(`items.${slug}.fullDesc`)}</p>
@@ -208,7 +208,7 @@ export default function WhitepaperDetailPage({ slug }: { slug: string }) {
               <div className="w-16 h-16 rounded-2xl bg-[#4B4DF7]/[0.12] border border-[#4B4DF7]/[0.15] flex items-center justify-center mx-auto mb-6">
                 <FileText className="h-7 w-7 text-[#4B4DF7]" />
               </div>
-              <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-semibold text-white/90 mb-3">{t('detail.heading')}</h2>
+              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-3 tracking-[-0.02em]">{t('detail.heading')}</h2>
               <p className="text-[15px] text-white/40">{t('detail.body2')}</p>
             </Reveal>
             <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] backdrop-blur-sm p-8 lg:p-10">
@@ -221,7 +221,7 @@ export default function WhitepaperDetailPage({ slug }: { slug: string }) {
         {related.length > 0 && (
           <section className="relative pt-8 pb-2 lg:pt-10 lg:pb-2">
             <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
-              <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-semibold text-white/90 mb-10">{t('detail.heading2')}</h2>
+              <h2 className="text-[clamp(1.5rem,3vw,3rem)] font-semibold text-white/90 mb-10 tracking-[-0.02em]">{t('detail.heading2')}</h2>
               <div className="grid md:grid-cols-2 gap-6">
                 {related.map((rw, i) => {
                   return (

--- a/app/[locale]/resources/whitepapers/body.tsx
+++ b/app/[locale]/resources/whitepapers/body.tsx
@@ -156,7 +156,7 @@ export default function WhitepapersPage() {
         <section className="relative pt-8 pb-20 lg:pt-10 lg:pb-24">
           <div className="max-w-[1400px] mx-auto px-8 lg:px-12 text-center">
             <Reveal duration={0.7}>
-              <h2 className="text-[clamp(1.5rem,3vw,2.5rem)] font-semibold text-white/90 mb-4 leading-[1.2] max-w-2xl mx-auto">{t('heading2')}</h2>
+              <h2 className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-white/90 mb-4 leading-[1.2] max-w-2xl mx-auto tracking-[-0.02em]">{t('heading2')}</h2>
               <p className="text-[16px] text-white/[0.45] mb-8 max-w-xl mx-auto">{t('body2')}</p>
               <Button
                 onClick={() => { router.push(href('book-meeting', lang)); window.scrollTo(0, 0); }}

--- a/components/customers/CustomersFinalCTA.tsx
+++ b/components/customers/CustomersFinalCTA.tsx
@@ -24,7 +24,7 @@ export default function CustomersFinalCTA() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('finalCTA.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/customers/CustomersHero.tsx
+++ b/components/customers/CustomersHero.tsx
@@ -55,7 +55,7 @@ export default function CustomersHero() {
           className="text-[48px] md:text-[64px] font-semibold tracking-[-0.02em] text-white/95 mb-8 max-w-5xl"
           style={{ lineHeight: 1.15 }}
         >{t.rich('hero.heading', {
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           as="p"

--- a/components/customers/CustomersROI.tsx
+++ b/components/customers/CustomersROI.tsx
@@ -42,7 +42,7 @@ export default function CustomersROI() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-12 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('roi.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-warm-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-warm-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -76,7 +76,7 @@ export default function ExploreStories() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-12">
           <h2 className="text-[clamp(2.5rem,5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-6">{t.rich('exploreStories.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
           <p className="text-[20px] text-white/[0.65] leading-[1.75] max-w-2xl">{t('exploreStories.body')}</p>
         </Reveal>

--- a/components/customers/ExploreStories.tsx
+++ b/components/customers/ExploreStories.tsx
@@ -75,7 +75,7 @@ export default function ExploreStories() {
     <section id="explore" data-testid="explore-stories" className="relative py-20 lg:py-28">
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-12">
-          <h2 className="text-[clamp(2.5rem,5vw,4.5rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-6">{t.rich('exploreStories.heading', {
+          <h2 className="text-[clamp(2.5rem,5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-6">{t.rich('exploreStories.heading', {
             span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
           })}</h2>
           <p className="text-[20px] text-white/[0.65] leading-[1.75] max-w-2xl">{t('exploreStories.body')}</p>

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -20,8 +20,8 @@ export default function CTASection() {
           duration={0.8}
           className="mb-8 md:mb-8"
         >
-          <h2 className="text-[clamp(1.5rem,3.5vw,3.5rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-white/90 max-w-4xl">{t.rich('cta.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+          <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 max-w-4xl">{t.rich('cta.heading', {
+            span: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/landing/CustomerStoriesSection.tsx
+++ b/components/landing/CustomerStoriesSection.tsx
@@ -32,7 +32,7 @@ export default function CustomerStoriesSection() {
         {/* Header */}
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.6rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-3 md:mb-4">{t.rich('customerStories.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
           })}</h2>
           <p className="text-[15px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-2xl">{t('customerStories.body')}</p>
         </Reveal>
@@ -97,7 +97,7 @@ export default function CustomerStoriesSection() {
           className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 md:p-8 lg:p-10"
         >
           <h3 className="text-[18px] md:text-[20px] font-semibold text-white/90 mb-3 md:mb-4">{t.rich('customerStories.heading2', {
-            span: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
           })}</h3>
           <p className="text-[14px] md:text-[15px] text-white/[0.65] leading-[1.6] md:leading-[1.75] mb-4 md:mb-6 max-w-3xl">{t('customerStories.body2')}</p>
           <div className="flex flex-wrap gap-2 md:gap-3">

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -65,9 +65,9 @@ export default function HeroSection() {
                 {t.rich('hero.heading', {
                   l: (chunks) => <span className="md:whitespace-nowrap">{chunks}</span>,
                   g: (chunks) => (
-                    <span className="italic font-bold gradient-text md:whitespace-nowrap">{chunks}</span>
+                    <span className="italic font-semibold gradient-text md:whitespace-nowrap">{chunks}</span>
                   ),
-                  gw: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+                  gw: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
                   br: () => <br />,
                 })}
               </h1>

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -61,7 +61,7 @@ export default function HowItWorksSection() {
           transition={{ duration: 0.7 }}
         >
           <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold leading-[1.08] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('howItWorks.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </m.div>
 

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -60,7 +60,7 @@ export default function HowItWorksSection() {
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.7 }}
         >
-          <h2 className="text-[clamp(1.6rem,4vw,3.5rem)] font-bold leading-[1.08] tracking-[-0.03em] text-[#1A1A2E]">{t.rich('howItWorks.heading', {
+          <h2 className="text-[clamp(1.6rem,4vw,3rem)] font-semibold leading-[1.08] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('howItWorks.heading', {
             span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </m.div>

--- a/components/landing/ProblemSection.tsx
+++ b/components/landing/ProblemSection.tsx
@@ -44,7 +44,7 @@ export default function ProblemSection() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <AnimatedSection className="mb-4 md:mb-6">
           <h2 className="text-[clamp(1.6rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('problem.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </AnimatedSection>
 

--- a/components/landing/ROISection.tsx
+++ b/components/landing/ROISection.tsx
@@ -36,7 +36,7 @@ export default function ROISection() {
         {/* Header row: title left + CTA right */}
         <Reveal duration={0.7} className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 md:gap-6 lg:gap-8 mb-10 md:mb-16 lg:mb-20">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.1] tracking-[-0.02em] text-[#1A1A2E] max-w-4xl">{t.rich('roi.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-warm-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-warm-on-light">{chunks}</span>,
           })}</h2>
           <Button asChild variant="primary" mode="light" className="shrink-0">
             <a

--- a/components/landing/SolutionSection.tsx
+++ b/components/landing/SolutionSection.tsx
@@ -76,7 +76,7 @@ export default function SolutionSection() {
         <Reveal duration={0.7} className="mb-16 lg:mb-20">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 max-w-3xl">{t.rich('solution.heading', {
             br: () => <br />,
-            span: (chunks) => <span className="font-bold gradient-text-warm">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-warm">{chunks}</span>,
           })}</h2>
           <p className="text-[15px] md:text-[18px] text-white/[0.65] leading-[1.7] mt-4 md:mt-6 max-w-xl">{t('solution.body')}</p>
         </Reveal>

--- a/components/product/AssessmentFormats.tsx
+++ b/components/product/AssessmentFormats.tsx
@@ -43,7 +43,7 @@ export default function AssessmentFormats() {
     <section id="verification-formats" data-testid="verification-formats" className="relative py-16 md:py-20 lg:py-28">
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-14">
-          <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-bold leading-[1.05] tracking-[-0.03em] text-white/90">{t.rich('assessmentFormats.heading', {
+          <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('assessmentFormats.heading', {
             span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>

--- a/components/product/AssessmentFormats.tsx
+++ b/components/product/AssessmentFormats.tsx
@@ -44,7 +44,7 @@ export default function AssessmentFormats() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-14">
           <h2 className="text-[clamp(2rem,4vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('assessmentFormats.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/product/EnterpriseTrust.tsx
+++ b/components/product/EnterpriseTrust.tsx
@@ -35,7 +35,7 @@ export default function EnterpriseTrust() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-12">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] mb-4 md:mb-6">{t.rich('enterpriseTrust.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-[#7A7A7A] leading-[1.6] md:leading-[1.75] max-w-2xl">{t('enterpriseTrust.body')}</p>
         </Reveal>

--- a/components/product/HowSkillvueWorks.tsx
+++ b/components/product/HowSkillvueWorks.tsx
@@ -45,7 +45,7 @@ export default function HowSkillvueWorks() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 max-w-4xl mb-4 md:mb-6">{t.rich('howSkillvueWorks.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-2xl">{t('howSkillvueWorks.body')}</p>
         </Reveal>

--- a/components/product/IntegrationEcosystem.tsx
+++ b/components/product/IntegrationEcosystem.tsx
@@ -50,7 +50,7 @@ export default function IntegrationEcosystem() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-10">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] mb-3 md:mb-4">{t.rich('integrationEcosystem.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-[#7A7A7A] leading-[1.6] md:leading-[1.75] max-w-2xl mb-4 md:mb-6">{t('integrationEcosystem.body')}</p>
           <p className="text-[15px] text-[#7A7A7A] leading-[1.75]">

--- a/components/product/ProductCTA.tsx
+++ b/components/product/ProductCTA.tsx
@@ -16,7 +16,7 @@ export default function ProductCTA() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-6 md:mb-10">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('cta.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/product/ProductHero.tsx
+++ b/components/product/ProductHero.tsx
@@ -51,7 +51,7 @@ export default function ProductHero() {
               style={{ lineHeight: 1.1 }}
             >{t.rich('hero.heading', {
               br: () => <br />,
-              span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+              span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
             })}</Reveal>
 
             <Reveal

--- a/components/product/WhatSkillvueDoes.tsx
+++ b/components/product/WhatSkillvueDoes.tsx
@@ -37,7 +37,7 @@ export default function WhatSkillvueDoes() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] max-w-4xl mb-4 md:mb-6">{t.rich('whatSkillvueDoes.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-[#7A7A7A] leading-[1.6] md:leading-[1.75] max-w-2xl">{t('whatSkillvueDoes.body')}</p>
         </Reveal>

--- a/components/product/WhatWeAssess.tsx
+++ b/components/product/WhatWeAssess.tsx
@@ -31,7 +31,7 @@ export default function WhatWeAssess() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] mb-4 md:mb-6">{t.rich('whatWeAssess.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-[#7A7A7A] leading-[1.6] md:leading-[1.75] max-w-2xl">{t('whatWeAssess.body')}</p>
         </Reveal>

--- a/components/science/MethodologyLifecycle.tsx
+++ b/components/science/MethodologyLifecycle.tsx
@@ -69,7 +69,7 @@ export default function MethodologyLifecycle() {
         {/* Title */}
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-4 md:mb-6">{t.rich('methodologyLifecycle.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/science/MethodologyLifecycle.tsx
+++ b/components/science/MethodologyLifecycle.tsx
@@ -68,7 +68,7 @@ export default function MethodologyLifecycle() {
 
         {/* Title */}
         <Reveal duration={0.7} className="mb-8 md:mb-16">
-          <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-bold leading-[1.05] tracking-[-0.02em] text-white/90 mb-4 md:mb-6">{t.rich('methodologyLifecycle.heading', {
+          <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-4 md:mb-6">{t.rich('methodologyLifecycle.heading', {
             span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>

--- a/components/science/ResponsibleAI.tsx
+++ b/components/science/ResponsibleAI.tsx
@@ -69,7 +69,7 @@ export default function ResponsibleAI() {
         {/* Responsible AI */}
         <Reveal duration={0.7} className="mb-8 md:mb-12">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] max-w-4xl">{t.rich('responsibleAI.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 
@@ -80,7 +80,7 @@ export default function ResponsibleAI() {
         {/* FAQ */}
         <Reveal duration={0.7} className="mb-6 md:mb-10">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('responsibleAI.heading2', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/science/ScienceCTA.tsx
+++ b/components/science/ScienceCTA.tsx
@@ -16,7 +16,7 @@ export default function ScienceCTA() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-6 md:mb-10">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('cta.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
         <Reveal y={20} duration={0.7} delay={0.2}>

--- a/components/science/ScienceHero.tsx
+++ b/components/science/ScienceHero.tsx
@@ -24,7 +24,7 @@ export default function ScienceHero() {
               style={{ lineHeight: 1.1 }}
             >{t.rich('hero.heading', {
               br: () => <br />,
-              span: (chunks) => <span className="italic font-bold gradient-text">{chunks}</span>,
+              span: (chunks) => <span className="italic font-semibold gradient-text">{chunks}</span>,
             })}</Reveal>
             <Reveal
               y={20}

--- a/components/science/ScienceHero.tsx
+++ b/components/science/ScienceHero.tsx
@@ -14,7 +14,7 @@ export default function ScienceHero() {
     <section id="science-hero" data-testid="science-hero" className="relative min-h-screen flex flex-col justify-center pt-[80px] overflow-hidden">
       <div className="relative z-10 max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full py-10 md:py-16 lg:py-0">
         <div className="lg:grid lg:grid-cols-12 lg:gap-8 items-center">
-          <div className="lg:col-span-7 flex flex-col gap-8 md:gap-10">
+          <div className="lg:col-span-7 flex flex-col gap-6 md:gap-8">
             <Reveal
               as="h1"
               y={40}
@@ -30,9 +30,9 @@ export default function ScienceHero() {
               y={20}
               duration={0.8}
               delay={0.5}
-              className="flex flex-col gap-6"
+              className="flex flex-col gap-8 md:gap-10"
             >
-              <p className="text-[14px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-md lg:max-w-lg font-normal md:font-light">
+              <p className="text-[14px] md:text-[18px] text-white/[0.65] leading-[1.6] md:leading-[1.75] max-w-xl lg:max-w-2xl font-normal md:font-light">
                 {t('hero.body')}
               </p>
               <Button asChild variant="primary" mode="dark" className="self-start gap-8">

--- a/components/science/ScienceTeam.tsx
+++ b/components/science/ScienceTeam.tsx
@@ -81,9 +81,9 @@ export default function ScienceTeam() {
           delay={0.1}
           className="rounded-xl md:rounded-2xl border border-[#1A1A2E]/[0.06] bg-white p-5 md:p-6 lg:p-10 mb-8 md:mb-14"
         >
-          <div className="flex flex-col md:flex-row gap-5 md:gap-8 lg:gap-12 items-start">
-            <div className="shrink-0 w-full md:w-[clamp(6rem,25vw,12rem)] aspect-square rounded-xl md:rounded-2xl overflow-hidden bg-[#F5F5FA]">
-              <img loading="lazy" decoding="async" src={lead.photo} alt={lead.name} className="w-full h-full object-cover" />
+          <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] gap-5 md:gap-8 lg:gap-12">
+            <div className="relative shrink-0 w-full md:w-auto aspect-square rounded-xl md:rounded-2xl overflow-hidden bg-[#F5F5FA]">
+              <img loading="lazy" decoding="async" src={lead.photo} alt={lead.name} className="absolute inset-0 w-full h-full object-cover" />
             </div>
             <div className="flex-1 pt-0 md:pt-2">
               <h3 className="text-[clamp(1.5rem,2.5vw,2rem)] font-semibold text-[#1A1A2E] mb-1.5">

--- a/components/science/ScienceTeam.tsx
+++ b/components/science/ScienceTeam.tsx
@@ -70,7 +70,7 @@ export default function ScienceTeam() {
         {/* Section title */}
         <Reveal duration={0.7} className="mb-8 md:mb-12">
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('team.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/science/ScientificPillars.tsx
+++ b/components/science/ScientificPillars.tsx
@@ -34,7 +34,7 @@ export default async function ScientificPillars() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal className="mb-8 md:mb-16" duration={0.7}>
           <h2 className="text-[clamp(1.5rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('scientificPillars.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/shared/SolutionFinalCTA.tsx
+++ b/components/shared/SolutionFinalCTA.tsx
@@ -17,7 +17,7 @@ export default function SolutionFinalCTA({ headline, accentWord }) {
         <Reveal duration={0.7} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] backdrop-blur-sm p-5 md:p-8 lg:p-10 text-center">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90 mb-6">
             {headline}{' '}
-            <span className="italic font-bold gradient-text">{accentWord}</span>
+            <span className="italic font-semibold gradient-text">{accentWord}</span>
           </h2>
           <Button asChild variant="primary" mode="dark">
             <a href={href('book-meeting', lang)}>

--- a/components/solutions/im/IMHero.tsx
+++ b/components/solutions/im/IMHero.tsx
@@ -21,7 +21,7 @@ export default function IMHero() {
           className="text-[48px] md:text-[64px] font-semibold tracking-[-0.02em] text-white/95 mb-10 max-w-5xl"
           style={{ lineHeight: 1.15 }}
         >{t.rich('imHero.heading', {
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           y={20}

--- a/components/solutions/im/IMHowSolves.tsx
+++ b/components/solutions/im/IMHowSolves.tsx
@@ -32,7 +32,7 @@ export default function IMHowSolves() {
       <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="max-w-3xl mb-12 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('imHowSolves.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/im/IMProblem.tsx
+++ b/components/solutions/im/IMProblem.tsx
@@ -51,7 +51,7 @@ export default function IMProblem() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-12 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('imProblem.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/im/IMShift.tsx
+++ b/components/solutions/im/IMShift.tsx
@@ -29,7 +29,7 @@ export default function IMShift() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('imShift.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/ld/LDHero.tsx
+++ b/components/solutions/ld/LDHero.tsx
@@ -22,7 +22,7 @@ export default function LDHero() {
           style={{ lineHeight: 1.15 }}
         >{t.rich('ldHero.heading', {
           br: () => <br />,
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           y={20}

--- a/components/solutions/ld/LDHowSolves.tsx
+++ b/components/solutions/ld/LDHowSolves.tsx
@@ -60,7 +60,7 @@ export default function LDHowSolves() {
 
         <Reveal duration={0.7} className="max-w-3xl mb-12 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">{t.rich('ldHowSolves.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[15px] md:text-[17px] text-[#7A7A7A] leading-[1.75]">{t('ldHowSolves.body')}</p>
         </Reveal>

--- a/components/solutions/ld/LDImpact.tsx
+++ b/components/solutions/ld/LDImpact.tsx
@@ -64,7 +64,7 @@ export default function LDImpact() {
         {/* Header */}
         <Reveal duration={0.7} className="text-center mb-12 md:mb-16 lg:mb-20">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">{t.rich('ldImpact.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[15px] md:text-[17px] text-[#7A7A7A] leading-[1.75] max-w-2xl mx-auto">{t('ldImpact.body')}</p>
         </Reveal>

--- a/components/solutions/ld/LDIntegration.tsx
+++ b/components/solutions/ld/LDIntegration.tsx
@@ -13,8 +13,8 @@ export default function LDIntegration() {
     <section id="ld-integration" data-testid="ld-integration" className="relative py-20 lg:py-28">
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="rounded-2xl border border-white/[0.08] bg-white/[0.04] backdrop-blur-sm p-10">
-          <h2 className="text-[clamp(1.5rem,2.5vw,2.2rem)] font-semibold text-white/90 mb-6">{t.rich('ldIntegration.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          <h2 className="text-[clamp(1.5rem,4vw,3rem)] font-semibold text-white/90 mb-6 tracking-[-0.02em]">{t.rich('ldIntegration.heading', {
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
           <p className="text-[16px] text-white/[0.65] leading-[1.75] max-w-3xl mb-10">{t('ldIntegration.body')}</p>
           <div className="flex flex-wrap gap-3">

--- a/components/solutions/ld/LDProblem.tsx
+++ b/components/solutions/ld/LDProblem.tsx
@@ -27,7 +27,7 @@ export default function LDProblem() {
       <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('ldProblem.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/ld/LDShift.tsx
+++ b/components/solutions/ld/LDShift.tsx
@@ -29,7 +29,7 @@ export default function LDShift() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('ldShift.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/pm/PMHero.tsx
+++ b/components/solutions/pm/PMHero.tsx
@@ -21,7 +21,7 @@ export default function PMHero() {
           className="text-[48px] md:text-[64px] font-semibold tracking-[-0.02em] text-white/95 mb-10 max-w-5xl"
           style={{ lineHeight: 1.15 }}
         >{t.rich('pmHero.heading', {
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           y={20}

--- a/components/solutions/pm/PMHowSolves.tsx
+++ b/components/solutions/pm/PMHowSolves.tsx
@@ -12,7 +12,7 @@ export default function PMHowSolves() {
       <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('pmHowSolves.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/pm/PMProblem.tsx
+++ b/components/solutions/pm/PMProblem.tsx
@@ -62,7 +62,7 @@ export default function PMProblem() {
         {/* Header row: title + subtitle */}
         <Reveal duration={0.7} className="max-w-3xl mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">{t.rich('pmProblem.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[17px] text-[#7A7A7A] leading-[1.75]">{t('pmProblem.body')}</p>
         </Reveal>

--- a/components/solutions/pm/PMShift.tsx
+++ b/components/solutions/pm/PMShift.tsx
@@ -27,7 +27,7 @@ export default function PMShift() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('pmShift.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/pr/PRConsulting.tsx
+++ b/components/solutions/pr/PRConsulting.tsx
@@ -61,7 +61,7 @@ export default function PRConsulting() {
         {/* Header */}
         <Reveal duration={0.7} className="max-w-3xl mb-12 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212] mb-5">{t.rich('prConsulting.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[15px] md:text-[17px] text-[#7A7A7A] leading-[1.75] max-w-2xl">{t('prConsulting.body')}</p>
         </Reveal>

--- a/components/solutions/pr/PRHero.tsx
+++ b/components/solutions/pr/PRHero.tsx
@@ -21,7 +21,7 @@ export default function PRHero() {
           className="text-[48px] md:text-[64px] font-semibold tracking-[-0.02em] text-white/95 mb-10 max-w-5xl"
           style={{ lineHeight: 1.15 }}
         >{t.rich('prHero.heading', {
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           y={20}

--- a/components/solutions/pr/PRHowSolves.tsx
+++ b/components/solutions/pr/PRHowSolves.tsx
@@ -29,7 +29,7 @@ export default function PRHowSolves() {
       <div className="max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('prHowSolves.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/pr/PRProblem.tsx
+++ b/components/solutions/pr/PRProblem.tsx
@@ -29,7 +29,7 @@ export default function PRProblem() {
       <div className="relative max-w-[1400px] mx-auto px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#121212]">{t.rich('prProblem.heading', {
-            span: (chunks) => <span className="font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/ta/TAFunnel.tsx
+++ b/components/solutions/ta/TAFunnel.tsx
@@ -158,7 +158,7 @@ export default function TAFunnel() {
         {/* Title */}
         <Reveal duration={0.7} className="mb-8 md:mb-14">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] max-w-4xl">{t.rich('taFunnel.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/ta/TAHero.tsx
+++ b/components/solutions/ta/TAHero.tsx
@@ -22,7 +22,7 @@ export default function TAHero() {
           style={{ lineHeight: 1.1 }}
         >{t.rich('taHero.heading', {
           br: () => <br />,
-          span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+          span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
         })}</Reveal>
         <Reveal
           y={20}

--- a/components/solutions/ta/TAImpact.tsx
+++ b/components/solutions/ta/TAImpact.tsx
@@ -27,7 +27,7 @@ export default function TAImpact() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="mb-8 md:mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E]">{t.rich('taImpact.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
         </Reveal>
         <div className="grid gap-4 lg:grid-cols-3 lg:gap-5">

--- a/components/solutions/ta/TAProblem.tsx
+++ b/components/solutions/ta/TAProblem.tsx
@@ -27,7 +27,7 @@ export default function TAProblem() {
       <div className="relative max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12">
         <Reveal duration={0.7} className="max-w-[900px] mb-16">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-[#1A1A2E] mb-8">{t.rich('taProblem.heading', {
-            span: (chunks) => <span className="italic font-bold gradient-text-on-light">{chunks}</span>,
+            span: (chunks) => <span className="italic font-semibold gradient-text-on-light">{chunks}</span>,
           })}</h2>
           <p className="text-[14px] md:text-[18px] text-[#7A7A7A] leading-[1.75]">{t('taProblem.body')}</p>
         </Reveal>

--- a/components/solutions/ta/TAShift.tsx
+++ b/components/solutions/ta/TAShift.tsx
@@ -29,7 +29,7 @@ export default function TAShift() {
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full">
         <Reveal duration={0.7} className="mb-10 md:mb-20">
           <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('taShift.heading', {
-            span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+            span: (chunks) => <span className="font-semibold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>
 

--- a/components/solutions/ta/TAShift.tsx
+++ b/components/solutions/ta/TAShift.tsx
@@ -28,7 +28,7 @@ export default function TAShift() {
     <section id="ta-shift" data-testid="ta-shift" className="relative py-20 lg:py-28 md:flex md:items-center">
       <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 w-full">
         <Reveal duration={0.7} className="mb-10 md:mb-20">
-          <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.03em] text-white/90">{t.rich('taShift.heading', {
+          <h2 className="text-[clamp(1.8rem,3.5vw,3rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white/90">{t.rich('taShift.heading', {
             span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
           })}</h2>
         </Reveal>

--- a/messages/en.json
+++ b/messages/en.json
@@ -5115,7 +5115,7 @@
           "role": "HR Director"
         }
       },
-      "heading": "Proof, not <span>promises.</span>",
+      "heading": "<span>Proof</span>, not promises.",
       "body": "Leading Global enterprises make talent decisions with confidence.",
       "cta": "Book a Demo",
       "cta2": "Join 50+ Global enterprises",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7145,7 +7145,7 @@
       "cta": "Book a Demo"
     },
     "hero": {
-      "heading": "Science you can stake<br></br>talent decisions<br></br><span>on.</span>",
+      "heading": "Science you can stake<br></br>talent decisions <span>on.</span>",
       "cta": "Book a Demo",
       "body": "Measuring people is hard. To make talent decisions you can trust, accuracy and reliability aren't optional. Skillvue is built on I/O psychology and psychometrics, ensuring every data point holds up to scrutiny."
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -7086,7 +7086,7 @@
           "desc": "Because skills and roles evolve quickly, measurement must evolve with them. Continuous monitoring and scientist-led iteration keep signals accurate and defensible."
         }
       },
-      "heading": "A rigorous, end-to-end verification <span>lifecycle</span>",
+      "heading": "A <span>rigorous</span>, end-to-end verification lifecycle",
       "text": "Step"
     },
     "responsibleAI": {
@@ -7134,7 +7134,7 @@
           "a": "Yes. Every deployment starts with your competency model. We map your framework to validated constructs, generate contextualized items, and validate them against your population before going live."
         }
       },
-      "heading": "Responsible AI built for <span>high-stakes talent decisions</span>",
+      "heading": "<span>Responsible AI</span> built for high-stakes talent decisions",
       "heading2": "Frequently asked <span>questions</span>"
     },
     "cta": {
@@ -7145,7 +7145,7 @@
       "cta": "Book a Demo"
     },
     "hero": {
-      "heading": "Science you can stake<br></br>talent decisions <span>on.</span>",
+      "heading": "<span>Science</span> you can stake<br></br>talent decisions on.",
       "cta": "Book a Demo",
       "body": "Measuring people is hard. To make talent decisions you can trust, accuracy and reliability aren't optional. Skillvue is built on I/O psychology and psychometrics, ensuring every data point holds up to scrutiny."
     },
@@ -7164,7 +7164,7 @@
           "role": "People Scientist"
         }
       },
-      "heading": "The team behind the <span>science</span>",
+      "heading": "The <span>team</span> behind the science",
       "body": "External collaborators from academic, HR consulting and corporate world",
       "lead": {
         "role": "Head of AI & Science",
@@ -7184,7 +7184,7 @@
           "desc": "Psychometrics governs the design of every verification we build: which format, which scale, which scoring model. The goal is simple: maximize accuracy, minimize noise, and make sure results mean what they claim to mean."
         }
       },
-      "heading": "Two disciplines, one standard of <span>rigor</span>"
+      "heading": "Two disciplines, <span>one standard of rigor</span>"
     },
     "meta": {
       "title": "The Science Behind Skillvue | Psychometrics & AI",

--- a/messages/it.json
+++ b/messages/it.json
@@ -5115,7 +5115,7 @@
           "role": "Direttore HR"
         }
       },
-      "heading": "Fatti, non <span>promesse.</span>",
+      "heading": "<span>Fatti</span>, non promesse.",
       "body": "Le principali aziende globali prendono decisioni sul talento con fiducia.",
       "cta": "Prenota una Demo",
       "cta2": "Unisciti a oltre 50 aziende globali",

--- a/messages/it.json
+++ b/messages/it.json
@@ -7086,7 +7086,7 @@
           "desc": "Dato che competenze e ruoli evolvono rapidamente, la misurazione deve evolvere con loro. Monitoraggio continuo e iterazione guidata dagli scienziati sono un must per rendere le nostre valutazioni accurate e difendibili."
         }
       },
-      "heading": "Un verification rigoroso per gestire un <span>lifecycle end-to-end</span>",
+      "heading": "Un verification <span>rigoroso</span> per gestire un lifecycle end-to-end",
       "text": "Passo"
     },
     "responsibleAI": {
@@ -7134,7 +7134,7 @@
           "a": "Sì. Ogni progetto parte dal tuo modello di competenze. Mappiamo il tuo framework di costrutti validati, generiamo item contestualizzati e li validiamo prima di andare live con l'verification."
         }
       },
-      "heading": "AI responsabile, costruita per le decisioni che più contano nella <span>gestione del talento</span>",
+      "heading": "<span>AI responsabile</span>, costruita per le decisioni che più contano nella gestione del talento",
       "heading2": "Q&A <span></span>"
     },
     "cta": {
@@ -7145,7 +7145,7 @@
       "cta": "Prenota una Demo"
     },
     "hero": {
-      "heading": "Scienza su cui puoi<br></br>basare <span>le tue decisioni</span>",
+      "heading": "<span>Scienza</span> su cui puoi<br></br>basare le tue decisioni",
       "cta": "Prenota una Demo",
       "body": "Valutare le persone è difficile. Per prendere decisioni sul talento di cui fidarsi, accuratezza e affidabilità non possono essere degli optional. Skillvue è costruito su basi psicometriche e psicologiche rigorose, che garantiscono output a prova di qualsiasi scrutinio."
     },
@@ -7164,7 +7164,7 @@
           "role": "People Scientist"
         }
       },
-      "heading": "Il team dietro la <span>scienza</span>",
+      "heading": "Il <span>team</span> dietro la scienza",
       "body": "collaboratori esterni dal mondo accademico, della consulenza HR e delle grandi corporate",
       "lead": {
         "role": "Head of AI & Science",

--- a/messages/it.json
+++ b/messages/it.json
@@ -7145,7 +7145,7 @@
       "cta": "Prenota una Demo"
     },
     "hero": {
-      "heading": "Scienza su cui puoi<br></br>basare<br></br><span>le tue decisioni</span>",
+      "heading": "Scienza su cui puoi<br></br>basare <span>le tue decisioni</span>",
       "cta": "Prenota una Demo",
       "body": "Valutare le persone è difficile. Per prendere decisioni sul talento di cui fidarsi, accuratezza e affidabilità non possono essere degli optional. Skillvue è costruito su basi psicometriche e psicologiche rigorose, che garantiscono output a prova di qualsiasi scrutinio."
     },


### PR DESCRIPTION
## Summary
- Normalized every section-title H2 sitewide to a consistent 48px desktop maximum, -2% letter-spacing, and font-semibold weight, bringing over 20 different inconsistent size/weight/tracking combinations across ~90 files into one standard.
- Fixed the accent-span pattern used by `t.rich()` headings, which had a systemic bug: the gradient-colored accent phrase rendered bolder (font-bold) than the rest of the heading (font-semibold) on both H1 hero headings and H2 section titles across the site. Accent phrases are now differentiated only by color, matching the intended design.
- Fixed the Science page hero: an orphaned single-word accent line, a subtitle capped much narrower than the heading, and an inverted heading/subtitle/button spacing rhythm compared to the homepage hero.
- Fixed the Science page team section: the lead photo now stretches to match the height of its neighboring bio text while staying 1:1, instead of a small fixed square.
- Repositioned the gradient accent emphasis on 5 Science page headings and the homepage's "Proof, not promises." heading to the words specified in review.

## Test plan
- [x] `./harness/init.sh` passes (all gates + build)
- [x] Verified live in both locales at multiple viewport widths (desktop maxes, mobile scaling)
- [x] Verified H1/H2 accent-weight fix across Home, Product, Science, all 5 Solutions pages, Customers, Careers, Book a Demo, Demo pages
- [x] Verified Science page hero, subtitle, spacing, and team photo fixes at desktop and mobile widths, both locales
