### PR TITLE
Dashboard demo cross-country

### DIFF
--- a/app/[locale]/demo/body.tsx
+++ b/app/[locale]/demo/body.tsx
@@ -21,7 +21,7 @@ import { href } from '@/i18n/routes';
 const DASHBOARDS = [
   { id: 'retail', Icon: Store, route: 'demo/retail' },
   { id: 'salesNetwork', Icon: Users, route: 'demo/sales-network' },
-  { id: 'crossCountry', Icon: Globe, route: undefined },
+  { id: 'crossCountry', Icon: Globe, route: 'demo/cross-country' },
 ];
 
 // The preview chart's numbers. Illustrative, and said to be illustrative in
@@ -123,23 +123,18 @@ export default function DemoHub() {
                   <p className="text-[14px] text-white/[0.55] leading-[1.7] mb-6">
                     {t(`dashboards.${id}.body`)}
                   </p>
-                  {/* A card without a route is a dashboard not built yet, and
-                      it stays a badge: a card that navigates nowhere reads as a
-                      broken site rather than as a roadmap. */}
-                  {route ? (
-                    <a
-                      href={href(route, lang)}
-                      className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
-                    >
-                      <span className="h-1.5 w-1.5 rounded-full bg-[#5DDBA4]" />
-                      {t('status.open')}
-                    </a>
-                  ) : (
-                    <span className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/50">
-                      <span className="h-1.5 w-1.5 rounded-full bg-[#FFAF64]" />
-                      {t('status.comingSoon')}
-                    </span>
-                  )}
+                  {/* All three dashboards exist now, so the "coming soon" badge
+                      and its message are gone rather than kept dead for a fourth
+                      card that may never come. A card added without a route
+                      fails at prerender inside href(), which is the loud
+                      failure this repo prefers over a silently missing link. */}
+                  <a
+                    href={href(route, lang)}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-3 py-1.5 text-[12px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-[#5DDBA4]" />
+                    {t('status.open')}
+                  </a>
                 </Reveal>
               ))}
             </div>

--- a/app/[locale]/demo/cross-country/body.tsx
+++ b/app/[locale]/demo/cross-country/body.tsx
@@ -557,10 +557,16 @@ export default function CrossCountryDemo() {
 
           <Panel
             title={t('mobility.heading')}
+            // Four numbers, not three. `somewhatReluctant` used to be added to
+            // `notInterested` and called the no — which is the same move as
+            // adding "would consider it" to the yes, in the sentence that
+            // explains why we do not do that. Reluctance is hesitation; it
+            // belongs in the middle with the maybes, not at an end.
             body={t('mobility.body', {
               yes: n(mobility.veryWilling + mobility.willing),
               maybe: n(mobility.openToConsidering),
-              no: n(mobility.somewhatReluctant + mobility.notInterested),
+              reluctant: n(mobility.somewhatReluctant),
+              no: n(mobility.notInterested),
             })}
             note={t('mobility.caption')}
           >

--- a/app/[locale]/demo/cross-country/body.tsx
+++ b/app/[locale]/demo/cross-country/body.tsx
@@ -1,0 +1,639 @@
+'use client';
+
+// The cross-country demo dashboard.
+//
+// Same construction as the other two: numbers from data/demo/cross-country.ts,
+// words from messages/ under demo.cross-country, charts from the one wrapper.
+//
+// Two things this page does not draw.
+//
+// 1. No radar comparing two groups. The Acceptance asks for one, and the
+//    extract cannot carry it: `countryGroups` holds a headcount and a skill
+//    matching mean per group and nothing else, so there are no axes to put a
+//    radar on. A one-dimensional radar is a bar chart wearing a costume, and
+//    the bar chart says the same thing without implying the extract has a
+//    per-group competency profile in it. The group selector went with it —
+//    a control that redraws nothing is worse than no control.
+//
+// 2. No reading built on `skillMatching.min` or `max`. Those are two
+//    individuals' scores rather than group statistics, so a "top performer"
+//    framing on them would be an individual record with a label on it. The
+//    section works off `distribution` and `median`.
+
+import { useMemo, useState, type ReactNode } from 'react';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
+import Footer from '@/components/Footer';
+import Navbar from '@/components/landing/Navbar';
+import { Reveal } from '@/components/ui/reveal';
+import DemoView from '@/components/demo/DemoView';
+import Chart from '@/components/demo/charts/Chart';
+import { crossCountry } from '@/data/demo/cross-country';
+import { href } from '@/i18n/routes';
+
+const FRAMES = ['competencies', 'framework'];
+const COMPETENCIES = Object.keys(crossCountry.competencies);
+const BANDS = Object.keys(crossCountry.competencies.vision.bands);
+const GROUPS = Object.keys(crossCountry.countryGroups);
+const MOBILITY = Object.keys(crossCountry.mobility);
+const AREAS = Object.keys(crossCountry.preferredAreas);
+const GROWTH = Object.keys(crossCountry.growth);
+const HOW_TO_READ = ['matching', 'scale', 'groups', 'areas', 'mobility', 'counts'];
+
+// Every hex here is already in the ALLOWED list of scripts/check-colors.mjs.
+const SERIES = ['#4B4DF7', '#FFAF64', '#5DDBA4', '#8A8CFF', '#FF5656'];
+const GRID = 'rgba(255,255,255,0.06)';
+const TICK = 'rgba(255,255,255,0.45)';
+const AXIS = { grid: { color: GRID }, ticks: { color: TICK } };
+const LEGEND = {
+  labels: { color: 'rgba(255,255,255,0.6)', usePointStyle: true, boxWidth: 8, padding: 16 },
+};
+const axisTitle = (text: string) => ({ display: true, text, color: TICK });
+
+const sum = (values: number[]) => values.reduce((a, b) => a + b, 0);
+
+/** The recurring card. Local, because nothing outside this page has a second use for it. */
+function Panel({
+  title,
+  body,
+  note,
+  children,
+}: {
+  title: string;
+  body?: string;
+  note?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Reveal
+      as="section"
+      y={20}
+      duration={0.6}
+      className="rounded-xl md:rounded-2xl border border-white/[0.08] bg-white/[0.04] p-6 md:p-10"
+    >
+      <h2 className="text-[24px] md:text-[32px] font-semibold text-white/90 mb-3">{title}</h2>
+      {body ? (
+        <p className="text-[15px] text-white/[0.55] leading-[1.7] max-w-3xl mb-8">{body}</p>
+      ) : null}
+      {children}
+      {note ? (
+        <p className="text-[13px] text-white/40 leading-[1.7] max-w-3xl mt-6">{note}</p>
+      ) : null}
+    </Reveal>
+  );
+}
+
+export default function CrossCountryDemo() {
+  const lang = useLocale();
+  // The namespace is the route id with '/' becoming '.', so it keeps the kebab.
+  const t = useTranslations('demo.cross-country');
+  const format = useFormatter();
+  const [frame, setFrame] = useState(FRAMES[0]);
+  const [skill, setSkill] = useState(COMPETENCIES[0]);
+
+  // Formatting first, then interpolation: next-intl passes a numeric ICU
+  // argument through as-is, so `{below}` would print "51.2" on the Italian page
+  // beside the "51,2" everything else produces.
+  const n = (value: number, digits = 1) =>
+    format.number(value, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+
+  const { population, skillMatching, countryGroups, mobility, preferredAreas, growth } = crossCountry;
+  const items = frame === 'competencies' ? COMPETENCIES : Object.keys(crossCountry.framework);
+  const source = crossCountry[frame];
+  const nameOf = (id: string) => t(`${frame}.${id}`);
+
+  const belowThreshold = sum(
+    skillMatching.distribution.slice(0, skillMatching.threshold / skillMatching.binWidth),
+  );
+  const groupsBySize = [...GROUPS].sort((a, b) => countryGroups[b].n - countryGroups[a].n);
+  const groupMatching = GROUPS.map((g) => countryGroups[g].skillMatching);
+  const best = GROUPS.reduce((a, b) =>
+    countryGroups[b].skillMatching > countryGroups[a].skillMatching ? b : a,
+  );
+
+  // Neither of these depends on the selectors, so they are built once.
+  const fixed = useMemo(
+    () => ({
+      matching: {
+        data: {
+          labels: skillMatching.distribution.map(
+            (_, i) => `${i * skillMatching.binWidth}–${(i + 1) * skillMatching.binWidth}`,
+          ),
+          datasets: [
+            {
+              label: t('matching.series'),
+              data: [...skillMatching.distribution],
+              backgroundColor: SERIES[0],
+              hoverBackgroundColor: '#7B7DF9',
+              borderRadius: 4,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, grid: { display: false }, title: axisTitle(t('matching.axisScore')) },
+            y: { ...AXIS, beginAtZero: true, title: axisTitle(t('matching.axis')) },
+          },
+        },
+      },
+
+      groups: {
+        data: {
+          labels: GROUPS.map((g) => t(`groups.names.${g}`)),
+          datasets: [
+            {
+              label: t('groups.series'),
+              data: groupMatching,
+              backgroundColor: SERIES[0],
+              borderRadius: 4,
+              maxBarThickness: 56,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, grid: { display: false } },
+            // Zero-based: the three means are within three points of each
+            // other, and a truncated axis would draw that as a chasm.
+            y: { ...AXIS, beginAtZero: true, title: axisTitle(t('groups.axis')) },
+          },
+        },
+      },
+
+      mobility: {
+        data: {
+          labels: MOBILITY.map((m) => t(`mobility.items.${m}`)),
+          datasets: [
+            {
+              label: t('mobility.series'),
+              data: MOBILITY.map((m) => mobility[m]),
+              backgroundColor: SERIES[0],
+              borderRadius: 4,
+              maxBarThickness: 56,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, grid: { display: false } },
+            y: { ...AXIS, beginAtZero: true, title: axisTitle(t('mobility.axis')) },
+          },
+        },
+      },
+
+      areas: {
+        data: {
+          labels: AREAS.map((a) => t(`areas.items.${a}`)),
+          datasets: [
+            {
+              label: t('areas.series'),
+              data: AREAS.map((a) => preferredAreas[a]),
+              backgroundColor: SERIES[2],
+              borderRadius: 4,
+              maxBarThickness: 40,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          indexAxis: 'y' as const,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, beginAtZero: true, title: axisTitle(t('areas.axis')) },
+            y: { ...AXIS, grid: { display: false } },
+          },
+        },
+      },
+
+      growth: {
+        data: {
+          labels: GROWTH.map((g) => t(`growth.items.${g}`)),
+          datasets: [
+            {
+              label: t('growth.series'),
+              data: GROWTH.map((g) => growth[g]),
+              backgroundColor: SERIES[1],
+              borderRadius: 4,
+              maxBarThickness: 40,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          indexAxis: 'y' as const,
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { ...AXIS, beginAtZero: true, title: axisTitle(t('growth.axis')) },
+            y: { ...AXIS, grid: { display: false } },
+          },
+        },
+      },
+    }),
+    [t, lang],
+  );
+
+  // The two panels the frame selector drives.
+  const frameCharts = useMemo(
+    () => ({
+      means: {
+        data: {
+          labels: items.map(nameOf),
+          datasets: [
+            {
+              label: t('frames.means.series'),
+              data: items.map((id) => source[id].mean),
+              backgroundColor: SERIES[0],
+              borderRadius: 4,
+              maxBarThickness: 32,
+            },
+          ],
+        },
+        options: {
+          locale: lang,
+          indexAxis: 'y' as const,
+          plugins: { legend: { display: false } },
+          // Zero-based, and no maximum: the five-point scale is the client's
+          // and its top is not in the extract, so the page does not assert one.
+          scales: {
+            x: { ...AXIS, beginAtZero: true },
+            y: { ...AXIS, grid: { display: false } },
+          },
+        },
+      },
+
+      bands: {
+        data: {
+          labels: items.map(nameOf),
+          datasets: BANDS.map((band, i) => ({
+            label: t(`bands.${band}`),
+            data: items.map((id) => source[id].bands[band]),
+            backgroundColor: SERIES[i],
+            borderRadius: 2,
+          })),
+        },
+        options: {
+          locale: lang,
+          indexAxis: 'y' as const,
+          plugins: { legend: { ...LEGEND, position: 'bottom' as const } },
+          scales: {
+            x: { ...AXIS, stacked: true, min: 0, max: 100, title: axisTitle(t('frames.bands.axis')) },
+            y: { ...AXIS, stacked: true, grid: { display: false } },
+          },
+        },
+      },
+    }),
+    // `frame` is what `items`, `source` and `nameOf` derive from.
+    [t, lang, frame],
+  );
+
+  const drivers = useMemo(() => {
+    const keys = Object.keys(crossCountry.drivers[skill]);
+    return {
+      data: {
+        labels: keys.map((d) => t(`drivers.names.${d}`)),
+        datasets: [
+          {
+            label: t('drivers.series'),
+            data: keys.map((d) => crossCountry.drivers[skill][d]),
+            backgroundColor: SERIES[1],
+            borderRadius: 4,
+            maxBarThickness: 20,
+          },
+        ],
+      },
+      options: {
+        locale: lang,
+        indexAxis: 'y' as const,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { ...AXIS, beginAtZero: true },
+          y: { ...AXIS, grid: { display: false } },
+        },
+      },
+      count: keys.length,
+    };
+  }, [t, lang, skill]);
+
+  const headline = [
+    { id: 'invited', value: n(population.invited, 0) },
+    { id: 'evaluated', value: n(population.evaluated, 0) },
+    { id: 'completion', value: `${n(population.evaluatedPct)}%` },
+  ];
+
+  return (
+    <>
+      <DemoView slug="cross-country" />
+      <Navbar />
+      <main>
+        <section className="relative pt-[80px]">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 py-20 lg:py-24">
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              className="text-[13px] font-semibold tracking-[0.18em] uppercase text-white/40 mb-6"
+            >
+              {t('hero.eyebrow')}
+            </Reveal>
+            <Reveal
+              as="h1"
+              y={40}
+              duration={0.8}
+              delay={0.1}
+              className="text-[40px] md:text-[56px] font-semibold tracking-[-0.02em] text-white/95 mb-8 max-w-4xl"
+              style={{ lineHeight: 1.15 }}
+            >
+              {t.rich('hero.heading', {
+                span: (chunks) => <span className="font-bold gradient-text">{chunks}</span>,
+              })}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.8}
+              delay={0.2}
+              className="text-[18px] text-white/[0.65] leading-[1.75] max-w-3xl mb-8"
+              style={{ fontWeight: 300 }}
+            >
+              {t('hero.body')}
+            </Reveal>
+            <Reveal
+              as="p"
+              y={20}
+              duration={0.6}
+              delay={0.3}
+              className="text-[14px] text-white/40 leading-[1.7] max-w-2xl"
+            >
+              {t('hero.note')}
+            </Reveal>
+          </div>
+        </section>
+
+        <div className="max-w-[1400px] mx-auto px-5 md:px-8 lg:px-12 pb-24 lg:pb-32 flex flex-col gap-4 md:gap-6">
+          <Panel title={t('population.heading')} note={t('population.rounding')}>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 md:gap-8">
+              {headline.map((s) => (
+                <div key={s.id}>
+                  <span
+                    className="block text-white stat-value text-[32px] md:text-[44px] mb-2"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {s.value}
+                  </span>
+                  <span className="block text-[14px] font-semibold text-white/80 mb-2">
+                    {t(`population.${s.id}.label`)}
+                  </span>
+                  <span className="block text-[13px] text-white/40 leading-[1.7]">
+                    {t(`population.${s.id}.note`)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel
+            title={t('matching.heading')}
+            body={t('matching.body', {
+              threshold: n(skillMatching.threshold, 0),
+              below: n(belowThreshold),
+              above: n(100 - belowThreshold),
+            })}
+            note={t('matching.caption')}
+          >
+            <div className="flex flex-wrap gap-8 mb-8">
+              {[
+                { id: 'mean', value: skillMatching.mean },
+                { id: 'median', value: skillMatching.median },
+              ].map((s) => (
+                <div key={s.id}>
+                  <span
+                    className="block text-white stat-value text-[26px] md:text-[32px] mb-1"
+                    style={{ lineHeight: 1, letterSpacing: '-0.03em' }}
+                  >
+                    {n(s.value)}
+                  </span>
+                  <span className="block text-[13px] text-white/45">{t(`matching.${s.id}`)}</span>
+                </div>
+              ))}
+            </div>
+            <Chart
+              className="h-[280px] md:h-[340px]"
+              type="bar"
+              ariaLabel={t('matching.ariaLabel')}
+              data={fixed.matching.data}
+              options={fixed.matching.options}
+            />
+          </Panel>
+
+          <Panel
+            title={t('groups.heading')}
+            body={t('groups.body')}
+            note={t('groups.caption', {
+              spread: n(Math.max(...groupMatching) - Math.min(...groupMatching)),
+              small: n(countryGroups[best].n, 0),
+              large: n(countryGroups[groupsBySize[0]].n, 0),
+            })}
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+              {GROUPS.map((g, i) => (
+                <div key={g} className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5">
+                  <span
+                    className="block h-1 w-8 rounded-full mb-4"
+                    style={{ backgroundColor: SERIES[i] }}
+                  />
+                  <span className="block text-[15px] font-semibold text-white/90 mb-3">
+                    {t(`groups.names.${g}`)}
+                  </span>
+                  <div className="flex items-baseline justify-between gap-4">
+                    <span className="text-[13px] text-white/45">{t('groups.people')}</span>
+                    <span className="text-[14px] font-semibold text-white/85 tabular-nums">
+                      {n(countryGroups[g].n, 0)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <Chart
+              className="h-[260px] md:h-[320px]"
+              type="bar"
+              ariaLabel={t('groups.ariaLabel')}
+              data={fixed.groups.data}
+              options={fixed.groups.options}
+            />
+          </Panel>
+
+          <Panel title={t('frames.heading')} body={t('frames.body')}>
+            <div className="flex flex-wrap items-center gap-2 mb-8">
+              <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 mr-2">
+                {t('frames.label')}
+              </span>
+              {FRAMES.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  aria-pressed={frame === f}
+                  onClick={() => setFrame(f)}
+                  className={`px-4 py-2 md:px-5 md:py-2.5 rounded-full text-[13px] font-medium transition-all duration-300 ${
+                    frame === f
+                      ? 'bg-white/[0.1] text-white border border-white/[0.15]'
+                      : 'text-white/40 border border-transparent hover:text-white/70'
+                  }`}
+                >
+                  {t(`frames.options.${f}`)}
+                </button>
+              ))}
+            </div>
+
+            <h3 className="text-[17px] font-semibold text-white/85 mb-4">
+              {t('frames.means.heading')}
+            </h3>
+            <Chart
+              className="h-[240px] md:h-[320px]"
+              type="bar"
+              ariaLabel={t('frames.means.ariaLabel')}
+              data={frameCharts.means.data}
+              options={frameCharts.means.options}
+            />
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+              {t('frames.means.caption', {
+                narrow: n(spreadOf(crossCountry.competencies), 2),
+                wide: n(spreadOf(crossCountry.framework), 2),
+              })}
+            </p>
+
+            <h3 className="text-[17px] font-semibold text-white/85 mt-10 mb-4">
+              {t('frames.bands.heading')}
+            </h3>
+            <Chart
+              className="h-[280px] md:h-[380px]"
+              type="bar"
+              ariaLabel={t('frames.bands.ariaLabel')}
+              data={frameCharts.bands.data}
+              options={frameCharts.bands.options}
+            />
+            <p className="text-[13px] text-white/40 leading-[1.7] mt-4">
+              {t('frames.bands.caption')}
+            </p>
+          </Panel>
+
+          <Panel title={t('drivers.heading')} body={t('drivers.body')} note={t('drivers.caption')}>
+            <div className="flex flex-wrap items-center gap-2 mb-8">
+              <span className="text-[12px] font-semibold tracking-[0.14em] uppercase text-white/35 mr-2">
+                {t('drivers.label')}
+              </span>
+              {COMPETENCIES.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  aria-pressed={skill === c}
+                  onClick={() => setSkill(c)}
+                  className={`px-4 py-2 rounded-full text-[13px] font-medium transition-all duration-300 ${
+                    skill === c
+                      ? 'bg-white/[0.1] text-white border border-white/[0.15]'
+                      : 'text-white/40 border border-transparent hover:text-white/70'
+                  }`}
+                >
+                  {t(`competencies.${c}`)}
+                </button>
+              ))}
+            </div>
+            {/* The tallest competency carries 22 behaviours, so the box grows
+                with the list rather than squeezing them into a fixed height. */}
+            <div style={{ height: `${Math.max(240, drivers.count * 26)}px` }}>
+              <Chart
+                className="h-full w-full"
+                type="bar"
+                ariaLabel={t('drivers.ariaLabel')}
+                data={drivers.data}
+                options={drivers.options}
+              />
+            </div>
+          </Panel>
+
+          <Panel
+            title={t('mobility.heading')}
+            body={t('mobility.body', {
+              yes: n(mobility.veryWilling + mobility.willing),
+              maybe: n(mobility.openToConsidering),
+              no: n(mobility.somewhatReluctant + mobility.notInterested),
+            })}
+            note={t('mobility.caption')}
+          >
+            <Chart
+              className="h-[280px] md:h-[340px]"
+              type="bar"
+              ariaLabel={t('mobility.ariaLabel')}
+              data={fixed.mobility.data}
+              options={fixed.mobility.options}
+            />
+          </Panel>
+
+          <Panel
+            title={t('areas.heading')}
+            body={t('areas.body', {
+              total: n(sum(AREAS.map((a) => preferredAreas[a]))),
+              each: n(sum(AREAS.map((a) => preferredAreas[a])) / 100, 1),
+            })}
+            note={t('areas.caption')}
+          >
+            <Chart
+              className="h-[260px] md:h-[300px]"
+              type="bar"
+              ariaLabel={t('areas.ariaLabel')}
+              data={fixed.areas.data}
+              options={fixed.areas.options}
+            />
+          </Panel>
+
+          <Panel title={t('growth.heading')} body={t('growth.body')} note={t('growth.caption')}>
+            <Chart
+              className="h-[220px] md:h-[260px]"
+              type="bar"
+              ariaLabel={t('growth.ariaLabel')}
+              data={fixed.growth.data}
+              options={fixed.growth.options}
+            />
+          </Panel>
+
+          <Panel title={t('howToRead.heading')} body={t('howToRead.body')}>
+            <dl className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
+              {HOW_TO_READ.map((id) => (
+                <div key={id}>
+                  <dt className="text-[15px] font-semibold text-white/90 mb-2">
+                    {t(`howToRead.items.${id}.question`, {
+                      threshold: n(skillMatching.threshold, 0),
+                    })}
+                  </dt>
+                  <dd className="text-[14px] text-white/[0.55] leading-[1.7]">
+                    {t(`howToRead.items.${id}.answer`)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </Panel>
+
+          <Panel title={t('closing.heading')} body={t('closing.body')}>
+            <a
+              href={href('demo', lang)}
+              className="inline-flex items-center gap-2 rounded-full border border-white/[0.12] px-4 py-2 text-[13px] font-semibold text-white/70 transition-colors duration-300 hover:text-white hover:border-white/[0.25]"
+            >
+              {t('closing.back')}
+            </a>
+          </Panel>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+/** Distance between the highest and lowest mean in a frame. */
+function spreadOf(frame: Record<string, { mean: number }>) {
+  const means = Object.values(frame).map((v) => v.mean);
+  return Math.max(...means) - Math.min(...means);
+}

--- a/app/[locale]/demo/cross-country/opengraph-image.tsx
+++ b/app/[locale]/demo/cross-country/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ogFor } from '@/i18n/og-card';
+
+export { size, contentType } from '@/i18n/og-card';
+
+export function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'it' }];
+}
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return ogFor('demo/cross-country', locale);
+}

--- a/app/[locale]/demo/cross-country/page.tsx
+++ b/app/[locale]/demo/cross-country/page.tsx
@@ -1,0 +1,33 @@
+// The server half of this route. The page itself is body.tsx.
+//
+// Same shape as every other route, with `"noindex": true` on
+// `demo/cross-country` in i18n/routes.json doing the one thing that differs:
+// robots noindex/nofollow, and out of the sitemap.
+import { NextIntlClientProvider } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+import { buildMetadata } from '@/i18n/metadata';
+import { messagesForRoute } from '@/i18n/messages';
+import JsonLd from '@/i18n/json-ld';
+import Body from './body';
+
+const ROUTE = 'demo/cross-country';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return buildMetadata(ROUTE, locale);
+}
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={await messagesForRoute(ROUTE, locale)}>
+      <JsonLd routeId={ROUTE} locale={locale} />
+      <Body />
+    </NextIntlClientProvider>
+  );
+}

--- a/i18n/routes.json
+++ b/i18n/routes.json
@@ -245,6 +245,14 @@
     "noindex": true
   },
   {
+    "id": "demo/cross-country",
+    "paths": {
+      "en": "/demo/cross-country",
+      "it": "/demo/cross-country"
+    },
+    "noindex": true
+  },
+  {
     "id": "demo/retail",
     "paths": {
       "en": "/demo/retail-network",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4600,7 +4600,6 @@
       }
     },
     "status": {
-      "comingSoon": "Coming soon",
       "open": "Open the dashboard"
     },
     "preview": {
@@ -4990,6 +4989,240 @@
       "closing": {
         "heading": "How this page was made",
         "body": "Every number here is a group statistic, computed once outside this website from data that never entered it. Headcounts are rounded to the nearest five, no group carrying a score holds fewer than twenty-five people, and the knowledge areas are named for what they test rather than for the client's sector. The source dashboard has a participant table with a first name and a surname in it; there is nothing of that kind here, in any form.",
+        "back": "Back to the demo dashboards"
+      }
+    },
+    "cross-country": {
+      "meta": {
+        "title": "Cross-country talent map — demo dashboard | Skillvue",
+        "description": "One competency frame applied to a population spread across several countries, with growth aspirations and openness to moving read alongside it. Aggregates only: every individual record removed."
+      },
+      "hero": {
+        "eyebrow": "Interactive demo",
+        "heading": "One frame, <span>populations that were not comparable</span>",
+        "body": "A group HR team assessing across borders usually has one profile per country and no way to put them side by side. This is what it looks like when the same frame is applied to all of them at once — competencies, the behaviours under them, and what people say they want next.",
+        "note": "Aggregates only. No person and no individual record is on this page: every figure is a group statistic, computed once outside this website."
+      },
+      "population": {
+        "heading": "Who this is about",
+        "invited": {
+          "label": "People invited",
+          "note": "The full population in scope for the programme."
+        },
+        "evaluated": {
+          "label": "Assessments completed",
+          "note": "Every average on this page is computed on these, and on no one else."
+        },
+        "completion": {
+          "label": "Completion rate",
+          "note": "High enough that the results describe the population rather than the people who happened to finish."
+        },
+        "rounding": "Headcounts are rounded to the nearest five so that no count identifies anyone, while the percentages are computed on the real population — divide one into the other and it will be a fraction out."
+      },
+      "matching": {
+        "heading": "Skill matching against the frame",
+        "body": "How closely each person matches the profile their role was mapped to, in ten-point bands. The client set the bar at {threshold}, and it falls almost exactly in the middle of this population: {below}% below it, {above}% at or above.",
+        "series": "Share of those assessed",
+        "axis": "% of those assessed",
+        "axisScore": "Skill matching",
+        "ariaLabel": "Bar chart of the share of assessed people in each ten-point band of skill matching",
+        "mean": "Mean",
+        "median": "Median",
+        "caption": "A bar set where this one is does not say the population failed. It splits it in half, which is what a bar written from the role rather than from the people in it usually does — and it is the reason the shape above says more than the single number underneath it."
+      },
+      "groups": {
+        "heading": "Three groups, not three equals",
+        "body": "The population is spread unevenly, so it ships as three groups rather than as a list. Two of them are single countries large enough to stand on their own; the third pools the remainder, because several of those held too few people to publish — or to anonymise.",
+        "names": {
+          "primary": "Largest group",
+          "secondary": "Second group",
+          "others": "All other countries"
+        },
+        "series": "Mean skill matching",
+        "axis": "Skill matching",
+        "ariaLabel": "Bar chart of mean skill matching for each of the three country groups",
+        "people": "People",
+        "caption": "The three means sit within {spread} points of each other, and the group scoring highest is also the smallest — {small} people against {large}. A gap that size on a group that size is not a finding about a country; it is what a spread this narrow looks like when the samples are more than eight times apart."
+      },
+      "frames": {
+        "heading": "Where the population stands",
+        "body": "Two frames over the same people: four headline competencies, and the nine areas the assessment scores in detail. Pick one and both panels redraw.",
+        "label": "Frame",
+        "options": {
+          "competencies": "Four competencies",
+          "framework": "Nine detailed areas"
+        },
+        "means": {
+          "heading": "Average score",
+          "series": "Average",
+          "ariaLabel": "Bar chart of the average score for each item in the selected frame",
+          "caption": "The four competencies land within {narrow} of each other and the nine areas spread over {wide}. Averaging up to four numbers is what flattens a population; the detail is where a programme finds something to do."
+        },
+        "bands": {
+          "heading": "How that average is made up",
+          "axis": "% of those assessed",
+          "ariaLabel": "Stacked bar chart of the share of assessed people in each rating band, for every item in the selected frame",
+          "caption": "The same average can be a population clustered in the middle or one split at both ends, and only this view tells them apart."
+        }
+      },
+      "competencies": {
+        "vision": "Vision",
+        "openness": "Openness",
+        "leadership": "Leadership",
+        "accountability": "Accountability"
+      },
+      "framework": {
+        "marketAwareness": "Market awareness",
+        "customerCentricApproach": "Customer-centric approach",
+        "customerRelationshipManagement": "Customer relationship management",
+        "communicationInfluence": "Communication and influence",
+        "emotionalIntelligence": "Emotional intelligence",
+        "negotiation": "Negotiation",
+        "relationshipBuilding": "Relationship building",
+        "solutionsOriented": "Solutions orientation",
+        "digitalTools": "Digital tools"
+      },
+      "bands": {
+        "veryPoor": "Well below",
+        "belowAverage": "Below average",
+        "adequate": "Adequate",
+        "good": "Good",
+        "excellent": "Excellent"
+      },
+      "drivers": {
+        "heading": "The behaviours underneath",
+        "body": "Each competency is scored from observed behaviours, and the average of those behaviours is the competency's score. Pick one to see what it is made of.",
+        "label": "Competency",
+        "series": "Average score",
+        "ariaLabel": "Bar chart of the average score on each behaviour of the selected competency",
+        "caption": "The behaviours under one competency spread far wider than the competencies spread among themselves. That is the level a development plan is written at — a competency score tells you where to look, not what to do.",
+        "names": {
+          "monitoringMarkets": "Monitors markets",
+          "identifyingOpportunities": "Identifies opportunities",
+          "anticipatingTrends": "Anticipates trends",
+          "focusingOnCustomers": "Focuses on customers",
+          "settingQualityStandards": "Sets quality standards",
+          "workingSystematically": "Works systematically",
+          "maintainingQualityProcesses": "Maintains quality processes",
+          "maintainingProductivity": "Maintains productivity",
+          "applyingTechnicalExpertise": "Applies technical expertise",
+          "developingTechnicalExpertise": "Develops technical expertise",
+          "usingTechnology": "Uses technology",
+          "speakingFluently": "Speaks fluently",
+          "explainingConcepts": "Explains concepts",
+          "articulatingKeyPoints": "Articulates key points",
+          "publicSpeaking": "Speaks in public",
+          "projectingCredibility": "Projects credibility",
+          "respondingToTheAudience": "Responds to the audience",
+          "showingConsideration": "Shows consideration",
+          "showingEmpathy": "Shows empathy",
+          "stabilisingEmotions": "Stays even under strain",
+          "toleratingCriticism": "Takes criticism",
+          "managingConflict": "Manages conflict",
+          "promotingIdeas": "Promotes ideas",
+          "gainingAgreement": "Gains agreement",
+          "navigatingPolitics": "Navigates politics",
+          "buildingRelationships": "Builds relationships",
+          "developingNetworks": "Develops networks",
+          "relatingAcrossLevels": "Relates across levels",
+          "understandingOthers": "Understands others",
+          "listeningToOthers": "Listens to others",
+          "consultingOthers": "Consults others",
+          "supportingOthers": "Supports others",
+          "caringForOthers": "Cares for others",
+          "learningQuickly": "Learns quickly",
+          "acceptingNewIdeas": "Accepts new ideas",
+          "thinkingQuickly": "Thinks quickly",
+          "supportingOrganisationalLearning": "Supports organisational learning",
+          "evaluatingInformation": "Evaluates information",
+          "testingAssumptions": "Tests assumptions",
+          "producingSolutions": "Produces solutions",
+          "formingJudgements": "Forms judgements",
+          "demonstratingSystemsThinking": "Thinks in systems",
+          "adaptingToSituations": "Adapts to situations",
+          "gatheringInformation": "Gathers information",
+          "adaptingInterpersonalStyle": "Adapts interpersonal style",
+          "managingAmbiguity": "Manages ambiguity"
+        }
+      },
+      "mobility": {
+        "heading": "Openness to moving",
+        "body": "Asked whether they would relocate. {yes}% said yes outright and {no}% said no; the {maybe}% in between said they would consider it, which is a different answer and worth keeping separate from the first.",
+        "series": "Share of those assessed",
+        "axis": "% of those assessed",
+        "ariaLabel": "Bar chart of the share of assessed people at each level of openness to relocating",
+        "items": {
+          "veryWilling": "Very willing",
+          "willing": "Willing",
+          "openToConsidering": "Would consider it",
+          "somewhatReluctant": "Somewhat reluctant",
+          "notInterested": "Not interested"
+        },
+        "caption": "Adding the middle to the two on its left would give a number more than four times the size of the first, and it would not mean the same thing. The middle is where a conversation can move someone; it is not a commitment already made."
+      },
+      "areas": {
+        "heading": "Where people would rather work",
+        "body": "The functions people named when asked where they would want to move. More than one answer was allowed, so the shares add to {total}% — about {each} areas named per person on average — and they cannot be read as a split of the population.",
+        "series": "Share who named it",
+        "axis": "% who named it",
+        "ariaLabel": "Bar chart of the share of assessed people who named each functional area",
+        "items": {
+          "sales": "Sales",
+          "technicalSpecialist": "Technical specialist",
+          "marketing": "Marketing",
+          "operations": "Operations",
+          "hr": "People and organisation",
+          "finance": "Finance"
+        },
+        "caption": "Two areas are named by more than half the population each, which is only possible because the question let people name several. Read each bar on its own: it is the share who named that area, not the share who chose it over the others."
+      },
+      "growth": {
+        "heading": "Which direction they want to grow in",
+        "body": "One answer each this time, so these do split the population. The three real options come out close together, and the largest of them is not the one an org chart would predict.",
+        "series": "Share of those assessed",
+        "axis": "% of those assessed",
+        "ariaLabel": "Bar chart of the share of assessed people wanting each direction of growth",
+        "items": {
+          "crossFunctional": "Move across functions",
+          "deepenExpertise": "Go deeper in their field",
+          "teamManagement": "Manage a team",
+          "noPreference": "No preference"
+        },
+        "caption": "Fewer than three in ten want to manage a team. A succession plan that assumes the ambitious ones want a management ladder is planning for a group this population does not have."
+      },
+      "howToRead": {
+        "heading": "How to read the results",
+        "body": "Six things that are obvious once someone has worked with this frame, and are not obvious at all on a first read.",
+        "items": {
+          "matching": {
+            "question": "What is skill matching, and what does the bar at {threshold} mean?",
+            "answer": "It is how closely one person's assessed profile matches the profile the role was mapped to — not a mark out of a hundred. The bar is the client's, set from the role rather than from the people in it, so a population sitting around it is the normal starting point rather than a bad result."
+          },
+          "scale": {
+            "question": "What do the scores and the five bands mean?",
+            "answer": "Every competency is scored on the same five-point scale, and the bands are that scale in words. The score is the average of the observed behaviours underneath it, which is why two areas with the same average can have completely different shapes."
+          },
+          "groups": {
+            "question": "Why three groups, and why not compare them directly?",
+            "answer": "Because they are not the same kind of thing. Two are single countries big enough to stand alone; the third pools the rest. They differ in size by more than a factor of eight, so a few points between them says much less than the same gap between two groups of equal size would."
+          },
+          "areas": {
+            "question": "Why do the preferred areas add up to more than a hundred?",
+            "answer": "People could name more than one, so every bar is the share who named that area and the column is not a split of anything. The direction-of-growth question allowed one answer, and that one does split the population."
+          },
+          "mobility": {
+            "question": "Why is “would consider it” kept out of the yes?",
+            "answer": "Because it is not one. Folding it in would turn one in seven into two in three, and a number built that way falls apart the moment someone asks what was actually asked."
+          },
+          "counts": {
+            "question": "Why do the headcounts not divide into the percentages?",
+            "answer": "Every headcount here is rounded to the nearest five so that no count can identify anyone, while every percentage is computed on the real figure. The rounding is the point; the small mismatch is what it costs."
+          }
+        }
+      },
+      "closing": {
+        "heading": "How this page was made",
+        "body": "Every number here is a group statistic, computed once outside this website from data that never entered it. Headcounts are rounded to the nearest five, no published group holds fewer than twenty-five people, the countries are grouped rather than named, and one function is named for what it does rather than for the sector it belongs to. The source dashboard has a participant table with names in it; there is nothing of that kind here, in any form.",
         "back": "Back to the demo dashboards"
       }
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -5028,7 +5028,7 @@
         "ariaLabel": "Bar chart of the share of assessed people in each ten-point band of skill matching",
         "mean": "Mean",
         "median": "Median",
-        "caption": "A bar set where this one is does not say the population failed. It splits it in half, which is what a bar written from the role rather than from the people in it usually does — and it is the reason the shape below says more than the two numbers above it."
+        "caption": "A bar set where this one is does not say the population failed. It splits it in half, which is what a bar written from the role rather than from the people in it usually does — and it is the reason the shape of the distribution says more than the two figures above it."
       },
       "groups": {
         "heading": "Three groups, not three equals",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5028,7 +5028,7 @@
         "ariaLabel": "Bar chart of the share of assessed people in each ten-point band of skill matching",
         "mean": "Mean",
         "median": "Median",
-        "caption": "A bar set where this one is does not say the population failed. It splits it in half, which is what a bar written from the role rather than from the people in it usually does — and it is the reason the shape above says more than the single number underneath it."
+        "caption": "A bar set where this one is does not say the population failed. It splits it in half, which is what a bar written from the role rather than from the people in it usually does — and it is the reason the shape below says more than the two numbers above it."
       },
       "groups": {
         "heading": "Three groups, not three equals",
@@ -5056,7 +5056,7 @@
           "heading": "Average score",
           "series": "Average",
           "ariaLabel": "Bar chart of the average score for each item in the selected frame",
-          "caption": "The four competencies land within {narrow} of each other and the nine areas spread over {wide}. Averaging up to four numbers is what flattens a population; the detail is where a programme finds something to do."
+          "caption": "The four competencies land within {narrow} of each other and the nine areas spread over {wide}. Reducing a population to four averages is what flattens it; the detail is where a programme finds something to do."
         },
         "bands": {
           "heading": "How that average is made up",
@@ -5147,7 +5147,7 @@
       },
       "mobility": {
         "heading": "Openness to moving",
-        "body": "Asked whether they would relocate. {yes}% said yes outright and {no}% said no; the {maybe}% in between said they would consider it, which is a different answer and worth keeping separate from the first.",
+        "body": "Asked whether they would relocate, {yes}% said yes outright and {no}% said no. Everyone else is in the middle: {maybe}% would consider it and {reluctant}% leaned against without refusing. Neither of those two belongs at either end.",
         "series": "Share of those assessed",
         "axis": "% of those assessed",
         "ariaLabel": "Bar chart of the share of assessed people at each level of openness to relocating",
@@ -5158,7 +5158,7 @@
           "somewhatReluctant": "Somewhat reluctant",
           "notInterested": "Not interested"
         },
-        "caption": "Adding the middle to the two on its left would give a number more than four times the size of the first, and it would not mean the same thing. The middle is where a conversation can move someone; it is not a commitment already made."
+        "caption": "Folding the middle into the yes would give a number more than four times the size of it, and folding the reluctant into the no would inflate that end by half again. Neither is what was asked. The middle is where a conversation can move someone: it is not a commitment already made, and it is not a refusal either."
       },
       "areas": {
         "heading": "Where people would rather work",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4631,7 +4631,7 @@
         "heading": "Che cosa è stato misurato",
         "advisors": {
           "label": "Sales advisor valutati",
-          "note": "La popolazione su cui è calcolato ogni taglio di questa pagina. I {managers} store manager sono stati valutati su uno schema diverso e non entrano in queste cifre."
+          "note": "La popolazione su cui è calcolato ogni taglio di questa pagina. Gli store manager, {managers}, sono stati valutati su uno schema diverso e non entrano in queste cifre."
         },
         "stores": {
           "label": "Punti vendita nel perimetro",
@@ -4653,7 +4653,7 @@
         "axisScore": "Punteggio di competenze",
         "axisShare": "% di advisor",
         "ariaLabel": "Grafico a barre della quota di sales advisor in ciascuna fascia di cinque punti del punteggio di competenze",
-        "caption": "Il {above}% degli advisor supera {threshold}. È una quota, non una classifica — ed è il numero su cui si costruisce un budget di sviluppo."
+        "caption": "{above}% degli advisor supera {threshold}. È una quota, non una classifica — ed è il numero su cui si costruisce un budget di sviluppo."
       },
       "cuts": {
         "heading": "La stessa rete, tagliata in quattro modi",
@@ -4884,7 +4884,7 @@
           "soft": "Soft skill",
           "hard": "Conoscenze tecniche"
         },
-        "coverage": "Queste due famiglie tengono {covered} delle {assessed} persone valutate. Le altre stanno in famiglie troppo piccole per essere pubblicate da sole — sotto la soglia di venticinque persone che ogni cifra qui rispetta — quindi sono dentro tutti i totali di questa pagina e spacchettate in nessuno.",
+        "coverage": "Queste due famiglie tengono {covered} persone valutate su {assessed}. Le altre stanno in famiglie troppo piccole per essere pubblicate da sole — sotto la soglia di venticinque persone che ogni cifra qui rispetta — quindi sono dentro tutti i totali di questa pagina e spacchettate in nessuno.",
         "overlap": "Una sola soft skill è stata misurata su entrambe le famiglie, e due delle aree di conoscenza. È per questo che non esiste una classifica unica delle due."
       },
       "profile": {
@@ -4961,7 +4961,7 @@
       },
       "quadrants": {
         "heading": "Comportamento e conoscenza, incrociati",
-        "body": "Ogni persona supera la soglia comportamentale, quella tecnica, tutte e due o nessuna. Le due soglie fanno un lavoro molto diverso: il {hardCleared}% è sopra quella tecnica e il {softCleared}% sopra quella comportamentale, quindi la base tecnica ce l’ha quasi tutta la rete e ciò che la separa è il comportamento.",
+        "body": "Ogni persona supera la soglia comportamentale, quella tecnica, tutte e due o nessuna. Le due soglie fanno un lavoro molto diverso: {hardCleared}% è sopra quella tecnica e {softCleared}% sopra quella comportamentale, quindi la base tecnica ce l’ha quasi tutta la rete e ciò che la separa è il comportamento.",
         "axisSoft": "Soft skill",
         "axisHard": "Conoscenze tecniche",
         "high": "da {threshold} in su",
@@ -5021,14 +5021,14 @@
       },
       "matching": {
         "heading": "Skill matching rispetto allo schema",
-        "body": "Quanto ogni persona aderisce al profilo su cui il suo ruolo è stato mappato, in fasce da dieci punti. Il cliente ha messo l’asticella a {threshold}, e cade quasi esattamente in mezzo a questa popolazione: il {below}% sotto, il {above}% da lì in su.",
+        "body": "Quanto ogni persona aderisce al profilo su cui il suo ruolo è stato mappato, in fasce da dieci punti. Il cliente ha messo l’asticella a {threshold}, e cade quasi esattamente in mezzo a questa popolazione: {below}% sotto, {above}% da lì in su.",
         "series": "Quota dei valutati",
         "axis": "% dei valutati",
         "axisScore": "Skill matching",
         "ariaLabel": "Grafico a barre della quota di persone valutate in ciascuna fascia da dieci punti di skill matching",
         "mean": "Media",
         "median": "Mediana",
-        "caption": "Un’asticella messa dov’è questa non dice che la popolazione è bocciata. La taglia a metà, che è quello che di solito fa un’asticella scritta a partire dal ruolo e non da chi lo ricopre — ed è il motivo per cui la forma qui sopra dice più del numero singolo."
+        "caption": "Un’asticella messa dov’è questa non dice che la popolazione è bocciata. La taglia a metà, che è quello che di solito fa un’asticella scritta a partire dal ruolo e non da chi lo ricopre — ed è il motivo per cui la forma della distribuzione dice più delle due cifre qui sopra."
       },
       "groups": {
         "heading": "Tre gruppi, non tre pari",
@@ -5147,7 +5147,7 @@
       },
       "mobility": {
         "heading": "Apertura a spostarsi",
-        "body": "Alla domanda se si trasferirebbero, il {yes}% ha detto sì e il {no}% ha detto no. Tutti gli altri stanno nel mezzo: il {maybe}% ci penserebbe e il {reluctant}% è poco convinto senza però rifiutare. Nessuno dei due appartiene a un estremo.",
+        "body": "Alla domanda se si trasferirebbero, {yes}% ha detto sì e {no}% ha detto no. Tutti gli altri stanno nel mezzo: {maybe}% ci penserebbe e {reluctant}% è poco convinto senza però rifiutare. Nessuno dei due appartiene a un estremo.",
         "series": "Quota dei valutati",
         "axis": "% dei valutati",
         "ariaLabel": "Grafico a barre della quota di valutati per ciascun livello di apertura a trasferirsi",
@@ -5162,7 +5162,7 @@
       },
       "areas": {
         "heading": "Dove le persone preferirebbero lavorare",
-        "body": "Le funzioni indicate rispondendo a dove vorrebbero spostarsi. Si poteva dare più di una risposta, quindi le quote sommano al {total}% — circa {each} aree indicate a testa in media — e non si possono leggere come una ripartizione della popolazione.",
+        "body": "Le funzioni indicate rispondendo a dove vorrebbero spostarsi. Si poteva dare più di una risposta, quindi le quote sommano a {total}% — circa {each} aree indicate a testa in media — e non si possono leggere come una ripartizione della popolazione.",
         "series": "Quota che l’ha indicata",
         "axis": "% che l’ha indicata",
         "ariaLabel": "Grafico a barre della quota di valutati che ha indicato ciascuna area funzionale",

--- a/messages/it.json
+++ b/messages/it.json
@@ -5000,7 +5000,7 @@
       "hero": {
         "eyebrow": "Demo interattiva",
         "heading": "Un solo schema, <span>popolazioni che non erano confrontabili</span>",
-        "body": "Un HR di gruppo che valuta oltre confine di solito ha un profilo per paese e nessun modo di metterli affiancati. Questo è che cosa si vede quando lo stesso schema viene applicato a tutti insieme: le competenze, i comportamenti che ci stanno sotto, e che cosa le persone dicono di volere dopo.",
+        "body": "Un HR di gruppo che valuta oltre confine di solito ha un profilo per paese e nessun modo di metterli affiancati. Ecco che cosa si vede quando lo stesso schema viene applicato a tutti insieme: le competenze, i comportamenti che ci stanno sotto, e che cosa le persone dicono di volere dopo.",
         "note": "Solo aggregati. Su questa pagina non c’è nessuna persona e nessun record individuale: ogni cifra è una statistica di gruppo, calcolata una volta fuori da questo sito."
       },
       "population": {
@@ -5056,7 +5056,7 @@
           "heading": "Punteggio medio",
           "series": "Media",
           "ariaLabel": "Grafico a barre del punteggio medio di ciascuna voce dello schema selezionato",
-          "caption": "Le quattro competenze stanno dentro {narrow} l’una dall’altra e le nove aree si distendono su {wide}. Fare la media fino a quattro numeri è ciò che appiattisce una popolazione; è nel dettaglio che un programma trova qualcosa da fare."
+          "caption": "Le quattro competenze stanno dentro {narrow} l’una dall’altra e le nove aree si distendono su {wide}. Ridurre una popolazione a quattro medie è ciò che la appiattisce; è nel dettaglio che un programma trova qualcosa da fare."
         },
         "bands": {
           "heading": "Come è fatta quella media",
@@ -5147,7 +5147,7 @@
       },
       "mobility": {
         "heading": "Apertura a spostarsi",
-        "body": "Alla domanda se si trasferirebbero, il {yes}% ha detto sì e il {no}% ha detto no; il {maybe}% nel mezzo ha detto che ci penserebbe, che è una risposta diversa e va tenuta separata dalla prima.",
+        "body": "Alla domanda se si trasferirebbero, il {yes}% ha detto sì e il {no}% ha detto no. Tutti gli altri stanno nel mezzo: il {maybe}% ci penserebbe e il {reluctant}% è poco convinto senza però rifiutare. Nessuno dei due appartiene a un estremo.",
         "series": "Quota dei valutati",
         "axis": "% dei valutati",
         "ariaLabel": "Grafico a barre della quota di valutati per ciascun livello di apertura a trasferirsi",
@@ -5158,7 +5158,7 @@
           "somewhatReluctant": "Poco convinto",
           "notInterested": "Non interessato"
         },
-        "caption": "Sommare la fascia centrale alle due alla sua sinistra darebbe un numero più di quattro volte il primo, e non vorrebbe dire la stessa cosa. Il centro è dove una conversazione può spostare qualcuno; non è un impegno già preso."
+        "caption": "Sommare il centro ai sì darebbe un numero più di quattro volte il primo, e sommare i poco convinti ai no gonfierebbe quell’estremo di metà. Nessuna delle due somme è la domanda che è stata fatta. Il centro è dove una conversazione può spostare qualcuno: non è un impegno già preso, e non è nemmeno un rifiuto."
       },
       "areas": {
         "heading": "Dove le persone preferirebbero lavorare",

--- a/messages/it.json
+++ b/messages/it.json
@@ -4600,7 +4600,6 @@
       }
     },
     "status": {
-      "comingSoon": "In arrivo",
       "open": "Apri la dashboard"
     },
     "preview": {
@@ -4990,6 +4989,240 @@
       "closing": {
         "heading": "Come è fatta questa pagina",
         "body": "Ogni numero qui è una statistica di gruppo, calcolata una volta fuori da questo sito su dati che in questo sito non sono mai entrati. Gli headcount sono arrotondati al multiplo di cinque, nessun gruppo che porta un punteggio contiene meno di venticinque persone, e le aree di conoscenza sono nominate per quello che misurano invece che per il settore del cliente. La dashboard di origine ha una tabella partecipanti con nome e cognome dentro; qui non c’è nulla del genere, in nessuna forma.",
+        "back": "Torna alle dashboard demo"
+      }
+    },
+    "cross-country": {
+      "meta": {
+        "title": "Mappa dei talenti cross-country — dashboard demo | Skillvue",
+        "description": "Un solo schema di competenze applicato a una popolazione distribuita su più paesi, letto insieme alle aspirazioni di crescita e all’apertura a spostarsi. Solo aggregati: nessun dato individuale."
+      },
+      "hero": {
+        "eyebrow": "Demo interattiva",
+        "heading": "Un solo schema, <span>popolazioni che non erano confrontabili</span>",
+        "body": "Un HR di gruppo che valuta oltre confine di solito ha un profilo per paese e nessun modo di metterli affiancati. Questo è che cosa si vede quando lo stesso schema viene applicato a tutti insieme: le competenze, i comportamenti che ci stanno sotto, e che cosa le persone dicono di volere dopo.",
+        "note": "Solo aggregati. Su questa pagina non c’è nessuna persona e nessun record individuale: ogni cifra è una statistica di gruppo, calcolata una volta fuori da questo sito."
+      },
+      "population": {
+        "heading": "Di chi si parla",
+        "invited": {
+          "label": "Persone invitate",
+          "note": "L’intera popolazione nel perimetro del programma."
+        },
+        "evaluated": {
+          "label": "Assessment completati",
+          "note": "Ogni media di questa pagina è calcolata su queste persone e su nessun’altra."
+        },
+        "completion": {
+          "label": "Tasso di completamento",
+          "note": "Abbastanza alto perché i risultati descrivano la popolazione e non chi è arrivato in fondo."
+        },
+        "rounding": "Gli headcount sono arrotondati al multiplo di cinque perché nessun conteggio identifichi qualcuno, mentre le percentuali sono calcolate sulla popolazione reale: dividendo gli uni per le altre il conto non torna, e sbaglia di un soffio."
+      },
+      "matching": {
+        "heading": "Skill matching rispetto allo schema",
+        "body": "Quanto ogni persona aderisce al profilo su cui il suo ruolo è stato mappato, in fasce da dieci punti. Il cliente ha messo l’asticella a {threshold}, e cade quasi esattamente in mezzo a questa popolazione: il {below}% sotto, il {above}% da lì in su.",
+        "series": "Quota dei valutati",
+        "axis": "% dei valutati",
+        "axisScore": "Skill matching",
+        "ariaLabel": "Grafico a barre della quota di persone valutate in ciascuna fascia da dieci punti di skill matching",
+        "mean": "Media",
+        "median": "Mediana",
+        "caption": "Un’asticella messa dov’è questa non dice che la popolazione è bocciata. La taglia a metà, che è quello che di solito fa un’asticella scritta a partire dal ruolo e non da chi lo ricopre — ed è il motivo per cui la forma qui sopra dice più del numero singolo."
+      },
+      "groups": {
+        "heading": "Tre gruppi, non tre pari",
+        "body": "La popolazione è distribuita in modo molto disomogeneo, quindi esce come tre gruppi invece che come un elenco. Due sono singoli paesi abbastanza grandi da stare in piedi da soli; il terzo accorpa i rimanenti, perché diversi di quelli avevano troppe poche persone per essere pubblicati — o per essere resi anonimi.",
+        "names": {
+          "primary": "Gruppo maggiore",
+          "secondary": "Secondo gruppo",
+          "others": "Tutti gli altri paesi"
+        },
+        "series": "Skill matching medio",
+        "axis": "Skill matching",
+        "ariaLabel": "Grafico a barre dello skill matching medio di ciascuno dei tre gruppi di paesi",
+        "people": "Persone",
+        "caption": "Le tre medie stanno dentro {spread} punti l’una dall’altra, e il gruppo che segna il valore più alto è anche il più piccolo: {small} persone contro {large}. Una differenza di quell’ordine su un gruppo di quella taglia non è una scoperta su un paese; è l’aspetto che ha una forbice così stretta quando i campioni stanno a più di un fattore otto di distanza."
+      },
+      "frames": {
+        "heading": "Dove sta la popolazione",
+        "body": "Due schemi sulle stesse persone: quattro competenze di sintesi e le nove aree che l’assessment misura in dettaglio. Scegline uno e i due pannelli si ridisegnano.",
+        "label": "Schema",
+        "options": {
+          "competencies": "Quattro competenze",
+          "framework": "Nove aree di dettaglio"
+        },
+        "means": {
+          "heading": "Punteggio medio",
+          "series": "Media",
+          "ariaLabel": "Grafico a barre del punteggio medio di ciascuna voce dello schema selezionato",
+          "caption": "Le quattro competenze stanno dentro {narrow} l’una dall’altra e le nove aree si distendono su {wide}. Fare la media fino a quattro numeri è ciò che appiattisce una popolazione; è nel dettaglio che un programma trova qualcosa da fare."
+        },
+        "bands": {
+          "heading": "Come è fatta quella media",
+          "axis": "% dei valutati",
+          "ariaLabel": "Grafico a barre impilate della quota di valutati in ciascuna fascia di giudizio, per ogni voce dello schema selezionato",
+          "caption": "La stessa media può essere una popolazione ammassata al centro o una spaccata ai due estremi, e solo questa vista le distingue."
+        }
+      },
+      "competencies": {
+        "vision": "Visione",
+        "openness": "Apertura",
+        "leadership": "Leadership",
+        "accountability": "Responsabilità"
+      },
+      "framework": {
+        "marketAwareness": "Conoscenza del mercato",
+        "customerCentricApproach": "Approccio centrato sul cliente",
+        "customerRelationshipManagement": "Gestione della relazione con il cliente",
+        "communicationInfluence": "Comunicazione e influenza",
+        "emotionalIntelligence": "Intelligenza emotiva",
+        "negotiation": "Negoziazione",
+        "relationshipBuilding": "Costruzione di relazioni",
+        "solutionsOriented": "Orientamento alla soluzione",
+        "digitalTools": "Strumenti digitali"
+      },
+      "bands": {
+        "veryPoor": "Molto sotto",
+        "belowAverage": "Sotto la media",
+        "adequate": "Adeguato",
+        "good": "Buono",
+        "excellent": "Eccellente"
+      },
+      "drivers": {
+        "heading": "I comportamenti che ci stanno sotto",
+        "body": "Ogni competenza è misurata a partire da comportamenti osservati, e la media di quei comportamenti è il punteggio della competenza. Scegline una per vedere di che cosa è fatta.",
+        "label": "Competenza",
+        "series": "Punteggio medio",
+        "ariaLabel": "Grafico a barre del punteggio medio di ciascun comportamento della competenza selezionata",
+        "caption": "I comportamenti sotto una competenza si distendono molto più di quanto le competenze si distendano fra loro. È il livello a cui si scrive un piano di sviluppo: il punteggio di una competenza dice dove guardare, non che cosa fare.",
+        "names": {
+          "monitoringMarkets": "Monitora i mercati",
+          "identifyingOpportunities": "Individua le opportunità",
+          "anticipatingTrends": "Anticipa le tendenze",
+          "focusingOnCustomers": "Si concentra sul cliente",
+          "settingQualityStandards": "Fissa standard di qualità",
+          "workingSystematically": "Lavora in modo sistematico",
+          "maintainingQualityProcesses": "Mantiene i processi di qualità",
+          "maintainingProductivity": "Mantiene la produttività",
+          "applyingTechnicalExpertise": "Applica competenze tecniche",
+          "developingTechnicalExpertise": "Sviluppa competenze tecniche",
+          "usingTechnology": "Usa la tecnologia",
+          "speakingFluently": "Si esprime con scioltezza",
+          "explainingConcepts": "Spiega i concetti",
+          "articulatingKeyPoints": "Argomenta i punti chiave",
+          "publicSpeaking": "Parla in pubblico",
+          "projectingCredibility": "Trasmette credibilità",
+          "respondingToTheAudience": "Risponde all’interlocutore",
+          "showingConsideration": "Mostra considerazione",
+          "showingEmpathy": "Mostra empatia",
+          "stabilisingEmotions": "Resta stabile sotto tensione",
+          "toleratingCriticism": "Accetta le critiche",
+          "managingConflict": "Gestisce il conflitto",
+          "promotingIdeas": "Promuove le idee",
+          "gainingAgreement": "Ottiene consenso",
+          "navigatingPolitics": "Si muove fra gli equilibri interni",
+          "buildingRelationships": "Costruisce relazioni",
+          "developingNetworks": "Sviluppa reti di contatti",
+          "relatingAcrossLevels": "Si relaziona a ogni livello",
+          "understandingOthers": "Capisce gli altri",
+          "listeningToOthers": "Ascolta gli altri",
+          "consultingOthers": "Consulta gli altri",
+          "supportingOthers": "Sostiene gli altri",
+          "caringForOthers": "Si prende cura degli altri",
+          "learningQuickly": "Impara in fretta",
+          "acceptingNewIdeas": "Accoglie idee nuove",
+          "thinkingQuickly": "Ragiona rapidamente",
+          "supportingOrganisationalLearning": "Sostiene l’apprendimento dell’organizzazione",
+          "evaluatingInformation": "Valuta le informazioni",
+          "testingAssumptions": "Mette alla prova le ipotesi",
+          "producingSolutions": "Produce soluzioni",
+          "formingJudgements": "Si forma un giudizio",
+          "demonstratingSystemsThinking": "Ragiona per sistemi",
+          "adaptingToSituations": "Si adatta alle situazioni",
+          "gatheringInformation": "Raccoglie informazioni",
+          "adaptingInterpersonalStyle": "Adatta lo stile relazionale",
+          "managingAmbiguity": "Gestisce l’ambiguità"
+        }
+      },
+      "mobility": {
+        "heading": "Apertura a spostarsi",
+        "body": "Alla domanda se si trasferirebbero, il {yes}% ha detto sì e il {no}% ha detto no; il {maybe}% nel mezzo ha detto che ci penserebbe, che è una risposta diversa e va tenuta separata dalla prima.",
+        "series": "Quota dei valutati",
+        "axis": "% dei valutati",
+        "ariaLabel": "Grafico a barre della quota di valutati per ciascun livello di apertura a trasferirsi",
+        "items": {
+          "veryWilling": "Molto disponibile",
+          "willing": "Disponibile",
+          "openToConsidering": "Ci penserebbe",
+          "somewhatReluctant": "Poco convinto",
+          "notInterested": "Non interessato"
+        },
+        "caption": "Sommare la fascia centrale alle due alla sua sinistra darebbe un numero più di quattro volte il primo, e non vorrebbe dire la stessa cosa. Il centro è dove una conversazione può spostare qualcuno; non è un impegno già preso."
+      },
+      "areas": {
+        "heading": "Dove le persone preferirebbero lavorare",
+        "body": "Le funzioni indicate rispondendo a dove vorrebbero spostarsi. Si poteva dare più di una risposta, quindi le quote sommano al {total}% — circa {each} aree indicate a testa in media — e non si possono leggere come una ripartizione della popolazione.",
+        "series": "Quota che l’ha indicata",
+        "axis": "% che l’ha indicata",
+        "ariaLabel": "Grafico a barre della quota di valutati che ha indicato ciascuna area funzionale",
+        "items": {
+          "sales": "Vendite",
+          "technicalSpecialist": "Specialista tecnico",
+          "marketing": "Marketing",
+          "operations": "Operations",
+          "hr": "Persone e organizzazione",
+          "finance": "Finance"
+        },
+        "caption": "Due aree sono indicate da più di metà della popolazione ciascuna, cosa possibile solo perché la domanda permetteva di indicarne più d’una. Ogni barra va letta da sola: è la quota che ha indicato quell’area, non la quota che l’ha scelta al posto delle altre."
+      },
+      "growth": {
+        "heading": "In che direzione vogliono crescere",
+        "body": "Qui una risposta a testa, quindi queste sì che ripartiscono la popolazione. Le tre opzioni vere escono vicine fra loro, e la più grande non è quella che un organigramma prevederebbe.",
+        "series": "Quota dei valutati",
+        "axis": "% dei valutati",
+        "ariaLabel": "Grafico a barre della quota di valutati che desidera ciascuna direzione di crescita",
+        "items": {
+          "crossFunctional": "Spostarsi fra funzioni",
+          "deepenExpertise": "Approfondire il proprio mestiere",
+          "teamManagement": "Gestire un team",
+          "noPreference": "Nessuna preferenza"
+        },
+        "caption": "Meno di tre su dieci vogliono gestire un team. Un piano di successione che dia per scontato che chi ha ambizione voglia una scala manageriale sta pianificando per un gruppo che questa popolazione non ha."
+      },
+      "howToRead": {
+        "heading": "Come si leggono questi risultati",
+        "body": "Sei cose che sono ovvie per chi ha già lavorato con questo schema, e per niente ovvie a una prima lettura.",
+        "items": {
+          "matching": {
+            "question": "Che cos’è lo skill matching, e che cosa vuol dire l’asticella a {threshold}?",
+            "answer": "È quanto il profilo valutato di una persona aderisce al profilo su cui il ruolo è stato mappato — non è un voto in centesimi. L’asticella è del cliente ed è tarata sul ruolo, non su chi lo ricopre: una popolazione che le sta intorno è il punto di partenza normale, non un cattivo risultato."
+          },
+          "scale": {
+            "question": "Che cosa vogliono dire i punteggi e le cinque fasce?",
+            "answer": "Ogni competenza è misurata sulla stessa scala a cinque livelli, e le fasce sono quella scala a parole. Il punteggio è la media dei comportamenti osservati che ci stanno sotto, ed è per questo che due aree con la stessa media possono avere forme completamente diverse."
+          },
+          "groups": {
+            "question": "Perché tre gruppi, e perché non confrontarli direttamente?",
+            "answer": "Perché non sono la stessa cosa. Due sono singoli paesi abbastanza grandi da stare da soli; il terzo accorpa i rimanenti. Fra loro c’è più di un fattore otto di taglia, quindi pochi punti di differenza dicono molto meno di quanto direbbe lo stesso scarto fra due gruppi di pari dimensione."
+          },
+          "areas": {
+            "question": "Perché le aree preferite sommano a più di cento?",
+            "answer": "Perché si poteva indicarne più d’una: ogni barra è la quota che ha indicato quell’area e la colonna non è la ripartizione di niente. La domanda sulla direzione di crescita ammetteva una sola risposta, e quella invece ripartisce la popolazione."
+          },
+          "mobility": {
+            "question": "Perché «ci penserebbe» non viene contato come un sì?",
+            "answer": "Perché non lo è. Sommarlo trasformerebbe uno su sette in due su tre, e un numero costruito così si sfascia nel momento in cui qualcuno chiede che cosa fosse la domanda."
+          },
+          "counts": {
+            "question": "Perché gli headcount non tornano con le percentuali?",
+            "answer": "Ogni headcount qui è arrotondato al multiplo di cinque perché nessun conteggio possa identificare qualcuno, mentre ogni percentuale è calcolata sulla cifra vera. L’arrotondamento è il punto; il piccolo scarto è quello che costa."
+          }
+        }
+      },
+      "closing": {
+        "heading": "Come è fatta questa pagina",
+        "body": "Ogni numero qui è una statistica di gruppo, calcolata una volta fuori da questo sito su dati che in questo sito non sono mai entrati. Gli headcount sono arrotondati al multiplo di cinque, nessun gruppo pubblicato contiene meno di venticinque persone, i paesi sono raggruppati invece che nominati, e una funzione è nominata per quello che fa invece che per il settore a cui appartiene. La dashboard di origine ha una tabella partecipanti con dentro i nomi; qui non c’è nulla del genere, in nessuna forma.",
         "back": "Torna alle dashboard demo"
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:assets": "node scripts/check-assets.mjs",
     "check:demo-event": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-event.mjs",
     "check:demo-anonymity": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-anonymity.mjs",
+    "check:demo-cross-country": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-cross-country.mjs",
     "check:demo-retail": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-retail.mjs",
     "check:demo-sales-network": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-demo-sales-network.mjs",
     "test:smoke": "node scripts/smoke.mjs"

--- a/scripts/check-demo-cross-country.mjs
+++ b/scripts/check-demo-cross-country.mjs
@@ -1,0 +1,321 @@
+// check-demo-cross-country — the cross-country dashboard's labels exist, and
+// its copy still describes the data underneath it.
+//
+// Same two gaps as the other two demo gates. Every label is fetched with a
+// composed key — t(`framework.${id}`), t(`drivers.names.${d}`) — which
+// check:i18n cannot read, so the ids come from the data and are matched against
+// both catalogues in both directions.
+//
+// The claims are the longer half, and this page has more of them than the other
+// two because more of its numbers are easy to read wrongly. Three in particular
+// are asserted as the *shape* of the reading, not as a value: the preferred
+// areas sum past 100 because the question was multi-select, `openToConsidering`
+// is not a yes, and the three country groups differ in size by a factor the
+// copy names. Each of those is a sentence on the page that a refreshed extract
+// could silently falsify.
+//
+// Run: npm run check:demo-cross-country
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { crossCountry: cc } = await import(
+  pathToFileURL(join(ROOT, 'data/demo/cross-country.ts')).href
+);
+
+const catalogues = Object.fromEntries(
+  ['en', 'it'].map((l) => [
+    l,
+    JSON.parse(readFileSync(join(ROOT, `messages/${l}.json`), 'utf8')).demo['cross-country'],
+  ]),
+);
+
+const at = (catalogue, path) =>
+  path.split('.').reduce((node, seg) => (node == null ? undefined : node[seg]), catalogue);
+
+const missing = [];
+const label = (path) => {
+  for (const locale of ['en', 'it']) {
+    if (typeof at(catalogues[locale], path) !== 'string') {
+      missing.push(`  ${locale}: demo.cross-country.${path}`);
+    }
+  }
+};
+
+const sum = (values) => values.reduce((a, b) => a + b, 0);
+const mean = (values) => sum(values) / values.length;
+
+const COMPETENCIES = Object.keys(cc.competencies);
+const FRAMEWORK = Object.keys(cc.framework);
+const BANDS = Object.keys(cc.competencies.vision.bands);
+const GROUPS = Object.keys(cc.countryGroups);
+const DRIVERS = [...new Set(Object.values(cc.drivers).flatMap((d) => Object.keys(d)))];
+
+// ── Every composed key the page builds ─────────────────────────────────────
+for (const c of COMPETENCIES) label(`competencies.${c}`);
+for (const f of FRAMEWORK) label(`framework.${f}`);
+for (const b of BANDS) label(`bands.${b}`);
+for (const g of GROUPS) label(`groups.names.${g}`);
+for (const d of DRIVERS) label(`drivers.names.${d}`);
+for (const m of Object.keys(cc.mobility)) label(`mobility.items.${m}`);
+for (const a of Object.keys(cc.preferredAreas)) label(`areas.items.${a}`);
+for (const g of Object.keys(cc.growth)) label(`growth.items.${g}`);
+for (const card of ['invited', 'evaluated', 'completion']) {
+  label(`population.${card}.label`);
+  label(`population.${card}.note`);
+}
+// The frame selector names its two options and picks its item labels from
+// whichever frame is open, both through composed keys.
+for (const frame of ['competencies', 'framework']) label(`frames.options.${frame}`);
+// "How to read the results" is the section that makes the rest legible, so a
+// missing entry there is the one gap that would not look like a bug.
+for (const item of ['matching', 'scale', 'groups', 'areas', 'mobility', 'counts']) {
+  label(`howToRead.items.${item}.question`);
+  label(`howToRead.items.${item}.answer`);
+}
+
+assert.deepEqual(
+  missing,
+  [],
+  `${missing.length} label(s) the page composes have no message:\n${missing.join('\n')}\n` +
+    'next-intl renders the key path when a key is missing, so this ships as literal ' +
+    '"framework.negotiation" where the bar\'s name should be.',
+);
+
+// The other direction: a label with nothing behind it renders nowhere and still
+// asks to be translated.
+const stale = [
+  ...Object.keys(catalogues.en.competencies).filter((k) => !COMPETENCIES.includes(k)).map((k) => `  competencies.${k}`),
+  ...Object.keys(catalogues.en.framework).filter((k) => !FRAMEWORK.includes(k)).map((k) => `  framework.${k}`),
+  ...Object.keys(catalogues.en.drivers.names).filter((k) => !DRIVERS.includes(k)).map((k) => `  drivers.names.${k}`),
+  ...Object.keys(catalogues.en.bands).filter((k) => !BANDS.includes(k)).map((k) => `  bands.${k}`),
+];
+assert.deepEqual(stale, [], `Labels with nothing behind them:\n${stale.join('\n')}`);
+
+// ── The shape the page's controls are built on ─────────────────────────────
+// Both frames are drawn by one pair of charts, so every item in either has to
+// carry the same fields, and every band has to exist in every item — a stacked
+// bar with a hole in it is a bar that silently stops at 80%.
+for (const [frame, items] of [['competencies', cc.competencies], ['framework', cc.framework]]) {
+  for (const [id, item] of Object.entries(items)) {
+    assert.equal(typeof item.mean, 'number', `${frame}.${id} has no mean.`);
+    assert.deepEqual(
+      Object.keys(item.bands).sort(),
+      [...BANDS].sort(),
+      `${frame}.${id} does not carry the same five bands as the rest.`,
+    );
+  }
+}
+// frames.options names the two frames by their size — "Four competencies",
+// "Nine detailed areas" — and frames.body repeats both counts.
+assert.equal(COMPETENCIES.length, 4, `${COMPETENCIES.length} competencies; the copy says four.`);
+assert.equal(FRAMEWORK.length, 9, `${FRAMEWORK.length} detailed areas; the copy says nine.`);
+
+// Every competency in the pills must have behaviours to draw.
+for (const c of COMPETENCIES) {
+  assert.ok(
+    Object.keys(cc.drivers[c] ?? {}).length > 0,
+    `${c} is selectable in the competency pills but has no behaviours under it.`,
+  );
+}
+
+// ── Shares are shares ──────────────────────────────────────────────────────
+const sums = (name, values) => {
+  const total = sum(values);
+  assert.ok(Math.abs(total - 100) <= 0.5, `${name} sums to ${total.toFixed(1)}, not 100.`);
+};
+sums('skillMatching.distribution', [...cc.skillMatching.distribution]);
+sums('mobility', Object.values(cc.mobility));
+sums('growth', Object.values(cc.growth));
+for (const [frame, items] of [['competencies', cc.competencies], ['framework', cc.framework]]) {
+  for (const [id, item] of Object.entries(items)) sums(`${frame}.${id}.bands`, Object.values(item.bands));
+}
+
+// preferredAreas is the exception, and the page says so twice — in `areas.body`
+// and in the how-to-read entry. If it ever did sum to 100 those two paragraphs
+// would be explaining something that is no longer true.
+const areasTotal = sum(Object.values(cc.preferredAreas));
+assert.ok(
+  areasTotal > 110,
+  `preferredAreas sums to ${areasTotal.toFixed(1)}. The page explains at length why it is not a ` +
+    'split of the population; at this total it reads as one.',
+);
+
+// ── The extract is frozen ──────────────────────────────────────────────────
+// Same call as check-demo-sales-network, on the same criterion: this page
+// renders numbers it says nothing about. Fifty-eight framework means, band
+// shares and behaviour scores are drawn and never named, so no rule derived
+// from the copy can pin them. On a legitimate refresh, update the digest — and
+// re-read the copy, because the assertions below are what say which sentences
+// the new numbers broke.
+const DIGEST = 'cff005ddb997e69c730b90ecd579613a125f4cb2dedaf0775030b7ed920103a8';
+const digest = createHash('sha256').update(JSON.stringify(cc)).digest('hex');
+assert.equal(
+  digest,
+  DIGEST,
+  'data/demo/cross-country.ts has changed. If that was deliberate, put the new digest in this ' +
+    `file (${digest}) and check every claim below against the new numbers.`,
+);
+
+// ── The scales hold ────────────────────────────────────────────────────────
+for (const [name, value] of [
+  ['population.evaluatedPct', cc.population.evaluatedPct],
+  ...Object.entries(cc.mobility).map(([k, v]) => [`mobility.${k}`, v]),
+  ...Object.entries(cc.growth).map(([k, v]) => [`growth.${k}`, v]),
+  ...Object.entries(cc.preferredAreas).map(([k, v]) => [`preferredAreas.${k}`, v]),
+  ...cc.skillMatching.distribution.map((v, i) => [`skillMatching.distribution[${i}]`, v]),
+]) {
+  assert.ok(value >= 0 && value <= 100, `${name} is ${value}, which the page prints as a percent.`);
+}
+
+// A competency's score is the mean of its behaviours. Not "inside their range":
+// that only catches a behaviour moving inward, which is the half that distorts
+// nothing (#170). Here the two agree to two decimals, so the tolerance is tight.
+for (const [c, behaviours] of Object.entries(cc.drivers)) {
+  const computed = mean(Object.values(behaviours));
+  assert.ok(
+    Math.abs(computed - cc.competencies[c].mean) <= 0.01,
+    `${c} scores ${cc.competencies[c].mean} but its behaviours average ${computed.toFixed(3)}. ` +
+      'drivers.body tells the reader the second is the first.',
+  );
+}
+
+// ── The headline figures the copy quotes ───────────────────────────────────
+// The three groups are the whole evaluated population, split.
+assert.equal(
+  sum(GROUPS.map((g) => cc.countryGroups[g].n)),
+  cc.population.evaluated,
+  'The country groups no longer add up to the evaluated population.',
+);
+assert.ok(
+  cc.population.evaluated < cc.population.invited,
+  'Everyone invited completed the assessment; population.completion describes a gap that is gone.',
+);
+
+// ── The sentences the page argues, against the numbers it argues them from ──
+
+// matching.body: the bar "falls almost exactly in the middle of this
+// population". This is the page refusing both overclaims — neither "the
+// population is below the bar" nor the reverse.
+const { distribution, threshold, binWidth } = cc.skillMatching;
+const below = sum(distribution.slice(0, threshold / binWidth));
+assert.ok(
+  below > 40 && below < 60,
+  `${below.toFixed(1)}% sit below the bar. matching.body says it falls almost exactly in the ` +
+    'middle, which at this split it does not.',
+);
+// matching.mean and .median are printed side by side as if they agree.
+assert.ok(
+  Math.abs(cc.skillMatching.mean - cc.skillMatching.median) <= 1,
+  'The mean and the median have separated; the page shows them together without comment.',
+);
+
+// groups.caption: the three means are within a few points, and the highest
+// scoring group is also the smallest.
+const matchings = GROUPS.map((g) => cc.countryGroups[g].skillMatching);
+const spread = Math.max(...matchings) - Math.min(...matchings);
+assert.ok(
+  spread < 10,
+  `The group means spread over ${spread.toFixed(1)} points. groups.caption calls that narrow.`,
+);
+const best = GROUPS.reduce((a, b) =>
+  cc.countryGroups[b].skillMatching > cc.countryGroups[a].skillMatching ? b : a,
+);
+const largest = GROUPS.reduce((a, b) => (cc.countryGroups[b].n > cc.countryGroups[a].n ? b : a));
+assert.notEqual(
+  best,
+  largest,
+  'The highest-scoring group is now also the largest; groups.caption says the opposite.',
+);
+// howToRead.groups: "they differ in size by a factor of eight".
+const sizeRatio =
+  Math.max(...GROUPS.map((g) => cc.countryGroups[g].n)) /
+  Math.min(...GROUPS.map((g) => cc.countryGroups[g].n));
+assert.ok(
+  sizeRatio > 8,
+  `The largest group is ${sizeRatio.toFixed(1)} times the smallest. Two paragraphs say more than ` +
+    'eight — an earlier draft said "eight times", which at 8.67 was the sentence rounding in its ' +
+    'own favour.',
+);
+
+// frames.means.caption: the four competencies land close together and the nine
+// areas spread much wider. That contrast is the section's argument.
+const narrow = spreadOf(cc.competencies);
+const wide = spreadOf(cc.framework);
+assert.ok(
+  wide > narrow * 2,
+  `The competencies spread over ${narrow.toFixed(2)} and the detailed areas over ` +
+    `${wide.toFixed(2)}. frames.means.caption is written around the second being much wider.`,
+);
+
+// drivers.caption: the behaviours under one competency spread wider than the
+// competencies spread among themselves.
+// "The behaviours under one competency" is every competency, not the widest
+// one, so every one of them has to clear it.
+const tightest = Math.min(
+  ...Object.values(cc.drivers).map((b) => {
+    const values = Object.values(b);
+    return Math.max(...values) - Math.min(...values);
+  }),
+);
+assert.ok(
+  tightest > narrow,
+  `The tightest competency spreads its behaviours over ${tightest.toFixed(2)}, against ` +
+    `${narrow.toFixed(2)} between the competencies. drivers.caption says that of any of them, ` +
+    'not just of the widest.',
+);
+
+// mobility.body and mobility.caption: the outright yes is small, the middle is
+// several times its size, and folding the two together is the overclaim the
+// page refuses by name.
+const yes = cc.mobility.veryWilling + cc.mobility.willing;
+const maybe = cc.mobility.openToConsidering;
+assert.ok(
+  (yes + maybe) / yes > 4,
+  `Folding the middle in would take ${yes.toFixed(1)}% to ${(yes + maybe).toFixed(1)}%, a factor ` +
+    `of ${((yes + maybe) / yes).toFixed(1)}. mobility.caption says more than four.`,
+);
+assert.ok(
+  yes < 25,
+  `${yes.toFixed(1)}% say yes outright. The section is written around that being a small share.`,
+);
+
+// growth.caption: fewer than three in ten want to manage a team, and it is not
+// the largest of the three real answers.
+assert.ok(
+  cc.growth.teamManagement < 30,
+  `${cc.growth.teamManagement}% want to manage a team; growth.caption says fewer than three in ten.`,
+);
+const topGrowth = Object.entries(cc.growth)
+  .filter(([k]) => k !== 'noPreference')
+  .reduce((a, b) => (b[1] > a[1] ? b : a))[0];
+assert.notEqual(
+  topGrowth,
+  'teamManagement',
+  'Managing a team is now the most wanted direction; growth.body says the largest is not the one ' +
+    'an org chart would predict.',
+);
+
+// areas.body: two areas are each named by more than half, which is only
+// possible under a multi-select question.
+const namedByHalf = Object.values(cc.preferredAreas).filter((v) => v > 50).length;
+assert.equal(
+  namedByHalf,
+  2,
+  `${namedByHalf} areas are named by more than half the population; areas.caption says two.`,
+);
+
+function spreadOf(frame) {
+  const means = Object.values(frame).map((v) => v.mean);
+  return Math.max(...means) - Math.min(...means);
+}
+
+console.log(`[OK] demo cross country: extract pinned by digest (every value, no meaning)`);
+console.log(
+  `[OK] demo cross country: ${COMPETENCIES.length + FRAMEWORK.length + DRIVERS.length} composed ` +
+    'labels, and every claim the copy makes still true of the data',
+);

--- a/scripts/check-demo-cross-country.mjs
+++ b/scripts/check-demo-cross-country.mjs
@@ -214,6 +214,38 @@ assert.ok(
   'The mean and the median have separated; the page shows them together without comment.',
 );
 
+// The three headline figures in .stat-value are the first numbers a reader
+// sees, so they get rules rather than only the digest: "the page draws it and
+// never names it" is the case for pinning a value, and it does not apply to
+// something printed at 44px with a label under it.
+//
+// The completion rate against its own two headcounts.
+const completion = (cc.population.evaluated / cc.population.invited) * 100;
+assert.ok(
+  Math.abs(completion - cc.population.evaluatedPct) <= 0.1,
+  `population.evaluatedPct is ${cc.population.evaluatedPct} but ${cc.population.evaluated} of ` +
+    `${cc.population.invited} is ${completion.toFixed(2)}. All three are on screen together.`,
+);
+// The mean against the distribution drawn under it, from the bin midpoints.
+const binMean =
+  sum(
+    distribution.map((share, i) => share * (i * binWidth + binWidth / 2)),
+  ) / 100;
+assert.ok(
+  Math.abs(binMean - cc.skillMatching.mean) <= 0.5,
+  `The distribution averages ${binMean.toFixed(2)} but skillMatching.mean says ` +
+    `${cc.skillMatching.mean}. The chart and the number above it disagree.`,
+);
+// And the median inside the band where the distribution crosses halfway.
+let cumulative = 0;
+const medianBin = distribution.findIndex((share) => (cumulative += share) >= 50);
+assert.ok(
+  cc.skillMatching.median >= medianBin * binWidth &&
+    cc.skillMatching.median <= (medianBin + 1) * binWidth,
+  `skillMatching.median is ${cc.skillMatching.median}, outside the ` +
+    `${medianBin * binWidth}-${(medianBin + 1) * binWidth} band where the distribution crosses half.`,
+);
+
 // groups.caption: the three means are within a few points, and the highest
 // scoring group is also the smallest.
 const matchings = GROUPS.map((g) => cc.countryGroups[g].skillMatching);
@@ -222,14 +254,19 @@ assert.ok(
   spread < 10,
   `The group means spread over ${spread.toFixed(1)} points. groups.caption calls that narrow.`,
 );
+// "the group scoring highest is also the smallest" — assert that, not the
+// weaker "highest is not the largest" it used to say. With three groups those
+// come apart on the middle one: moving `others` up by 3.7, less than the 5.2
+// spread the page prints itself, made the sentence false and left this green.
 const best = GROUPS.reduce((a, b) =>
   cc.countryGroups[b].skillMatching > cc.countryGroups[a].skillMatching ? b : a,
 );
-const largest = GROUPS.reduce((a, b) => (cc.countryGroups[b].n > cc.countryGroups[a].n ? b : a));
-assert.notEqual(
+const smallest = GROUPS.reduce((a, b) => (cc.countryGroups[b].n < cc.countryGroups[a].n ? b : a));
+assert.equal(
   best,
-  largest,
-  'The highest-scoring group is now also the largest; groups.caption says the opposite.',
+  smallest,
+  `The highest-scoring group is '${best}' and the smallest is '${smallest}'; groups.caption says ` +
+    'they are the same one.',
 );
 // howToRead.groups: "they differ in size by a factor of eight".
 const sizeRatio =
@@ -282,6 +319,27 @@ assert.ok(
 assert.ok(
   yes < 25,
   `${yes.toFixed(1)}% say yes outright. The section is written around that being a small share.`,
+);
+
+// The same rule, in the other direction, and it is here because the page did
+// not have it: `somewhatReluctant` was being added to `notInterested` and
+// called the no — the identical aggregation the paragraph above refuses on the
+// yes side, in the same sentence. Guarding one end and not the other is how it
+// got through, so both ends are guarded now.
+const no = cc.mobility.notInterested;
+const reluctant = cc.mobility.somewhatReluctant;
+assert.ok(
+  (no + reluctant) / no > 1.4,
+  `Folding reluctance into the no would take ${no}% to ${(no + reluctant).toFixed(1)}%, a factor ` +
+    `of ${((no + reluctant) / no).toFixed(2)}. mobility.caption says it would inflate that end by ` +
+    'half again.',
+);
+// Neither end may claim the middle, because the middle is most of the
+// population — which is the fact both halves of the caption rest on.
+assert.ok(
+  cc.mobility.openToConsidering + reluctant > 50,
+  `The two middle answers hold ${(cc.mobility.openToConsidering + reluctant).toFixed(1)}%. The ` +
+    'section is written around the middle being where most of the population is.',
 );
 
 // growth.caption: fewer than three in ten want to manage a team, and it is not

--- a/scripts/check-demo-cross-country.mjs
+++ b/scripts/check-demo-cross-country.mjs
@@ -96,6 +96,39 @@ const stale = [
 ];
 assert.deepEqual(stale, [], `Labels with nothing behind them:\n${stale.join('\n')}`);
 
+// ── No Italian article welded in front of a variable number ────────────────
+// "il {reluctant}%" reads "il 11,0%", which is wrong Italian, and it was wrong
+// only because that share happens to be eleven. The article is fixed and the
+// number is not, so every one of these is one refresh away from the same
+// defect: eight, eleven, eighty, or anything starting with a vowel sound breaks
+// it. Twelve of them existed across the three dashboards and one had already
+// gone wrong.
+//
+// ponytail: scoped to `demo` because that is what has been audited. The rule is
+// general to Italian copy — move it to check:messages after sweeping the other
+// namespaces.
+const ARTICLE_BEFORE_NUMBER =
+  /\b(?:il|lo|la|le|i|gli|un|uno|una|del|dello|della|dei|degli|delle|al|allo|alla|nel|nello|nella|dal|dalla|sul|sulla|col)\s+\{/gi;
+const welded = [];
+const walk = (node, path) => {
+  for (const [key, value] of Object.entries(node)) {
+    const at = path ? `${path}.${key}` : key;
+    if (typeof value === 'string') {
+      for (const m of value.matchAll(ARTICLE_BEFORE_NUMBER)) welded.push(`  ${at}: "${m[0].trim()}…"`);
+    } else if (value && typeof value === 'object') {
+      walk(value, at);
+    }
+  }
+};
+walk(JSON.parse(readFileSync(join(ROOT, 'messages/it.json'), 'utf8')).demo, 'demo');
+assert.deepEqual(
+  welded,
+  [],
+  `${welded.length} Italian article(s) sit directly in front of an interpolated value:\n` +
+    `${welded.join('\n')}\n` +
+    'The article cannot agree with a number it does not know. Drop it, or put a word between them.',
+);
+
 // ── The shape the page's controls are built on ─────────────────────────────
 // Both frames are drawn by one pair of charts, so every item in either has to
 // carry the same fields, and every band has to exist in every item — a stacked
@@ -219,12 +252,24 @@ assert.ok(
 // never names it" is the case for pinning a value, and it does not apply to
 // something printed at 44px with a label under it.
 //
-// The completion rate against its own two headcounts.
-const completion = (cc.population.evaluated / cc.population.invited) * 100;
+// The completion rate against its own two headcounts — inside the window the
+// rounding can produce, not to two decimal places.
+//
+// The headcounts are rounded to the nearest five and the percentage is computed
+// on the true figures, which is what `population.rounding` spends a paragraph
+// telling the reader. A rule demanding the two divide exactly would contradict
+// that paragraph, and would go red on a refresh with a message the page itself
+// disproves — teaching whoever meets it that the gate is the thing that is
+// wrong. So the bound is derived from the rounding rather than picked: the true
+// ratio cannot be outside what these two counts allow.
+const ROUNDING = 5;
+const widest = ((cc.population.evaluated + ROUNDING / 2) / (cc.population.invited - ROUNDING / 2)) * 100;
+const narrowest = ((cc.population.evaluated - ROUNDING / 2) / (cc.population.invited + ROUNDING / 2)) * 100;
 assert.ok(
-  Math.abs(completion - cc.population.evaluatedPct) <= 0.1,
-  `population.evaluatedPct is ${cc.population.evaluatedPct} but ${cc.population.evaluated} of ` +
-    `${cc.population.invited} is ${completion.toFixed(2)}. All three are on screen together.`,
+  cc.population.evaluatedPct >= narrowest && cc.population.evaluatedPct <= widest,
+  `population.evaluatedPct is ${cc.population.evaluatedPct}, outside the ` +
+    `${narrowest.toFixed(1)}-${widest.toFixed(1)} the two headcounts allow once their rounding to ` +
+    `the nearest ${ROUNDING} is taken into account. All three figures are on screen together.`,
 );
 // The mean against the distribution drawn under it, from the bin midpoints.
 const binMean =
@@ -328,11 +373,16 @@ assert.ok(
 // got through, so both ends are guarded now.
 const no = cc.mobility.notInterested;
 const reluctant = cc.mobility.somewhatReluctant;
+// Two-sided, because "by half again" is a ratio and not a floor. One-sided at
+// 1.4 this survived a constant-sum redistribution — notInterested 21.8 to 15.0
+// and somewhatReluctant 11.0 to 17.8 gives 2.19 — and since these five shares
+// must total 100, a constant-sum redistribution is the only shape a refresh of
+// this field can take. The uncovered side was the only one that could happen.
+const inflation = (no + reluctant) / no;
 assert.ok(
-  (no + reluctant) / no > 1.4,
+  inflation > 1.4 && inflation < 1.6,
   `Folding reluctance into the no would take ${no}% to ${(no + reluctant).toFixed(1)}%, a factor ` +
-    `of ${((no + reluctant) / no).toFixed(2)}. mobility.caption says it would inflate that end by ` +
-    'half again.',
+    `of ${inflation.toFixed(2)}. mobility.caption says half again, which is 1.5.`,
 );
 // Neither end may claim the middle, because the middle is most of the
 // population — which is the fact both halves of the caption rest on.


### PR DESCRIPTION
L'ultima delle tre. Con questa le tre schede dell'hub diventano tutte link, e il
ramo «coming soon» sparisce perché non ha più nulla da annunciare.

## Le due letture che i dati non davano

**Le aree preferite non sono una ripartizione.** `preferredAreas` somma a
**164.9%**: erano scelte multiple, circa 1,6 aree a testa. Ogni barra è descritta
come «la quota che l'ha nominata», mai come «la quota che l'ha scelta al posto
delle altre», e il totale è stampato sulla pagina invece di essere nascosto.

**«Ci penserebbe» non è un sì.** Sommare `veryWilling + willing +
openToConsidering` dà 67,2% e sarebbe la sovravendita più naturale della pagina.
Quel numero compare in un punto solo: nella sezione «come leggere», per spiegare
perché non lo usiamo.

Poi la pagina ha fatto **la stessa cosa con il segno invertito**, e l'ha trovata
la review: diceva «il 32,8% ha detto no», che è `notInterested` più
`somewhatReluctant` — e `somewhatReluctant` è la barra che il grafico
immediatamente sotto etichetta «poco convinto». Ha detto no il 21,8%. Il difetto
stava dentro la frase che esiste per impedirlo, perché il lato sì era
argomentato e asserito due volte e il lato no non aveva nessuna regola.

Ora la sezione riporta quattro numeri separati — 13,5 · 21,8 · 53,7 · 11,0 — e
dice che i due centrali non appartengono a nessuno dei due estremi. Il gate ha
tre regole simmetriche, e quella sul lato no è una **banda** 1,4–1,6, non una
soglia da un lato solo: le cinque quote devono sommare a 100, quindi una
redistribuzione a somma costante è l'unica mutazione che quel campo può avere,
ed era esattamente il caso scoperto.

## Nessun radar, e la conseguenza

`countryGroups` porta per gruppo un headcount e **una** media: non ci sono assi.
Un radar a una dimensione è un grafico a barre travestito, e il travestimento
dichiara un profilo di competenze per gruppo che l'estratto non ha.

La conseguenza vera è che la sezione che dà il nome alla dashboard confronta i
gruppi su un numero ciascuno. È onesto e i gate lo proteggono, ma è una versione
debole della promessa del titolo: **#181** valuta se ricalcolare l'estratto con
le medie per competenza per gruppo, che i sorgenti contengono.

## L'articolo italiano, che era rotto ovunque

«Il 21,8%» è giusto, «il 11,0%» no. Quando l'articolo è fisso nel template e il
numero è interpolato, la correttezza dipende dal valore: la frase è giusta
finché il dato non cambia.

La ricognizione ne ha trovate **dodici**, su tutte e tre le dashboard — una
sbagliata oggi e undici latenti. Tutte rimosse riscrivendo la frase, non
elidendo a mano, e un check impedisce che tornino. La regola è dell'italiano e
non delle demo, quindi sale in `check:messages` con **#182**, dopo una
ricognizione degli altri sessanta namespace che nessuno ha ancora guardato.

## Il gate, e cosa costa dirgli la verità

**143 mutazioni su 164** uccise dalle regole semantiche a uno spostamento di un
punto pieno; il digest copre le restanti 21, che sono valori che la pagina
disegna e non nomina — verificati uno per uno in review.

Erano 145. La regola sul tasso di completamento asseriva che 345/390
riproducesse l'88,4 entro 0,1, mentre la pagina ha un paragrafo che spiega che i
conti **non** tornano perché gli headcount sono arrotondati a multipli di
cinque. Passava per 0,06, ma l'arrotondamento può spostare il rapporto fino a
~0,97: su un refresh legittimo sarebbe diventata rossa con un messaggio che
contraddice la pagina. Ora la finestra è derivata da `ROUNDING` — 87,3–89,7 — e
costa due mutazioni di copertura.

È il compromesso giusto: una regola che diventa rossa su dati corretti è peggio
di un buco, perché il primo che la incontra impara che il gate è la cosa di cui
diffidare, e quella lezione non resta confinata a un'assertion.

## Verifica

`./harness/init.sh` completo verde. Tre giri di review: la fuga a somma costante
sul lato no, l'assertion `best !== largest` che non copriva la frase che doveva
proteggere, e quattro difetti di copy monolingua — di cui uno **introdotto dalla
correzione di un altro**, perché un difetto bilingue segnalato in una lingua
diventa monolingua se lo si corregge dove è stato mostrato.

Le due pagine italiane già mergiate, toccate dalla correzione dell'articolo,
sono state rilette renderizzate e non solo nel diff: nessuna cifra cambiata,
nessuna frase con un senso diverso.

Closes #171