### PR TITLE
L'hub non serializza più la copy delle rotte figlie

### DIFF
--- a/i18n/messages.ts
+++ b/i18n/messages.ts
@@ -14,6 +14,8 @@
 // sitemap and the hreflang tags key off, so a page cannot drift into using a
 // namespace no route claims.
 
+import routes from './routes.json' with { type: 'json' };
+
 /**
  * Namespaces every page renders.
  *
@@ -67,6 +69,50 @@ export function pick(source: Record<string, unknown>, dotted: string) {
   return out;
 }
 
+/** The inverse of `pick`: the same object without one dotted path.
+ *  Exported for scripts/check-messages.mjs, like `pick`. */
+export function omit(source: Record<string, unknown>, dotted: string) {
+  const [head, ...rest] = dotted.split('.');
+  if (!(head in source)) return source;
+
+  const out = { ...source };
+  if (rest.length === 0) {
+    delete out[head];
+    return out;
+  }
+
+  const child = out[head];
+  if (typeof child !== 'object' || child === null || Array.isArray(child)) return source;
+  out[head] = omit(child as Record<string, unknown>, rest.join('.'));
+  return out;
+}
+
+/**
+ * The namespaces of the routes nested *under* this one.
+ *
+ * `demo` is a hub listing three dashboards, and the dashboards are routes of
+ * their own — so their copy sits at `demo.retail`, `demo.sales-network`,
+ * `demo.cross-country`, inside the hub’s namespace. Picking `demo` picked all
+ * of it: 32 KB of catalogue in a document that renders 2 KB of it, growing by
+ * one dashboard every time one is added, and invisible to harness/measure-js.mjs
+ * because it is payload and not JavaScript.
+ *
+ * This is the same defect CLAUDE.md describes for a provider rendered without
+ * `messages`, reached from the other side: nobody widened anything, the
+ * namespace hierarchy is wide by construction. So the cut is here rather than
+ * in a naming convention — it holds for any nested route, and a fourth
+ * dashboard inherits it without anyone remembering to.
+ *
+ * A dynamic segment is not a nested route: `resources/whitepapers/[slug]` and
+ * its index share one namespace (see `namespaceOf`), which is deliberate, and
+ * `startsWith` on a strict prefix leaves them alone.
+ */
+function nestedNamespaces(namespace: string): string[] {
+  return (routes as { id: string }[])
+    .map((route) => namespaceOf(route.id))
+    .filter((other) => other.startsWith(`${namespace}.`));
+}
+
 /**
  * Deep-merges the picked namespaces.
  *
@@ -104,6 +150,8 @@ export async function messagesForRoute(routeId: string, locale: string | undefin
   const all = (await import(`../messages/${locale ?? 'en'}.json`, { with: { type: 'json' } }))
     .default;
 
-  const wanted = [...SHARED, namespaceOf(routeId)];
-  return wanted.reduce<Record<string, unknown>>((acc, ns) => merge(acc, pick(all, ns)), {});
+  const namespace = namespaceOf(routeId);
+  const wanted = [...SHARED, namespace];
+  const picked = wanted.reduce<Record<string, unknown>>((acc, ns) => merge(acc, pick(all, ns)), {});
+  return nestedNamespaces(namespace).reduce((acc, ns) => omit(acc, ns), picked);
 }

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -15,7 +15,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const { messagesForRoute, namespaceOf, pick, merge } = await import(join(ROOT, 'i18n/messages.ts'));
+const { messagesForRoute, namespaceOf, pick, merge, omit } = await import(
+  join(ROOT, 'i18n/messages.ts'),
+);
 
 // ── Route id -> namespace ──────────────────────────────────────────────────
 assert.equal(namespaceOf('index'), 'home', 'the homepage namespace is `home`, not `index`');
@@ -76,6 +78,28 @@ assert.deepEqual(
 );
 assert.deepEqual(pick(catalogue, 'nope.at.all'), {}, 'an absent path picks nothing');
 assert.deepEqual(pick(catalogue, 'home.meta.title.deeper'), {}, 'walking past a leaf picks nothing');
+
+// `omit` on its own: it is what keeps a hub from carrying its children.
+assert.deepEqual(
+  omit({ demo: { hero: 1, retail: { a: 1 } } }, 'demo.retail'),
+  { demo: { hero: 1 } },
+  'omit removes the nested path and leaves its siblings',
+);
+assert.deepEqual(
+  omit({ demo: { hero: 1 } }, 'demo.retail'),
+  { demo: { hero: 1 } },
+  'omitting an absent path changes nothing',
+);
+assert.deepEqual(
+  omit({ demo: { hero: 1 } }, 'demo'),
+  {},
+  'a one-segment path removes the namespace itself',
+);
+assert.deepEqual(
+  omit({ demo: { hero: 'text' } }, 'demo.hero.deeper'),
+  { demo: { hero: 'text' } },
+  'walking past a leaf omits nothing — it must not replace the leaf with an object',
+);
 
 // ── The catalogue obeys its own conventions ────────────────────────────────
 // Documented in harness/docs/conventions.md. Three of the four rules there are
@@ -226,6 +250,57 @@ assert.deepEqual(
     'Use the curly apostrophe (\u2019). ICU reads the straight one as an escape and renders the ' +
     'tag as text.',
 );
+
+// ── A hub does not carry its children ──────────────────────────────────────
+// A route nested under another shares its namespace: the three demo dashboards
+// live at `demo.retail`, `demo.sales-network`, `demo.cross-country`, inside the
+// hub's own `demo`. Picking the hub's namespace picked all of them — 32 KB of
+// catalogue serialized into a document that renders 2 KB of it, and one
+// dashboard more every time one was added (#179).
+//
+// harness/measure-js.mjs cannot see this: it weighs JavaScript, and this is
+// payload. So it is asserted here, for every nested route rather than for the
+// three that have the shape today — the fourth dashboard must inherit the rule
+// without anyone remembering it exists.
+const routeList = JSON.parse(readFileSync(join(ROOT, 'i18n/routes.json'), 'utf8'));
+const pairs = routeList.flatMap((parent) =>
+  routeList
+    .filter((child) => namespaceOf(child.id).startsWith(`${namespaceOf(parent.id)}.`))
+    .map((child) => [parent, child]),
+);
+assert.ok(
+  pairs.length > 0,
+  'no nested routes found — the rule below would pass vacuously, so the derivation is wrong',
+);
+
+for (const locale of ['en', 'it']) {
+  for (const [parent, child] of pairs) {
+    const childNs = namespaceOf(child.id);
+    const leaked = leaves(await messagesForRoute(parent.id, locale))
+      .map(([key]) => key)
+      .filter((key) => key === childNs || key.startsWith(`${childNs}.`));
+    assert.deepEqual(
+      leaked,
+      [],
+      `${locale}: the document of /${parent.id} carries ${leaked.length} key(s) belonging to ` +
+        `/${child.id}:\n${leaked.map((k) => `  ${k}`).join('\n')}\n` +
+        'A route nested under another must not ship its copy. See nestedNamespaces() in i18n/messages.ts.',
+    );
+
+    // The other half: narrowing the parent must not have narrowed the child.
+    const catalogue = locale === 'en' ? catalogueEn : catalogueIt;
+    assert.deepEqual(
+      leaves(await messagesForRoute(child.id, locale))
+        .map(([key]) => key)
+        .filter((key) => key.startsWith(`${childNs}.`))
+        .sort(),
+      leaves(pick(catalogue, childNs))
+        .map(([key]) => key)
+        .sort(),
+      `${locale}: /${child.id} must still receive every key under ${childNs}`,
+    );
+  }
+}
 
 const onlyEn = en.filter((k) => !it.includes(k));
 const onlyIt = it.filter((k) => !en.includes(k));

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -100,6 +100,11 @@ assert.deepEqual(
   { demo: { hero: 'text' } },
   'walking past a leaf omits nothing — it must not replace the leaf with an object',
 );
+assert.deepEqual(
+  omit({ demo: { list: ['a'] } }, 'demo.list.0'),
+  { demo: { list: ['a'] } },
+  'an array is a value, not a path to walk into — an ICU message list is one message',
+);
 
 // ── The catalogue obeys its own conventions ────────────────────────────────
 // Documented in harness/docs/conventions.md. Three of the four rules there are
@@ -263,42 +268,66 @@ assert.deepEqual(
 // three that have the shape today — the fourth dashboard must inherit the rule
 // without anyone remembering it exists.
 const routeList = JSON.parse(readFileSync(join(ROOT, 'i18n/routes.json'), 'utf8'));
-const pairs = routeList.flatMap((parent) =>
-  routeList
-    .filter((child) => namespaceOf(child.id).startsWith(`${namespaceOf(parent.id)}.`))
-    .map((child) => [parent, child]),
-);
+const nests = routeList
+  .map((parent) => [
+    parent,
+    routeList.filter((child) => namespaceOf(child.id).startsWith(`${namespaceOf(parent.id)}.`)),
+  ])
+  .filter(([, children]) => children.length > 0);
 assert.ok(
-  pairs.length > 0,
-  'no nested routes found — the rule below would pass vacuously, so the derivation is wrong',
+  nests.length > 0,
+  'no nested routes found — the rules below would pass vacuously, so the derivation is wrong',
 );
 
 for (const locale of ['en', 'it']) {
-  for (const [parent, child] of pairs) {
-    const childNs = namespaceOf(child.id);
-    const leaked = leaves(await messagesForRoute(parent.id, locale))
-      .map(([key]) => key)
-      .filter((key) => key === childNs || key.startsWith(`${childNs}.`));
+  const catalogue = locale === 'en' ? catalogueEn : catalogueIt;
+
+  for (const [parent, children] of nests) {
+    const parentNs = namespaceOf(parent.id);
+    const childNamespaces = children.map((child) => namespaceOf(child.id));
+
+    // The half that is easy to forget, because the fix for the other one
+    // satisfies it by deleting: subtracting the children must leave the parent
+    // everything else. Without this, `omit(picked, parentNs)` — one plausible
+    // slip — passes green while the hub renders key paths where its copy was.
+    const under = (ns, key) => key === ns || key.startsWith(`${ns}.`);
     assert.deepEqual(
-      leaked,
-      [],
-      `${locale}: the document of /${parent.id} carries ${leaked.length} key(s) belonging to ` +
-        `/${child.id}:\n${leaked.map((k) => `  ${k}`).join('\n')}\n` +
-        'A route nested under another must not ship its copy. See nestedNamespaces() in i18n/messages.ts.',
+      leaves(await messagesForRoute(parent.id, locale))
+        .map(([key]) => key)
+        .filter((key) => under(parentNs, key))
+        .sort(),
+      leaves(pick(catalogue, parentNs))
+        .map(([key]) => key)
+        .filter((key) => !childNamespaces.some((childNs) => under(childNs, key)))
+        .sort(),
+      `${locale}: /${parent.id} must receive its own namespace, minus its children and nothing more`,
     );
 
-    // The other half: narrowing the parent must not have narrowed the child.
-    const catalogue = locale === 'en' ? catalogueEn : catalogueIt;
-    assert.deepEqual(
-      leaves(await messagesForRoute(child.id, locale))
+    for (const child of children) {
+      const childNs = namespaceOf(child.id);
+      const leaked = leaves(await messagesForRoute(parent.id, locale))
         .map(([key]) => key)
-        .filter((key) => key.startsWith(`${childNs}.`))
-        .sort(),
-      leaves(pick(catalogue, childNs))
-        .map(([key]) => key)
-        .sort(),
-      `${locale}: /${child.id} must still receive every key under ${childNs}`,
-    );
+        .filter((key) => under(childNs, key));
+      assert.deepEqual(
+        leaked,
+        [],
+        `${locale}: the document of /${parent.id} carries ${leaked.length} key(s) belonging to ` +
+          `/${child.id}:\n${leaked.map((k) => `  ${k}`).join('\n')}\n` +
+          'A route nested under another must not ship its copy. See nestedNamespaces() in i18n/messages.ts.',
+      );
+
+      // And narrowing the parent must not have narrowed the child.
+      assert.deepEqual(
+        leaves(await messagesForRoute(child.id, locale))
+          .map(([key]) => key)
+          .filter((key) => key.startsWith(`${childNs}.`))
+          .sort(),
+        leaves(pick(catalogue, childNs))
+          .map(([key]) => key)
+          .sort(),
+        `${locale}: /${child.id} must still receive every key under ${childNs}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Closes #179.

`messagesForRoute` prendeva il namespace della rotta per intero. Per una rotta
annidata sotto un'altra — le tre dashboard sotto `/demo` — quel namespace
contiene anche i figli, quindi l'hub serializzava nel proprio documento la copy
completa di ogni dashboard: 32 KB di catalogo per renderne 2, e una dashboard
in più a ogni aggiunta.

La nota sull'Issue chiedeva di verificare se il taglio giusto fosse in
`messagesForRoute` invece che nei nomi dei namespace. Lo è, e non erano tre
rotte: sono cinque, e le due più grosse non c'entrano con le demo.

| documento | prima | dopo |
|---|---:|---:|
| `/customers` | 230.129 B | 72.987 B |
| `/blog` | 123.647 B | 60.765 B |
| `/demo` | 76.444 B | 43.295 B |
| `/it/demo` | 78.822 B | 43.460 B |

(«prima» misurato in produzione, «dopo» sul documento prerenderizzato in
locale. Le 17 rotte figlie di `customers` non sono le 9 storie che il listato
rende: sono le storie più i loro tagli alternativi.)

Il listato clienti e l'indice del blog rendono ancora tutto: leggono
`customers.explore.stories.*` e `blog.articles.*`, namespace dell'hub e non
delle rotte figlie. Verificato sull'HTML costruito, non solo per ragionamento.
Un segmento dinamico non è una rotta annidata — `resources/whitepapers/[slug]`
condivide il namespace del suo indice per scelta esplicita, e il prefisso
stretto (`ns + '.'`) lo lascia intatto.

## Il check

In `check:messages`, derivato da `i18n/routes.json` e non scritto sulle rotte
di oggi. Tre asserzioni, perché due non bastavano:

1. il documento del genitore non contiene nessuna chiave dei figli;
2. ogni figlio continua a ricevere il proprio namespace per intero;
3. **il genitore riceve il proprio namespace meno i figli e nient'altro.**

La terza è arrivata dalla review. Senza, `omit(picked, namespace)` — cancellare
tutto invece di sottrarre, che è la riga accanto e somiglia alla soluzione —
passava verde mentre l'hub renderizzava path di chiave al posto del testo. È lo
stesso difetto col segno invertito, dentro il check che esiste per impedirlo.

Rotto in quattro direzioni per dimostrarlo:

- filtro disattivato (il comportamento pre-#179) → `en: the document of /blog
  carries 55 key(s) belonging to /blog/accountability`
- prefisso senza il punto, così una rotta omette sé stessa → fallisce
  l'asserzione che una pagina riceva il proprio namespace
- `omit(picked, namespace)` → `en: /blog must receive its own namespace, minus
  its children and nothing more`
- guardia `Array.isArray` rimossa da `omit` → una lista ICU torna come oggetto

`harness/measure-js.mjs` non poteva vedere niente di tutto questo: pesa il
JavaScript, e questo è payload. È il motivo per cui i numeri riportati su #169
e #170 erano corretti e il difetto è passato lo stesso.

## Verifica

- `./harness/init.sh` verde, 18 gate più il build
- `npm run test:smoke` verde
- nessun `MISSING_MESSAGE` e nessun path di chiave renderizzato come testo nei
  136 documenti prerenderizzati
- review: approvata, con il buco sopra chiuso in 81b11e7