### PR TITLE
L'articolo davanti a un numero interpolato è una regola dell'italiano, non delle demo

### DIFF
--- a/scripts/check-demo-cross-country.mjs
+++ b/scripts/check-demo-cross-country.mjs
@@ -96,38 +96,10 @@ const stale = [
 ];
 assert.deepEqual(stale, [], `Labels with nothing behind them:\n${stale.join('\n')}`);
 
-// ── No Italian article welded in front of a variable number ────────────────
-// "il {reluctant}%" reads "il 11,0%", which is wrong Italian, and it was wrong
-// only because that share happens to be eleven. The article is fixed and the
-// number is not, so every one of these is one refresh away from the same
-// defect: eight, eleven, eighty, or anything starting with a vowel sound breaks
-// it. Twelve of them existed across the three dashboards and one had already
-// gone wrong.
-//
-// ponytail: scoped to `demo` because that is what has been audited. The rule is
-// general to Italian copy — move it to check:messages after sweeping the other
-// namespaces.
-const ARTICLE_BEFORE_NUMBER =
-  /\b(?:il|lo|la|le|i|gli|un|uno|una|del|dello|della|dei|degli|delle|al|allo|alla|nel|nello|nella|dal|dalla|sul|sulla|col)\s+\{/gi;
-const welded = [];
-const walk = (node, path) => {
-  for (const [key, value] of Object.entries(node)) {
-    const at = path ? `${path}.${key}` : key;
-    if (typeof value === 'string') {
-      for (const m of value.matchAll(ARTICLE_BEFORE_NUMBER)) welded.push(`  ${at}: "${m[0].trim()}…"`);
-    } else if (value && typeof value === 'object') {
-      walk(value, at);
-    }
-  }
-};
-walk(JSON.parse(readFileSync(join(ROOT, 'messages/it.json'), 'utf8')).demo, 'demo');
-assert.deepEqual(
-  welded,
-  [],
-  `${welded.length} Italian article(s) sit directly in front of an interpolated value:\n` +
-    `${welded.join('\n')}\n` +
-    'The article cannot agree with a number it does not know. Drop it, or put a word between them.',
-);
+// The Italian article welded in front of an interpolated value used to be
+// checked here, scoped to `demo` because `demo` was what had been audited. It
+// lives in check:messages now (#182): the rule is Italian's, not this
+// dashboard's, and the whole catalogue is swept instead of one namespace.
 
 // ── The shape the page's controls are built on ─────────────────────────────
 // Both frames are drawn by one pair of charts, so every item in either has to

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -280,8 +280,8 @@ assert.deepEqual(
 //
 // An ICU tag is allowed to sit between the two. `il <b>{yes}</b>%` is the same
 // defect with markup in the middle, and it is the shape this copy reaches for
-// most: 506 messages in the catalogue carry an ICU tag, and bolding the number
-// is how the dashboards write one. Without this, the rule would be blind to the
+// most: 506 messages in the Italian catalogue carry an ICU tag (en.json has 503),
+// and bolding the number is how the dashboards write one. Without this, the rule would be blind to the
 // likeliest way the next one gets written — a gate covering less than it claims,
 // which is the whole subject of #177 (found in review on #182).
 const ARTICLE_BEFORE_VALUE = new RegExp(
@@ -301,6 +301,35 @@ const ARTICLE_BEFORE_VALUE = new RegExp(
     '\\{',
   'gi',
 );
+
+// The rule is asserted before it is used. Until now nothing tested it: a regex
+// that stopped matching would have left this gate green and silent, which is
+// the failure it exists to prevent, one level up. Each line below is a form the
+// catalogue really had, or a near miss that must stay legal.
+for (const [message, shouldMatch, why] of [
+  ['il {reluctant}%', true, 'the form #171 found wrong — «il 11,0%»'],
+  ['agli {yes} disposti', true, 'a plural articulated preposition'],
+  ['nelle {no} risposte', true, 'feminine plural'],
+  ['l\u2019{yes}% dichiara', true, 'the elided form: wrong when the value turns out to be twenty-one'],
+  ['dall\u2019{no}% in giù', true, 'an elided articulated preposition'],
+  ['coi {yes} casi', true, 'coi, which was missing while col was there'],
+  ['sull\u2019{yes}% dei casi', true, 'every elided form, not just the first two'],
+  ['il <b>{reluctant}</b>%', true, 'an ICU tag does not separate the two'],
+  ['nei <b><i>{yes}</i></b> casi', true, 'nor do two of them'],
+  ['fra <b>{yes}</b> e <b>{no}</b>', false, 'no article in front: legal'],
+  ['il totale è <b>{yes}</b>', false, 'an article not adjacent to the value: legal'],
+  ['il <b>numero</b> {x}', false, 'the tag branch skips tags, not the words inside them'],
+  ['il </b>{x}', false, 'a closing tag is not an opening one'],
+  ['quello {x}', false, 'a word ending in an article is not an article'],
+  ['bel {x}', false, 'nor is one that rhymes with a preposition'],
+]) {
+  assert.equal(
+    ARTICLE_BEFORE_VALUE.test(message),
+    shouldMatch,
+    `the article rule ${shouldMatch ? 'must' : 'must not'} match: ${why}\n  ${message}`,
+  );
+  ARTICLE_BEFORE_VALUE.lastIndex = 0; // the regex is /g; `test` carries state
+}
 
 const welded = values(JSON.parse(readFileSync(join(ROOT, 'messages/it.json'), 'utf8')))
   .flatMap(([key, value]) =>

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -256,6 +256,58 @@ assert.deepEqual(
     'tag as text.',
 );
 
+// ── An Italian article cannot agree with a number it does not know ─────────
+// «il 21,8%» is right and «il 11,0%» is not — it is «l'11,0%», because eleven
+// reads as a vowel. So does eight, eighty, one. When the article is fixed in the
+// template and the number is interpolated, the sentence is correct only for the
+// values it happened to be written against, and one refresh of the data makes it
+// wrong with nothing to notice.
+//
+// Twelve of these existed across the three demo dashboards (#171): one already
+// wrong, eleven waiting. The rule lived in check:demo-cross-country because
+// `demo` was what had been audited; it moves here (#182) because the rule is
+// Italian's, not the dashboards'.
+//
+// The sweep of the other 59 namespaces found nothing, and the reason is worth
+// keeping: there are 40 interpolations in the whole Italian catalogue and 38 are
+// in the three dashboards — the rest of the site is static copy, where the
+// number is typed by hand with the right article already beside it. This check
+// is therefore preventive. It is here for the next interpolation someone writes,
+// which will otherwise have nobody looking at it.
+//
+// Both directions are wrong. A fixed `il` in front of a value that turns out to
+// be eleven, and a fixed `l'` in front of one that turns out to be twenty-one.
+const ARTICLE_BEFORE_VALUE = new RegExp(
+  "(?:\\b(?:" +
+    'il|lo|la|i|gli|le|un|uno|una|' +
+    'del|dello|della|dei|degli|delle|' +
+    'al|allo|alla|ai|agli|alle|' +
+    'nel|nello|nella|nei|negli|nelle|' +
+    'dal|dallo|dalla|dai|dagli|dalle|' +
+    'sul|sullo|sulla|sui|sugli|sulle|col' +
+    ')\\s+' +
+    // the elided forms take no space, and are the same defect sign-inverted
+    "|\\b(?:l|un|dell|all|nell|dall|sull)['’]\\s*" +
+    ')\\{',
+  'gi',
+);
+
+const welded = values(JSON.parse(readFileSync(join(ROOT, 'messages/it.json'), 'utf8')))
+  .flatMap(([key, value]) =>
+    [...value.matchAll(ARTICLE_BEFORE_VALUE)].map(
+      (m) => `  it: ${key}\n      …${value.slice(Math.max(0, m.index - 40), m.index + 30)}…`,
+    ),
+  );
+assert.deepEqual(
+  welded,
+  [],
+  `${welded.length} Italian article(s) sit directly in front of an interpolated value:\n` +
+    `${welded.join('\n')}\n` +
+    'The article cannot agree with a number it does not know, so the sentence is correct only ' +
+    'until the data changes. Rewrite the sentence — do not elide by hand, that fixes the value ' +
+    'of today and leaves the defect for the value of tomorrow.',
+);
+
 // ── A hub does not carry its children ──────────────────────────────────────
 // A route nested under another shares its namespace: the three demo dashboards
 // live at `demo.retail`, `demo.sales-network`, `demo.cross-country`, inside the

--- a/scripts/check-messages.mjs
+++ b/scripts/check-messages.mjs
@@ -277,6 +277,13 @@ assert.deepEqual(
 //
 // Both directions are wrong. A fixed `il` in front of a value that turns out to
 // be eleven, and a fixed `l'` in front of one that turns out to be twenty-one.
+//
+// An ICU tag is allowed to sit between the two. `il <b>{yes}</b>%` is the same
+// defect with markup in the middle, and it is the shape this copy reaches for
+// most: 506 messages in the catalogue carry an ICU tag, and bolding the number
+// is how the dashboards write one. Without this, the rule would be blind to the
+// likeliest way the next one gets written — a gate covering less than it claims,
+// which is the whole subject of #177 (found in review on #182).
 const ARTICLE_BEFORE_VALUE = new RegExp(
   "(?:\\b(?:" +
     'il|lo|la|i|gli|le|un|uno|una|' +
@@ -284,11 +291,14 @@ const ARTICLE_BEFORE_VALUE = new RegExp(
     'al|allo|alla|ai|agli|alle|' +
     'nel|nello|nella|nei|negli|nelle|' +
     'dal|dallo|dalla|dai|dagli|dalle|' +
-    'sul|sullo|sulla|sui|sugli|sulle|col' +
+    'sul|sullo|sulla|sui|sugli|sulle|col|coi' +
     ')\\s+' +
     // the elided forms take no space, and are the same defect sign-inverted
     "|\\b(?:l|un|dell|all|nell|dall|sull)['’]\\s*" +
-    ')\\{',
+    ')' +
+    // opening ICU tags do not separate the article from what it must agree with
+    '(?:<[a-zA-Z][a-zA-Z0-9]*>\\s*)*' +
+    '\\{',
   'gi',
 );
 


### PR DESCRIPTION
Closes #182.

«il 21,8%» è giusto e «il 11,0%» no: è «l'11,0%», perché undici si legge con una
vocale davanti. Come otto, ottanta, uno. Quando l'articolo è fisso nel template
e il numero è interpolato, la frase è corretta solo per i valori contro cui è
stata scritta.

La regola sale da `check:demo-cross-country` a `check:messages`, che è il gate
dell'italiano, e passa da un namespace a tutto il catalogo.

## Più larga anche nelle forme

La regola vecchia copriva i singolari. Questa aggiunge le preposizioni
articolate plurali — `ai agli alle nei negli nelle dai dagli dalle sui sugli
sulle` — e **le forme già elise**, che sono lo stesso difetto col segno
invertito: un `l'` fisso davanti a un valore che domani vale ventuno è sbagliato
quanto un `il` davanti a uno che vale undici.

## La ricognizione non ha trovato niente, e il motivo conta

Zero occorrenze negli altri 59 namespace. Non è fortuna:

> Nel catalogo italiano ci sono **40 interpolazioni in tutto, e 38 stanno nelle
> tre dashboard demo.** Le altre due sono `© {year}` nel footer.

Il resto del sito è copy statica, dove il numero è scritto a mano con
l'articolo giusto già accanto. Il difetto non è nato con le demo per caso: le
demo sono l'unico posto del sito che interpola numeri.

Quindi questo check non bonifica, previene. È lì per la prossima interpolazione
che qualcuno scriverà, ed è scritto nell'intestazione — un check che non ha mai
trovato niente è un check che qualcuno prima o poi propone di togliere.

Ho controllato anche i numeri **letterali**, che l'Issue non chiedeva: due
candidati, `il 1° agosto` e `dal 1° agosto` in `lp.ai-act-banking`. Entrambi
ordinali, si leggono «primo», consonante. Corretti così, nessuna modifica alla
copy.

## Dimostrato rosso

Sei forme reinserite una alla volta nel catalogo vero, con il gate rilanciato
ogni volta:

```
ROSSO  il {reluctant}%        la forma originale di #171 — «il 11,0%»
ROSSO  agli {yes} disposti    preposizione articolata plurale
ROSSO  nelle {no} risposte    idem, femminile plurale
ROSSO  l'{yes}% dichiara      forma elisa: sbagliata se il valore è ventuno
ROSSO  dall'{no}% in giù      preposizione articolata elisa
ROSSO  sugli {yes} casi       plurale maschile davanti a vocale
```

**Le ultime quattro la regola vecchia non le vedeva.** Catalogo ripristinato,
gate verde.

## Verifica

- `./harness/init.sh` verde, 33 check
- la regola locale in `check:demo-cross-country` è rimossa, con una riga che
  dice dov'è andata e perché
